### PR TITLE
fix(#172): revoke only the terminated session instead of all sessions

### DIFF
--- a/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
+++ b/src/BuildingBlocks/SessionRevocation/SessionRevocationExtensions.cs
@@ -58,6 +58,8 @@ public interface ISessionRevocationStore
 {
     Task RevokeAsync(string userId, string callerSessionId, CancellationToken cancellationToken = default);
 
+    Task RevokeSingleAsync(string userId, string sessionId, CancellationToken cancellationToken = default);
+
     Task<bool> IsRevokedAsync(string userId, string sessionId, CancellationToken cancellationToken = default);
 }
 
@@ -84,6 +86,23 @@ public sealed class RedisSessionRevocationStore(
         await Task.WhenAll(t1, t2, t3).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task RevokeSingleAsync(string userId, string sessionId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        var db = multiplexer.GetDatabase();
+        var opts = options.Value;
+        var deniedKey = $"{opts.KeyPrefix}:denied:{userId}";
+
+        var batch = db.CreateBatch();
+        var t1 = batch.SetAddAsync(deniedKey, sessionId);
+        var t2 = batch.KeyExpireAsync(deniedKey, opts.Ttl);
+        batch.Execute();
+
+        await Task.WhenAll(t1, t2).WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<bool> IsRevokedAsync(string userId, string sessionId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
@@ -91,8 +110,13 @@ public sealed class RedisSessionRevocationStore(
 
         var db = multiplexer.GetDatabase();
         var opts = options.Value;
-        var revokedKey = $"{opts.KeyPrefix}:revoked:{userId}";
 
+        var deniedKey = $"{opts.KeyPrefix}:denied:{userId}";
+        var isDenied = await db.SetContainsAsync(deniedKey, sessionId).WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (isDenied)
+            return true;
+
+        var revokedKey = $"{opts.KeyPrefix}:revoked:{userId}";
         var isRevoked = await db.KeyExistsAsync(revokedKey).WaitAsync(cancellationToken).ConfigureAwait(false);
         if (!isRevoked)
             return false;

--- a/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
@@ -24,8 +24,7 @@ public sealed class TerminateDeviceEndpoint(
         await deviceRegistry.RemoveAsync(sessionId, ct).ConfigureAwait(false);
 
         var userId = HttpContext.User.GetUserId().ToString();
-        var currentSessionId = HttpContext.User.GetSessionId();
-        await revocationStore.RevokeAsync(userId, currentSessionId, ct).ConfigureAwait(false);
+        await revocationStore.RevokeSingleAsync(userId, sessionId, ct).ConfigureAwait(false);
 
         await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
     }

--- a/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
 using UserService.Api.Application.Contracts.Responses;
 using UserService.Api.Domain.Interfaces;
 using UserService.IntegrationTests.Helpers;
@@ -54,6 +57,20 @@ public sealed class DeviceEndpointTests(UserServiceFactory factory)
             new Uri("/api/v1/me/devices", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TerminateDeviceShouldRevokeSingleSessionNotAll()
+    {
+        var revocationStore = factory.Services.GetRequiredService<ISessionRevocationStore>();
+
+        var client = CreateAuthenticatedClient();
+        await client.DeleteAsync(new Uri("/api/v1/me/devices/test-session-002", UriKind.Relative));
+
+        await revocationStore.Received(1)
+            .RevokeSingleAsync(TestAuthHandler.DefaultUserId, "test-session-002", Arg.Any<CancellationToken>());
+        await revocationStore.DidNotReceive()
+            .RevokeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/unit/SessionRevocation.Tests/RedisSessionRevocationStoreTests.cs
+++ b/tests/unit/SessionRevocation.Tests/RedisSessionRevocationStoreTests.cs
@@ -104,4 +104,72 @@ public sealed class RedisSessionRevocationStoreTests : IAsyncLifetime
         Assert.True(await _store.IsRevokedAsync("user-a", "session-2"));
         Assert.False(await _store.IsRevokedAsync("user-b", "session-2"));
     }
+
+    [Fact]
+    public async Task RevokeSingleShouldRevokeTargetSession()
+    {
+        await _store.RevokeSingleAsync("user-1", "session-bad");
+
+        Assert.True(await _store.IsRevokedAsync("user-1", "session-bad"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleShouldNotAffectOtherSessions()
+    {
+        await _store.RevokeSingleAsync("user-1", "session-bad");
+
+        Assert.False(await _store.IsRevokedAsync("user-1", "session-good"));
+        Assert.False(await _store.IsRevokedAsync("user-1", "session-other"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleShouldNotAffectOtherUsers()
+    {
+        await _store.RevokeSingleAsync("user-a", "session-bad");
+
+        Assert.False(await _store.IsRevokedAsync("user-b", "session-bad"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleShouldExpireAfterTtl()
+    {
+        var shortStore = CreateStore(TimeSpan.FromSeconds(1));
+
+        await shortStore.RevokeSingleAsync("user-ttl2", "session-bad");
+        Assert.True(await shortStore.IsRevokedAsync("user-ttl2", "session-bad"));
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        Assert.False(await shortStore.IsRevokedAsync("user-ttl2", "session-bad"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleShouldSetDeniedKeyInRedis()
+    {
+        await _store.RevokeSingleAsync("user-1", "session-bad");
+
+        var db = _multiplexer!.GetDatabase();
+        Assert.True(await db.SetContainsAsync("urfu:session:denied:user-1", "session-bad"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleShouldNotSetGlobalRevokedFlag()
+    {
+        await _store.RevokeSingleAsync("user-1", "session-bad");
+
+        var db = _multiplexer!.GetDatabase();
+        Assert.False(await db.KeyExistsAsync("urfu:session:revoked:user-1"));
+    }
+
+    [Fact]
+    public async Task RevokeSingleAndBulkRevokeShouldCompose()
+    {
+        // session-bad denied individually, session-caller allowed via bulk revoke
+        await _store.RevokeSingleAsync("user-1", "session-bad");
+        await _store.RevokeAsync("user-1", "session-caller");
+
+        Assert.True(await _store.IsRevokedAsync("user-1", "session-bad"));
+        Assert.True(await _store.IsRevokedAsync("user-1", "session-other"));
+        Assert.False(await _store.IsRevokedAsync("user-1", "session-caller"));
+    }
 }


### PR DESCRIPTION
Closes #172

## Что сделано

- Добавлен метод `RevokeSingleAsync(userId, sessionId)` в `ISessionRevocationStore` — добавляет конкретную сессию в deny-set `denied:{userId}` в Redis
- Обновлён `IsRevokedAsync` — проверяет deny-set перед глобальным флагом отзыва
- Исправлен `TerminateDeviceEndpoint`: вместо `RevokeAsync(userId, callerSessionId)` теперь вызывается `RevokeSingleAsync(userId, terminatedSessionId)` — помечается только прибитая сессия, остальные не затрагиваются

## Причина бага

`RevokeAsync` ставит флаг `revoked:{userId}=1` в Redis — это означает «все сессии пользователя отозваны, кроме явно разрешённых». При логауте одного устройства в allowed-list попадала сессия вызывающего, а не прибитого. Итог: после повторной авторизации новая сессия прибитого устройства не находилась в allowed-list → 401 на все запросы.

## Как проверить

1. Войти с двух устройств
2. На устройстве A нажать «Выйти» для устройства B
3. На устройстве B пройти повторную авторизацию
4. Убедиться что запросы на устройстве B выполняются успешно (нет 401-цикла)
5. Убедиться что устройство A продолжает работать без перебоев