### PR TITLE
fix(#131): set AbortOnConnectFail=false so SmokeTests start without Redis

### DIFF
--- a/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
+++ b/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
@@ -32,7 +32,9 @@ public static class SessionRevocationExtensions
         services.TryAddSingleton<IConnectionMultiplexer>(static serviceProvider =>
         {
             var options = serviceProvider.GetRequiredService<IOptions<SessionRevocationOptions>>().Value;
-            return ConnectionMultiplexer.Connect(options.RedisConfiguration);
+            var configOptions = ConfigurationOptions.Parse(options.RedisConfiguration);
+            configOptions.AbortOnConnectFail = false;
+            return ConnectionMultiplexer.Connect(configOptions);
         });
 
         services.AddSingleton<ISessionRevocationStore, RedisSessionRevocationStore>();


### PR DESCRIPTION
Closes #131

## Что сделано
- В `SessionRevocationExtensions.AddSessionRevocation()` при регистрации `IConnectionMultiplexer` добавлен `AbortOnConnectFail = false`
- `ConnectionMultiplexer.Connect()` теперь не бросает при старте если Redis недоступен, а переподключается в фоне
- SmokeTests не шлют аутентифицированных запросов — Redis никогда не вызывается в тестах

## Как проверить
- Все тесты проходят локально: `dotnet test Urfu.Link.slnx -c Release`
- В CI pipeline `SmokeTests` больше не падают с `RedisConnectionException`