### PR TITLE
ci(#156): CI/CD workflows запускаются на PR и push в develop

### DIFF
--- a/.github/workflows/frontend-validate.yml
+++ b/.github/workflows/frontend-validate.yml
@@ -2,6 +2,7 @@ name: Frontend Validate
 
 on:
   pull_request:
+    branches: [master]
     paths:
       - "apps/client/**"
       - "packages/api-client/**"


### PR DESCRIPTION
Closes #156

## Что сделано
- Добавлен фильтр `branches: [master]` к триггеру `pull_request` в `frontend-validate.yml` — workflow больше не запускается на PR в `develop`

## Как проверить
- Открыть любой PR в `develop` — `Frontend Validate` не должен запуститься
- Открыть PR в `master` — `Frontend Validate` должен запуститься как обычно