### PR TITLE
fix(#151): use Pomerium JWT mapping to identify current session in TerminateAllDevicesEndpoint

### DIFF
--- a/src/Services/User/UserService.Api/Endpoints/TerminateAllDevicesEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/TerminateAllDevicesEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using FastEndpoints;
 using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Domain.Interfaces;
@@ -20,23 +22,19 @@ public sealed class TerminateAllDevicesEndpoint(
     public override async Task HandleAsync(CancellationToken ct)
     {
         var userId = HttpContext.User.GetUserId();
-        var realIp = HttpContext.Request.Headers["X-Real-Ip"].FirstOrDefault()
-                     ?? HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim();
-
         var sessions = await sessionManager.GetSessionsAsync(userId, ct).ConfigureAwait(false);
-        var currentSessionId = !string.IsNullOrEmpty(realIp)
-            ? sessions.FirstOrDefault(s => string.Equals(s.IpAddress, realIp, StringComparison.Ordinal))?.SessionId
-            : null;
+
+        var currentKeycloakSessionId = await ResolveCurrentKeycloakSessionIdAsync(sessions, ct).ConfigureAwait(false);
 
         // If we can't identify the current session, do nothing to avoid self-logout
-        if (currentSessionId is null)
+        if (currentKeycloakSessionId is null)
         {
             await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
             return;
         }
 
         var toTerminate = sessions
-            .Where(s => !string.Equals(s.SessionId, currentSessionId, StringComparison.Ordinal))
+            .Where(s => !string.Equals(s.SessionId, currentKeycloakSessionId, StringComparison.Ordinal))
             .ToList();
 
         await Task.WhenAll(
@@ -45,8 +43,52 @@ public sealed class TerminateAllDevicesEndpoint(
 
         await deviceRegistry.RemoveAllAsync(toTerminate.Select(s => s.SessionId), ct).ConfigureAwait(false);
 
-        await revocationStore.RevokeAsync(userId.ToString(), currentSessionId, ct).ConfigureAwait(false);
+        var callerSessionId = HttpContext.User.GetSessionId();
+        await revocationStore.RevokeAsync(userId.ToString(), callerSessionId, ct).ConfigureAwait(false);
 
         await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<string?> ResolveCurrentKeycloakSessionIdAsync(
+        IReadOnlyList<DeviceSession> sessions,
+        CancellationToken ct)
+    {
+        var pomSid = GetPomeriumSid(
+            HttpContext.Request.Headers["X-Pomerium-Jwt-Assertion"].FirstOrDefault());
+
+        if (pomSid is not null)
+        {
+            var mapped = await deviceRegistry.GetKeycloakSessionIdAsync(pomSid, ct).ConfigureAwait(false);
+            if (mapped is not null)
+                return mapped;
+        }
+
+        var realIp = HttpContext.Request.Headers["X-Real-Ip"].FirstOrDefault()
+                     ?? HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault()?.Split(',')[0].Trim();
+
+        return !string.IsNullOrEmpty(realIp)
+            ? sessions.FirstOrDefault(s => string.Equals(s.IpAddress, realIp, StringComparison.Ordinal))?.SessionId
+            : null;
+    }
+
+    private static string? GetPomeriumSid(string? jwtAssertion)
+    {
+        if (string.IsNullOrEmpty(jwtAssertion))
+            return null;
+
+        var parts = jwtAssertion.Split('.');
+        if (parts.Length < 2)
+            return null;
+
+        try
+        {
+            var payload = parts[1];
+            payload = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(payload.Replace('-', '+').Replace('_', '/')));
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("sid", out var sid) ? sid.GetString() : null;
+        }
+        catch (FormatException) { return null; }
+        catch (JsonException) { return null; }
     }
 }

--- a/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
 using UserService.Api.Application.Contracts.Responses;
+using UserService.Api.Domain.Interfaces;
 using UserService.IntegrationTests.Helpers;
 
 namespace UserService.IntegrationTests;
@@ -52,5 +54,28 @@ public sealed class DeviceEndpointTests(UserServiceFactory factory)
             new Uri("/api/v1/me/devices", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TerminateAllDevicesWithPomeriumMappingAndNoIpShouldTerminateSessions()
+    {
+        var sessionManager = (FakeSessionManager)factory.Services.GetRequiredService<ISessionManager>();
+        var deviceRegistry = factory.Services.GetRequiredService<IDeviceRegistry>();
+
+        sessionManager.Reset();
+        await deviceRegistry.SavePomeriumMappingAsync("test-pomerium-sid", "test-session-001");
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+        client.DefaultRequestHeaders.Add("X-Pomerium-Jwt-Assertion", TestPomeriumJwt);
+        // No X-Real-Ip — simulates production scenario where IP matching fails
+
+        var response = await client.DeleteAsync(new Uri("/api/v1/me/devices", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        var sessions = await sessionManager.GetSessionsAsync(Guid.Empty);
+        Assert.Single(sessions);
+        Assert.Equal("test-session-001", sessions[0].SessionId);
     }
 }

--- a/tests/integration/UserService.IntegrationTests/Helpers/FakeSessionManager.cs
+++ b/tests/integration/UserService.IntegrationTests/Helpers/FakeSessionManager.cs
@@ -4,11 +4,15 @@ namespace UserService.IntegrationTests.Helpers;
 
 public sealed class FakeSessionManager : ISessionManager
 {
-    private readonly List<DeviceSession> _sessions =
+    private List<DeviceSession> _sessions = CreateDefaultSessions();
+
+    private static List<DeviceSession> CreateDefaultSessions() =>
     [
         new("test-session-001", "127.0.0.1", DateTimeOffset.UtcNow, "Chrome", "Windows"),
         new("test-session-002", "192.168.1.1", DateTimeOffset.UtcNow.AddHours(-2), "Safari", "macOS"),
     ];
+
+    public void Reset() => _sessions = CreateDefaultSessions();
 
     public Task<IReadOnlyList<DeviceSession>> GetSessionsAsync(Guid userId, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
Closes #151

## Что сделано
- В `TerminateAllDevicesEndpoint` добавлен метод `ResolveCurrentKeycloakSessionIdAsync`: сначала ищет текущую Keycloak-сессию через Pomerium JWT → `deviceRegistry.GetKeycloakSessionIdAsync()`, фолбэк на IP-матчинг если маппинга нет
- Исправлен вызов `revocationStore.RevokeAsync` — теперь использует JWT `sid` через `GetSessionId()`, а не Keycloak session ID (как у `TerminateDeviceEndpoint`)
- Добавлен `Reset()` в `FakeSessionManager` для изоляции теста
- Добавлен интеграционный тест, воспроизводящий прод-сценарий (нет `X-Real-Ip`, есть Pomerium-маппинг)

## Причина бага
За Pomerium-прокси IP в `X-Real-Ip` не совпадает с IP в Keycloak → `currentSessionId == null` → ранний `return 204` без завершения сессий.

## Как проверить
1. Залогиниться с двух устройств
2. На одном вызвать `DELETE /api/v1/me/devices`
3. Убедиться, что `GET /api/v1/me/devices` возвращает только текущее устройство