### PR TITLE
fix(#137): replace IClassFixture with ICollectionFixture to prevent parallel factory startup

### DIFF
--- a/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
@@ -5,7 +5,8 @@ using UserService.IntegrationTests.Helpers;
 
 namespace UserService.IntegrationTests;
 
-public sealed class DeviceEndpointTests(UserServiceFactory factory) : IClassFixture<UserServiceFactory>
+[Collection("UserService")]
+public sealed class DeviceEndpointTests(UserServiceFactory factory)
 {
     // Minimal unsigned JWT with sid claim: {"alg":"none"}.{"sid":"test-pomerium-sid"}.
     private const string TestPomeriumJwt =

--- a/tests/integration/UserService.IntegrationTests/ProfileEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/ProfileEndpointTests.cs
@@ -5,7 +5,8 @@ using UserService.IntegrationTests.Helpers;
 
 namespace UserService.IntegrationTests;
 
-public sealed class ProfileEndpointTests(UserServiceFactory factory) : IClassFixture<UserServiceFactory>
+[Collection("UserService")]
+public sealed class ProfileEndpointTests(UserServiceFactory factory)
 {
     private HttpClient CreateAuthenticatedClient()
     {

--- a/tests/integration/UserService.IntegrationTests/ServiceMetadataTests.cs
+++ b/tests/integration/UserService.IntegrationTests/ServiceMetadataTests.cs
@@ -4,7 +4,8 @@ using UserService.Api.Domain;
 
 namespace UserService.IntegrationTests;
 
-public sealed class ServiceMetadataTests(UserServiceFactory factory) : IClassFixture<UserServiceFactory>
+[Collection("UserService")]
+public sealed class ServiceMetadataTests(UserServiceFactory factory)
 {
     private readonly HttpClient _client = factory.CreateClient();
 

--- a/tests/integration/UserService.IntegrationTests/UserServiceCollection.cs
+++ b/tests/integration/UserService.IntegrationTests/UserServiceCollection.cs
@@ -1,0 +1,4 @@
+namespace UserService.IntegrationTests;
+
+[CollectionDefinition("UserService")]
+public sealed class UserServiceCollectionDefinition : ICollectionFixture<UserServiceFactory>;


### PR DESCRIPTION
Closes #137

## Что сделано
- Добавлен `UserServiceCollectionDefinition` с `[CollectionDefinition("UserService")]` + `ICollectionFixture<UserServiceFactory>`
- `ServiceMetadataTests`, `ProfileEndpointTests`, `DeviceEndpointTests` переведены с `IClassFixture` на `[Collection("UserService")]`

Теперь все три класса делят один экземпляр `UserServiceFactory` и запускаются последовательно — race condition на статическом `JsonSerializerOptions` внутри FastEndpoints устранён.

## Как проверить
- Запустить `dotnet test tests/integration/UserService.IntegrationTests` несколько раз подряд — все 15 тестов должны стабильно проходить
- Убедиться что в CI джоб `build-test` больше не падает с `ArgumentException: Destination array was not long enough`