### PR TITLE
fix(#150): исправить invalidRedirectUri при истечении сессии

### DIFF
--- a/apps/client/src/features/auth/auth-gate.tsx
+++ b/apps/client/src/features/auth/auth-gate.tsx
@@ -3,10 +3,10 @@ import { useAuthStore } from "@/store/auth-store";
 import { useEffect, useState } from "react";
 import type { PropsWithChildren } from "react";
 import { ActivityIndicator, View } from "react-native";
+import { KEYCLOAK_CLIENT_ID, KEYCLOAK_REALM } from "./keycloak-constants";
 
-const CLIENT_ID = "urfu-link-web";
 const SCOPES = "openid profile email offline_access";
-const REDIRECT_URI = "http://localhost:3000/";
+const REDIRECT_URI = window.location.origin + "/";
 
 function base64urlEncode(bytes: Uint8Array): string {
     return btoa(String.fromCharCode(...bytes))
@@ -37,7 +37,7 @@ async function startPKCEFlow(): Promise<void> {
 
     const params = new URLSearchParams({
         response_type: "code",
-        client_id: CLIENT_ID,
+        client_id: KEYCLOAK_CLIENT_ID,
         redirect_uri: REDIRECT_URI,
         scope: SCOPES,
         state,
@@ -45,7 +45,7 @@ async function startPKCEFlow(): Promise<void> {
         code_challenge_method: "S256",
     });
 
-    window.location.href = `${appConfig.keycloakUrl}/realms/urfu-link/protocol/openid-connect/auth?${params}`;
+    window.location.href = `${appConfig.keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth?${params}`;
 }
 
 async function handleCallback(
@@ -61,13 +61,13 @@ async function handleCallback(
     sessionStorage.removeItem("pkce_state");
 
     const res = await fetch(
-        `${appConfig.keycloakUrl}/realms/urfu-link/protocol/openid-connect/token`,
+        `${appConfig.keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
         {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body: new URLSearchParams({
                 grant_type: "authorization_code",
-                client_id: CLIENT_ID,
+                client_id: KEYCLOAK_CLIENT_ID,
                 code,
                 redirect_uri: REDIRECT_URI,
                 code_verifier: storedVerifier,

--- a/apps/client/src/features/auth/keycloak-constants.ts
+++ b/apps/client/src/features/auth/keycloak-constants.ts
@@ -1,0 +1,2 @@
+export const KEYCLOAK_CLIENT_ID = "urfu-link-web";
+export const KEYCLOAK_REALM = "urfu-link";

--- a/apps/client/src/lib/config.ts
+++ b/apps/client/src/lib/config.ts
@@ -22,9 +22,9 @@ function getRawConfig(): Partial<RuntimeConfig> {
     const extra = (Constants.expoConfig?.extra ?? {}) as Partial<RuntimeConfig>;
     const webConfig = Platform.OS === "web" && typeof window !== "undefined" ? window.__APP_CONFIG__ ?? {} : {};
     return {
-        appEnv: webConfig.appEnv ?? extra.appEnv ?? defaultConfig.appEnv,
-        apiUrl: webConfig.apiUrl ?? extra.apiUrl ?? defaultConfig.apiUrl,
-        keycloakUrl: webConfig.keycloakUrl ?? extra.keycloakUrl ?? defaultConfig.keycloakUrl,
+        appEnv: webConfig.appEnv || extra.appEnv || defaultConfig.appEnv,
+        apiUrl: webConfig.apiUrl || extra.apiUrl || defaultConfig.apiUrl,
+        keycloakUrl: webConfig.keycloakUrl || extra.keycloakUrl || defaultConfig.keycloakUrl,
     };
 }
 const raw = getRawConfig();

--- a/apps/client/src/providers/auth-provider.tsx
+++ b/apps/client/src/providers/auth-provider.tsx
@@ -2,6 +2,7 @@ import { appConfig } from "@/lib/config";
 import { useAuthStore } from "@/store/auth-store";
 import { useEffect, useRef } from "react";
 import type { PropsWithChildren } from "react";
+import { KEYCLOAK_CLIENT_ID, KEYCLOAK_REALM } from "@/features/auth/keycloak-constants";
 
 async function refreshAccessToken(
     keycloakUrl: string,
@@ -9,13 +10,13 @@ async function refreshAccessToken(
 ): Promise<{ accessToken: string; refreshToken: string; expiresAt: number } | null> {
     try {
         const res = await fetch(
-            `${keycloakUrl}/realms/urfu-link/protocol/openid-connect/token`,
+            `${keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
             {
                 method: "POST",
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: new URLSearchParams({
                     grant_type: "refresh_token",
-                    client_id: "urfu-link-web",
+                    client_id: KEYCLOAK_CLIENT_ID,
                     refresh_token: refreshToken,
                 }).toString(),
             }

--- a/deploy/helm/services/frontend-web/values-dev.yaml
+++ b/deploy/helm/services/frontend-web/values-dev.yaml
@@ -23,6 +23,7 @@ service:
 env:
   APP_ENV: dev
   EXPO_PUBLIC_API_URL: https://api.dev.127.0.0.1.nip.io
+  EXPO_PUBLIC_KEYCLOAK_URL: https://id.ghjc.ru
 
 rollout:
   enabled: false

--- a/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
+++ b/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
@@ -356,7 +356,7 @@ spec:
               echo "Granted view-users to user-service-admin service account"
 
               # --- Frontend Web (public client for mobile) ---
-              ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*"]' '["https://urfu-link.ghjc.ru"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"
+              ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*","http://app.dev.127.0.0.1.nip.io/*"]' '["https://urfu-link.ghjc.ru","http://app.dev.127.0.0.1.nip.io"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"
 
               # --- Pomerium (centralized auth proxy) ---
               ensure_client "pomerium" '["https://auth.ghjc.ru/oauth2/callback","https://auth.ghjc.ru/.pomerium/callback","https://auth.ghjc.ru/.pomerium/signed_out"]' '["https://*.ghjc.ru"]' "false" "Pomerium Auth Proxy" "https://auth.ghjc.ru"


### PR DESCRIPTION
Closes #150

## Что сделано
- `auth-gate.tsx`: `REDIRECT_URI` теперь динамический — `window.location.origin + "/"` вместо захардкоженного `http://localhost:3000/`
- `keycloak-constants.ts` (новый): `CLIENT_ID` и `REALM` вынесены в одно место, убрано дублирование между `auth-gate.tsx` и `auth-provider.tsx`
- `config.ts`: `??` → `||` для `keycloakUrl`/`apiUrl`/`appEnv` — пустая строка теперь корректно даёт fallback на дефолт
- `values-dev.yaml`: добавлен `EXPO_PUBLIC_KEYCLOAK_URL: https://id.ghjc.ru`
- `keycloak-bootstrap-job.yaml`: добавлен `http://app.dev.127.0.0.1.nip.io/*` в разрешённые redirect URIs клиента `urfu-link-web`

## Как проверить
- Открыть `http://app.dev.127.0.0.1.nip.io` в браузере при истёкшей/отсутствующей сессии
- Убедиться, что происходит редирект на Keycloak без ошибки `invalidRedirectUriMessage`
- После успешного логина — редирект обратно на приложение