### PR TITLE
ci(#170): skip CI jobs for develop→master pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   build-test:
+    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,6 +45,7 @@ jobs:
         run: dotnet test Urfu.Link.slnx -c Release --no-build
 
   helm-validate:
+    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/frontend-validate.yml
+++ b/.github/workflows/frontend-validate.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   validate:
+    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   codeql:
     name: CodeQL
+    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,6 +45,7 @@ jobs:
 
   sbom:
     name: SBOM
+    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #170

## Что сделано
- Добавлено условие `if: github.head_ref != 'develop'` на jobs в трёх workflow
- `ci.yml`: `build-test`, `helm-validate`
- `security.yml`: `codeql`, `sbom`
- `frontend-validate.yml`: `validate`

## Как проверить
- Открыть PR из develop в master — CI-jobs должны быть пропущены (skipped)
- Открыть PR из feature-ветки в master — CI-jobs должны запускаться как обычно
- Push в master — CI-jobs должны запускаться как обычно