### PR TITLE
fix(#162): prevent CORS errors on Pomerium auth redirect

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -10,7 +10,16 @@
       "default": "./src/index.ts"
     }
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "peerDependencies": {
     "react": "19.2.0"
+  },
+  "devDependencies": {
+    "@vitest/browser": "^4.1.2",
+    "jsdom": "^29.0.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/api-client/src/__tests__/createApiClient.test.ts
+++ b/packages/api-client/src/__tests__/createApiClient.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createApiClient } from "../index";
+
+function mockFetchWith(responseInit: Partial<Response>) {
+  const response = {
+    status: 200,
+    ok: true,
+    type: "basic",
+    headers: new Headers(),
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(""),
+    ...responseInit,
+  } as Response;
+
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+describe("createApiClient", () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "https://urfu-link.ghjc.ru/chats?view=messages" },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  describe("redirect: manual (CORS prevention)", () => {
+    it("passes redirect: manual to every API fetch call", async () => {
+      const fetchSpy = mockFetchWith({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ userId: "1", identity: {}, account: {}, privacy: {}, notifications: {}, soundVideo: {} }),
+      });
+
+      const client = createApiClient({ baseUrl: "" });
+      await client.users.getMe();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ redirect: "manual" })
+      );
+    });
+  });
+
+  describe("handleUnauthorized — opaqueredirect (Pomerium → Keycloak redirect)", () => {
+    it("redirects to /.pomerium/sign_in on opaqueredirect response", async () => {
+      mockFetchWith({ type: "opaqueredirect", status: 0, ok: false });
+
+      const client = createApiClient({ baseUrl: "" });
+      try {
+        await client.users.getMe();
+      } catch {
+        // expected: response.ok is false → throws
+      }
+
+      expect(window.location.href).toBe(
+        "/.pomerium/sign_in?pomerium_redirect_uri=https%3A%2F%2Furfu-link.ghjc.ru%2Fchats%3Fview%3Dmessages"
+      );
+    });
+
+    it("redirects to /.pomerium/sign_in on 401 without X-Session-Revoked", async () => {
+      mockFetchWith({ status: 401, ok: false });
+
+      const client = createApiClient({ baseUrl: "" });
+      try {
+        await client.users.getMe();
+      } catch {
+        // expected
+      }
+
+      expect(window.location.href).toBe(
+        "/.pomerium/sign_in?pomerium_redirect_uri=https%3A%2F%2Furfu-link.ghjc.ru%2Fchats%3Fview%3Dmessages"
+      );
+    });
+
+    it("redirects to /.pomerium/sign_out on 401 with X-Session-Revoked: true", async () => {
+      const headers = new Headers({ "X-Session-Revoked": "true" });
+      mockFetchWith({ status: 401, ok: false, headers });
+
+      const client = createApiClient({ baseUrl: "" });
+      try {
+        await client.users.getMe();
+      } catch {
+        // expected
+      }
+
+      expect(window.location.href).toBe(
+        "/.pomerium/sign_out?pomerium_redirect_uri=https%3A%2F%2Furfu-link.ghjc.ru%2Fchats%3Fview%3Dmessages"
+      );
+    });
+
+    it("calls onUnauthorized instead of redirecting in dev mode", async () => {
+      mockFetchWith({ type: "opaqueredirect", status: 0, ok: false });
+
+      const onUnauthorized = vi.fn();
+      const client = createApiClient({ baseUrl: "https://api.dev", onUnauthorized });
+
+      try {
+        await client.users.getMe();
+      } catch {
+        // expected
+      }
+
+      expect(onUnauthorized).toHaveBeenCalled();
+      expect(window.location.href).toBe("https://urfu-link.ghjc.ru/chats?view=messages");
+    });
+  });
+});

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -37,7 +37,8 @@ export function createApiClient({ baseUrl, getAccessToken, onUnauthorized }: Api
 
   let redirecting = false;
   function handleUnauthorized(response: Response): void {
-    if (response.status !== 401) return;
+    const isAuthRedirect = response.type === "opaqueredirect";
+    if (response.status !== 401 && !isAuthRedirect) return;
     if (onUnauthorized) {
       onUnauthorized();
       return;
@@ -45,7 +46,7 @@ export function createApiClient({ baseUrl, getAccessToken, onUnauthorized }: Api
     if (typeof window !== "undefined" && !redirecting) {
       redirecting = true;
       const rd = encodeURIComponent(window.location.href);
-      const isRevoked = response.headers.get("X-Session-Revoked") === "true";
+      const isRevoked = !isAuthRedirect && response.headers.get("X-Session-Revoked") === "true";
       window.location.href = isRevoked
         ? `/.pomerium/sign_out?pomerium_redirect_uri=${rd}`
         : `/.pomerium/sign_in?pomerium_redirect_uri=${rd}`;

--- a/packages/api-client/src/users.ts
+++ b/packages/api-client/src/users.ts
@@ -87,6 +87,7 @@ export function createUsersApi(
         ...init?.headers,
       },
       credentials: "same-origin",
+      redirect: "manual",
     });
 
     handleUnauthorized(response);

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});


### PR DESCRIPTION
Closes #162

## Что сделано
- Добавлен `redirect: "manual"` во все fetch-запросы api-client — браузер больше не следует автоматически за Pomerium-редиректом к Keycloak, что устраняло CORS-ошибку
- `handleUnauthorized` теперь распознаёт `opaqueredirect` (response.type) как признак неаутентифицированного запроса и редиректит пользователя на `/.pomerium/sign_in` — так же, как при 401
- Настроен Vitest (jsdom) для пакета `api-client`, добавлены 5 тестов

## Как проверить
- Авторизоваться, открыть DevTools → Network
- Убедиться, что запросы к `/api/users/me` отдают данные без редиректа на `id.ghjc.ru`
- Убедиться, что при истечении сессии (или гонке после login) происходит редирект на `/.pomerium/sign_in`, а не CORS-ошибка в консоли