### PR TITLE
fix(session): revoke sessions in Redis so terminated devices get 401 immediately

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,5 +42,6 @@
     <PackageVersion Include="Testcontainers" Version="4.4.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageVersion Include="Testcontainers.Minio" Version="4.4.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/deploy/helm/services/api-gateway/values-prod.yaml
+++ b/deploy/helm/services/api-gateway/values-prod.yaml
@@ -20,6 +20,7 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
   Cors__AllowedOrigins__0: https://urfu-link.ghjc.ru
 
 secrets:

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -45,7 +45,10 @@ export function createApiClient({ baseUrl, getAccessToken, onUnauthorized }: Api
     if (typeof window !== "undefined" && !redirecting) {
       redirecting = true;
       const rd = encodeURIComponent(window.location.href);
-      window.location.href = `/.pomerium/sign_in?pomerium_redirect_uri=${rd}`;
+      const isRevoked = response.headers.get("X-Session-Revoked") === "true";
+      window.location.href = isRevoked
+        ? `/.pomerium/sign_out?pomerium_redirect_uri=${rd}`
+        : `/.pomerium/sign_in?pomerium_redirect_uri=${rd}`;
     }
   }
 

--- a/src/BuildingBlocks/SessionRevocation/SessionRevocation.csproj
+++ b/src/BuildingBlocks/SessionRevocation/SessionRevocation.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
+++ b/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Urfu.Link.BuildingBlocks.SessionRevocation;
+
+public static class SessionRevocationExtensions
+{
+    public static IServiceCollection AddSessionRevocation(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<SessionRevocationOptions>()
+            .Bind(configuration.GetSection(SessionRevocationOptions.SectionName))
+            .PostConfigure(options =>
+            {
+                if (string.IsNullOrWhiteSpace(options.RedisConfiguration))
+                {
+                    options.RedisConfiguration =
+                        configuration["Infrastructure:Redis:Configuration"]
+                        ?? configuration["ConnectionStrings:Redis"]
+                        ?? configuration["ConnectionStrings:Primary"]
+                        ?? "localhost:6379";
+                }
+            });
+
+        services.TryAddSingleton<IConnectionMultiplexer>(static serviceProvider =>
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<SessionRevocationOptions>>().Value;
+            return ConnectionMultiplexer.Connect(options.RedisConfiguration);
+        });
+
+        services.AddSingleton<ISessionRevocationStore, RedisSessionRevocationStore>();
+
+        return services;
+    }
+}
+
+public sealed class SessionRevocationOptions
+{
+    public const string SectionName = "SessionRevocation";
+
+    public string RedisConfiguration { get; set; } = string.Empty;
+
+    public string KeyPrefix { get; set; } = "urfu:session";
+
+    public TimeSpan Ttl { get; set; } = TimeSpan.FromSeconds(300);
+}
+
+public interface ISessionRevocationStore
+{
+    Task RevokeAsync(string userId, string callerSessionId, CancellationToken cancellationToken = default);
+
+    Task<bool> IsRevokedAsync(string userId, string sessionId, CancellationToken cancellationToken = default);
+}
+
+public sealed class RedisSessionRevocationStore(
+    IConnectionMultiplexer multiplexer,
+    IOptions<SessionRevocationOptions> options) : ISessionRevocationStore
+{
+    public async Task RevokeAsync(string userId, string callerSessionId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(callerSessionId);
+
+        var db = multiplexer.GetDatabase();
+        var opts = options.Value;
+        var revokedKey = $"{opts.KeyPrefix}:revoked:{userId}";
+        var allowedKey = $"{opts.KeyPrefix}:allowed:{userId}";
+
+        var batch = db.CreateBatch();
+        var t1 = batch.StringSetAsync(revokedKey, "1", opts.Ttl);
+        var t2 = batch.SetAddAsync(allowedKey, callerSessionId);
+        var t3 = batch.KeyExpireAsync(allowedKey, opts.Ttl);
+        batch.Execute();
+
+        await Task.WhenAll(t1, t2, t3).WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> IsRevokedAsync(string userId, string sessionId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        var db = multiplexer.GetDatabase();
+        var opts = options.Value;
+        var revokedKey = $"{opts.KeyPrefix}:revoked:{userId}";
+
+        var isRevoked = await db.KeyExistsAsync(revokedKey).WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (!isRevoked)
+            return false;
+
+        var allowedKey = $"{opts.KeyPrefix}:allowed:{userId}";
+        var isAllowed = await db.SetContainsAsync(allowedKey, sessionId).WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        return !isAllowed;
+    }
+}

--- a/src/Gateway/ApiGateway/ApiGateway.csproj
+++ b/src/Gateway/ApiGateway/ApiGateway.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\..\BuildingBlocks\Auth\Auth.csproj" />
     <ProjectReference Include="..\..\BuildingBlocks\Observability\Observability.csproj" />
     <ProjectReference Include="..\..\BuildingBlocks\Contracts\Contracts.csproj" />
+    <ProjectReference Include="..\..\BuildingBlocks\SessionRevocation\SessionRevocation.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Gateway/ApiGateway/Program.cs
+++ b/src/Gateway/ApiGateway/Program.cs
@@ -1,12 +1,15 @@
 using System.Threading.RateLimiting;
 using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Observability;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+using Urfu.Link.Gateway.ApiGateway;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddPlatformJwtAuthentication(builder.Configuration)
-    .AddPlatformObservability(builder.Configuration, "api-gateway");
+    .AddPlatformObservability(builder.Configuration, "api-gateway")
+    .AddSessionRevocation(builder.Configuration);
 
 builder.Services.AddCors(options =>
 {
@@ -70,6 +73,7 @@ app.Use((context, next) =>
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<SessionRevocationMiddleware>();
 
 app.MapGet("/", () => Results.Ok(new
 {

--- a/src/Gateway/ApiGateway/SessionRevocationMiddleware.cs
+++ b/src/Gateway/ApiGateway/SessionRevocationMiddleware.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+
+namespace Urfu.Link.Gateway.ApiGateway;
+
+public sealed class SessionRevocationMiddleware(
+    RequestDelegate next,
+    ISessionRevocationStore revocationStore)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var sub = context.User.FindFirstValue("sub");
+            var sid = context.User.FindFirstValue("sid");
+
+            if (sub is not null && sid is not null
+                && await revocationStore.IsRevokedAsync(sub, sid, context.RequestAborted).ConfigureAwait(false))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                context.Response.Headers["X-Session-Revoked"] = "true";
+                return;
+            }
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/src/Services/User/UserService.Api/Endpoints/TerminateAllDevicesEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/TerminateAllDevicesEndpoint.cs
@@ -1,10 +1,13 @@
 using FastEndpoints;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Domain.Interfaces;
 using UserService.Api.Infrastructure.Auth;
 
 namespace UserService.Api.Endpoints;
 
-public sealed class TerminateAllDevicesEndpoint(ISessionManager sessionManager)
+public sealed class TerminateAllDevicesEndpoint(
+    ISessionManager sessionManager,
+    ISessionRevocationStore revocationStore)
     : EndpointWithoutRequest
 {
     public override void Configure()
@@ -19,6 +22,8 @@ public sealed class TerminateAllDevicesEndpoint(ISessionManager sessionManager)
         var currentSessionId = HttpContext.User.GetSessionId();
 
         await sessionManager.TerminateAllExceptAsync(userId, currentSessionId, ct).ConfigureAwait(false);
+
+        await revocationStore.RevokeAsync(userId.ToString(), currentSessionId, ct).ConfigureAwait(false);
 
         await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
     }

--- a/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
@@ -1,5 +1,7 @@
 using FastEndpoints;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Domain.Interfaces;
+using UserService.Api.Infrastructure.Auth;
 
 namespace UserService.Api.Endpoints;
 
@@ -8,7 +10,9 @@ public sealed class TerminateDeviceRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
-public sealed class TerminateDeviceEndpoint(ISessionManager sessionManager)
+public sealed class TerminateDeviceEndpoint(
+    ISessionManager sessionManager,
+    ISessionRevocationStore revocationStore)
     : Endpoint<TerminateDeviceRequest>
 {
     public override void Configure()
@@ -20,7 +24,13 @@ public sealed class TerminateDeviceEndpoint(ISessionManager sessionManager)
     public override async Task HandleAsync(TerminateDeviceRequest req, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(req);
+
         await sessionManager.TerminateAsync(req.SessionId, ct).ConfigureAwait(false);
+
+        var userId = HttpContext.User.GetUserId().ToString();
+        var currentSessionId = HttpContext.User.GetSessionId();
+        await revocationStore.RevokeAsync(userId, currentSessionId, ct).ConfigureAwait(false);
+
         await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
     }
 }

--- a/src/Services/User/UserService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/User/UserService.Api/Infrastructure/DependencyInjection.cs
@@ -6,6 +6,7 @@ using UserService.Api.Domain;
 using UserService.Api.Domain.Interfaces;
 using UserService.Api.Infrastructure.Keycloak;
 using UserService.Api.Infrastructure.Persistence;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Infrastructure.Storage;
 
 namespace UserService.Api.Infrastructure;
@@ -50,6 +51,8 @@ public static class ModuleRegistration
 
         services.Configure<KeycloakAdminOptions>(configuration.GetSection(KeycloakAdminOptions.SectionName));
         services.AddHttpClient<ISessionManager, KeycloakSessionClient>();
+
+        services.AddSessionRevocation(configuration);
 
         return services;
     }

--- a/src/Services/User/UserService.Api/UserService.Api.csproj
+++ b/src/Services/User/UserService.Api/UserService.Api.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\..\BuildingBlocks\Contracts\Contracts.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\Outbox\Outbox.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\BuildingBlocks\SessionRevocation\SessionRevocation.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/integration/UserService.IntegrationTests/UserServiceFactory.cs
+++ b/tests/integration/UserService.IntegrationTests/UserServiceFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Domain.Interfaces;
 using UserService.Api.Infrastructure.Persistence;
 using UserService.IntegrationTests.Helpers;
@@ -59,6 +60,9 @@ public sealed class UserServiceFactory : WebApplicationFactory<Program>
 
             services.RemoveAll<ISessionManager>();
             services.AddSingleton<ISessionManager, FakeSessionManager>();
+
+            services.RemoveAll<ISessionRevocationStore>();
+            services.AddSingleton(Substitute.For<ISessionRevocationStore>());
 
             // Replace authentication with test scheme
             services.AddAuthentication(TestAuthHandler.SchemeName)

--- a/tests/unit/ApiGateway.Tests/ApiGateway.Tests.csproj
+++ b/tests/unit/ApiGateway.Tests/ApiGateway.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Gateway\ApiGateway\ApiGateway.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/unit/ApiGateway.Tests/SessionRevocationMiddlewareTests.cs
+++ b/tests/unit/ApiGateway.Tests/SessionRevocationMiddlewareTests.cs
@@ -1,0 +1,118 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+using Urfu.Link.Gateway.ApiGateway;
+
+namespace ApiGateway.Tests;
+
+public sealed class SessionRevocationMiddlewareTests
+{
+    private readonly ISessionRevocationStore _store = Substitute.For<ISessionRevocationStore>();
+    private bool _nextCalled;
+
+    private SessionRevocationMiddleware CreateMiddleware()
+    {
+        return new SessionRevocationMiddleware(_ =>
+        {
+            _nextCalled = true;
+            return Task.CompletedTask;
+        }, _store);
+    }
+
+    private static DefaultHttpContext CreateAuthenticatedContext(string sub, string sid)
+    {
+        var claims = new[]
+        {
+            new Claim("sub", sub),
+            new Claim("sid", sid),
+        };
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(identity),
+        };
+        return context;
+    }
+
+    private static DefaultHttpContext CreateAnonymousContext()
+    {
+        return new DefaultHttpContext();
+    }
+
+    [Fact]
+    public async Task ShouldPassThroughWhenUnauthenticated()
+    {
+        var middleware = CreateMiddleware();
+        var context = CreateAnonymousContext();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(_nextCalled);
+    }
+
+    [Fact]
+    public async Task ShouldPassThroughWhenNotRevoked()
+    {
+        var middleware = CreateMiddleware();
+        var context = CreateAuthenticatedContext("user-1", "session-1");
+        _store.IsRevokedAsync("user-1", "session-1", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(_nextCalled);
+        Assert.NotEqual(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturn401WhenSessionRevoked()
+    {
+        var middleware = CreateMiddleware();
+        var context = CreateAuthenticatedContext("user-1", "session-1");
+        _store.IsRevokedAsync("user-1", "session-1", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(_nextCalled);
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldSetRevocationHeaderWhenRevoked()
+    {
+        var middleware = CreateMiddleware();
+        var context = CreateAuthenticatedContext("user-1", "session-1");
+        _store.IsRevokedAsync("user-1", "session-1", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal("true", context.Response.Headers["X-Session-Revoked"].ToString());
+    }
+
+    [Fact]
+    public async Task ShouldPassThroughWhenNoSubClaim()
+    {
+        var middleware = CreateMiddleware();
+        var identity = new ClaimsIdentity([new Claim("sid", "session-1")], "TestAuth");
+        var context = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(_nextCalled);
+    }
+
+    [Fact]
+    public async Task ShouldPassThroughWhenNoSidClaim()
+    {
+        var middleware = CreateMiddleware();
+        var identity = new ClaimsIdentity([new Claim("sub", "user-1")], "TestAuth");
+        var context = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(_nextCalled);
+    }
+}

--- a/tests/unit/SessionRevocation.Tests/RedisSessionRevocationStoreTests.cs
+++ b/tests/unit/SessionRevocation.Tests/RedisSessionRevocationStoreTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+
+namespace SessionRevocation.Tests;
+
+public sealed class RedisSessionRevocationStoreTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redis = new RedisBuilder().Build();
+    private ConnectionMultiplexer? _multiplexer;
+    private RedisSessionRevocationStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _redis.StartAsync();
+        _multiplexer = await ConnectionMultiplexer.ConnectAsync(_redis.GetConnectionString());
+        _store = CreateStore(TimeSpan.FromSeconds(300));
+    }
+
+    public async Task DisposeAsync()
+    {
+        _multiplexer?.Dispose();
+        await _redis.DisposeAsync();
+    }
+
+    private RedisSessionRevocationStore CreateStore(TimeSpan ttl)
+    {
+        var options = Options.Create(new SessionRevocationOptions
+        {
+            KeyPrefix = "urfu:session",
+            Ttl = ttl,
+        });
+        return new RedisSessionRevocationStore(_multiplexer!, options);
+    }
+
+    [Fact]
+    public async Task ShouldReturnFalseWhenNoRevocation()
+    {
+        var result = await _store.IsRevokedAsync("user-1", "session-abc");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ShouldSetKeysInRedisOnRevoke()
+    {
+        await _store.RevokeAsync("user-1", "caller-session");
+
+        var db = _multiplexer!.GetDatabase();
+        Assert.True(await db.KeyExistsAsync("urfu:session:revoked:user-1"));
+        Assert.True(await db.SetContainsAsync("urfu:session:allowed:user-1", "caller-session"));
+    }
+
+    [Fact]
+    public async Task ShouldReturnTrueForNonAllowedSession()
+    {
+        await _store.RevokeAsync("user-1", "caller-session");
+
+        var result = await _store.IsRevokedAsync("user-1", "other-session");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ShouldReturnFalseForAllowedSession()
+    {
+        await _store.RevokeAsync("user-1", "caller-session");
+
+        var result = await _store.IsRevokedAsync("user-1", "caller-session");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ShouldAccumulateAllowedSessions()
+    {
+        await _store.RevokeAsync("user-1", "session-a");
+        await _store.RevokeAsync("user-1", "session-b");
+
+        Assert.False(await _store.IsRevokedAsync("user-1", "session-a"));
+        Assert.False(await _store.IsRevokedAsync("user-1", "session-b"));
+        Assert.True(await _store.IsRevokedAsync("user-1", "session-c"));
+    }
+
+    [Fact]
+    public async Task ShouldExpireKeysAfterTtl()
+    {
+        var shortStore = CreateStore(TimeSpan.FromSeconds(1));
+
+        await shortStore.RevokeAsync("user-ttl", "caller");
+        Assert.True(await shortStore.IsRevokedAsync("user-ttl", "other"));
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        Assert.False(await shortStore.IsRevokedAsync("user-ttl", "other"));
+    }
+
+    [Fact]
+    public async Task ShouldIsolateDifferentUsers()
+    {
+        await _store.RevokeAsync("user-a", "session-1");
+
+        Assert.True(await _store.IsRevokedAsync("user-a", "session-2"));
+        Assert.False(await _store.IsRevokedAsync("user-b", "session-2"));
+    }
+}

--- a/tests/unit/SessionRevocation.Tests/SessionRevocation.Tests.csproj
+++ b/tests/unit/SessionRevocation.Tests/SessionRevocation.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.Redis" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\SessionRevocation\SessionRevocation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Новый BuildingBlock `SessionRevocation`: per-user Redis-флаг + allowlist разрешённых `sid`. После вызова terminate UserService пишет в Redis (TTL 300s), gateway middleware проверяет на каждом запросе
- `SessionRevocationMiddleware` в ApiGateway: если `sid` не в allowlist → 401 + `X-Session-Revoked: true`
- `TerminateDeviceEndpoint` / `TerminateAllDevicesEndpoint` вызывают `RevokeAsync` после удаления KC-сессии
- Frontend `handleUnauthorized`: на `X-Session-Revoked` → `/.pomerium/sign_out` (prod) или `clearTokens` (dev)
- `deploy/helm/services/api-gateway/values-prod.yaml` — добавлена строка подключения Redis

## Test plan

- [x] `SessionRevocation.Tests` — 7 тестов с TestContainers Redis (TTL, allowlist, isolation)
- [x] `ApiGateway.Tests` — 6 тестов middleware (pass-through, 401, header, missing claims)
- [x] `UserService.IntegrationTests` — 15 тестов, все terminate endpoints зелёные
- [x] `UserService.UnitTests` — 22 теста, все зелёные

Closes #126