### PR TITLE
ci(#134): fix promote flow — PR-based promote instead of direct push

### DIFF
--- a/.github/actions/promote/action.yml
+++ b/.github/actions/promote/action.yml
@@ -1,0 +1,81 @@
+name: Promote image tag
+description: >
+  Update a Helm values file with a new image tag, open a branch,
+  and create an auto-merge PR against the target branch.
+
+inputs:
+  service:
+    description: Service name (e.g. api-gateway)
+    required: true
+  environment:
+    description: Target environment (dev or prod)
+    required: true
+  image_tag:
+    description: Image tag to pin in Helm values
+    required: true
+  base_branch:
+    description: Branch to open the PR against
+    required: false
+    default: master
+  github_token:
+    description: Token with contents:write and pull-requests:write
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Update Helm values
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        TARGET_ENV: ${{ inputs.environment }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+      run: |
+        python3 - <<'PY'
+        from pathlib import Path
+        import os, re
+        svc = os.environ["SERVICE"]
+        env = os.environ["TARGET_ENV"]
+        tag = os.environ["IMAGE_TAG"]
+        path = Path(f"deploy/helm/services/{svc}/values-{env}.yaml")
+        content = path.read_text(encoding="utf-8")
+        updated = re.sub(
+            r"(^\s*tag:\s*).*$",
+            lambda m: f"{m.group(1)}{tag}",
+            content, count=1, flags=re.MULTILINE,
+        )
+        if updated == content:
+            raise SystemExit(f"No 'tag:' field found in {path}")
+        path.write_text(updated, encoding="utf-8")
+        print(f"Updated {path} -> {tag}")
+        PY
+
+    - name: Commit, push, and open PR
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        SERVICE: ${{ inputs.service }}
+        TARGET_ENV: ${{ inputs.environment }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        BASE_BRANCH: ${{ inputs.base_branch }}
+      run: |
+        BRANCH="promote/${SERVICE}-${TARGET_ENV}-${IMAGE_TAG}"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git checkout -b "$BRANCH"
+        git add "deploy/helm/services/${SERVICE}/values-${TARGET_ENV}.yaml"
+        if git diff --cached --quiet; then
+          echo "Nothing to promote — tag already set to ${IMAGE_TAG}"
+          exit 0
+        fi
+        git commit -m "promote(${SERVICE}): ${TARGET_ENV} -> ${IMAGE_TAG}"
+        git push origin "$BRANCH"
+        PR_URL=$(gh pr create \
+          --repo "${GITHUB_REPOSITORY}" \
+          --base "${BASE_BRANCH}" \
+          --head "$BRANCH" \
+          --title "promote(${SERVICE}): ${TARGET_ENV} -> ${IMAGE_TAG}" \
+          --body "Automated image promotion.")
+        echo "PR: $PR_URL"
+        gh pr merge "$PR_URL" --auto --squash --repo "${GITHUB_REPOSITORY}" \
+          || echo "::warning::Auto-merge scheduling failed — manual merge required."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -252,41 +253,24 @@ jobs:
     if: github.event_name != 'pull_request' && needs.detect-changes.outputs.any_changed == 'true'
     needs: [build-images, detect-changes]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     steps:
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v6
         with:
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Promote built services
-        shell: bash
-        env:
-          MATRIX: ${{ needs.detect-changes.outputs.matrix }}
-        run: |
-          IMAGE_TAG="sha-${GITHUB_SHA::7}"
-          SERVICES=$(echo "$MATRIX" | jq -r '.include[].service')
-          for svc in $SERVICES; do
-            FILE="deploy/helm/services/${svc}/values-prod.yaml"
-            python3 -c "
-          import re, sys
-          from pathlib import Path
-          path = Path(sys.argv[1])
-          tag = sys.argv[2]
-          content = path.read_text()
-          updated = re.sub(r'(^\s*tag:\s*).*$', rf'\g<1>{tag}', content, count=1, flags=re.MULTILINE)
-          if updated == content:
-              raise SystemExit(f'Failed to update tag in {path}')
-          path.write_text(updated)
-          print(f'Updated {path} -> {tag}')
-          " "$FILE" "$IMAGE_TAG"
-          done
+      - name: Compute image tag
+        id: tag
+        run: echo "value=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/helm/services/*/values-prod.yaml
-          git commit -m "promote(ci): prod -> sha-${GITHUB_SHA::7}" || exit 0
-          git pull --rebase
-          git push
+      - name: Promote ${{ matrix.service }} to prod
+        uses: ./.github/actions/promote
+        with:
+          service: ${{ matrix.service }}
+          environment: prod
+          image_tag: ${{ steps.tag.outputs.value }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend-web-image.yml
+++ b/.github/workflows/frontend-web-image.yml
@@ -20,9 +20,12 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@v5
         with:
           version: 10.18.0
@@ -78,27 +81,9 @@ jobs:
         run: cosign sign "${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
 
       - name: Promote frontend-web to prod
-        run: |
-          IMAGE_TAG="sha-${GITHUB_SHA::7}"
-          FILE="deploy/helm/services/frontend-web/values-prod.yaml"
-          python3 -c "
-          import re, sys
-          from pathlib import Path
-          path = Path(sys.argv[1])
-          tag = sys.argv[2]
-          content = path.read_text()
-          updated = re.sub(r'(^\s*tag:\s*).*$', rf'\g<1>{tag}', content, count=1, flags=re.MULTILINE)
-          if updated == content:
-              raise SystemExit(f'Failed to update tag in {path}')
-          path.write_text(updated)
-          print(f'Updated {path} -> {tag}')
-          " "$FILE" "$IMAGE_TAG"
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/helm/services/frontend-web/values-prod.yaml
-          git commit -m "promote(frontend-web): prod -> sha-${GITHUB_SHA::7}" || exit 0
-          git pull --rebase
-          git push
+        uses: ./.github/actions/promote
+        with:
+          service: frontend-web
+          environment: prod
+          image_tag: ${{ env.IMAGE_TAG }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote-app.yml
+++ b/.github/workflows/promote-app.yml
@@ -33,8 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.environment == 'prod' && 'master' || 'develop' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify image exists
         env:
@@ -47,38 +51,11 @@ jobs:
             (echo "::error::Image ${IMAGE} not found in registry" && exit 1)
           echo "Image verified."
 
-      - name: Update Helm values
-        env:
-          SERVICE: ${{ inputs.service }}
-          TARGET_ENV: ${{ inputs.environment }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-          import os
-          import re
-
-          path = Path(f"deploy/helm/services/{os.environ['SERVICE']}/values-{os.environ['TARGET_ENV']}.yaml")
-          content = path.read_text(encoding="utf-8")
-          updated = re.sub(
-              r"(^\s*tag:\s*).*$",
-              lambda match: f"{match.group(1)}{os.environ['IMAGE_TAG']}",
-              content,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if updated == content:
-              raise SystemExit(f"Unable to update image tag in {path}")
-          path.write_text(updated, encoding="utf-8")
-          PY
-      - name: Commit promotion
-        env:
-          SERVICE: ${{ inputs.service }}
-          TARGET_ENV: ${{ inputs.environment }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add deploy/helm/services/${SERVICE}/values-${TARGET_ENV}.yaml
-          git commit -m "promote(${SERVICE}): ${TARGET_ENV} -> ${IMAGE_TAG}" || exit 0
-          git push
+      - name: Promote ${{ inputs.service }} to ${{ inputs.environment }}
+        uses: ./.github/actions/promote
+        with:
+          service: ${{ inputs.service }}
+          environment: ${{ inputs.environment }}
+          image_tag: ${{ inputs.image_tag }}
+          base_branch: ${{ inputs.environment == 'prod' && 'master' || 'develop' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #134

## Что сделано

- Добавлен composite action `.github/actions/promote/action.yml` — единая точка для promote: обновляет Helm values, создаёт ветку `promote/{service}-{env}-{tag}`, пушит, открывает PR с auto-merge
- `ci.yml`: `promote-prod` переработан в matrix job (один PR на сервис вместо batch git push в master)
- `frontend-web-image.yml`: убран прямой git push, добавлен `token:` в checkout, вызов composite action
- `promote-app.yml`: убраны шаги Update Helm values + Commit promotion, добавлен `token:` и `ref:` (master для prod / develop для dev) в checkout, вызов composite action

## Как проверить

1. Включить **Allow auto-merge** в Settings → General репозитория
2. Запустить `Promote App` вручную (workflow_dispatch) → убедиться что создаётся PR вместо прямого push
3. Пушнуть изменение в backend-сервис в master → убедиться что `promote-prod` создаёт отдельные PR для каждого затронутого сервиса