### PR TITLE
fix(#183): resolve session ID mismatch in single device revocation

### DIFF
--- a/src/Services/User/UserService.Api/Domain/Interfaces/IDeviceRegistry.cs
+++ b/src/Services/User/UserService.Api/Domain/Interfaces/IDeviceRegistry.cs
@@ -9,4 +9,5 @@ public interface IDeviceRegistry
 
     Task SavePomeriumMappingAsync(string pomeriumSid, string keycloakSessionId, CancellationToken cancellationToken = default);
     Task<string?> GetKeycloakSessionIdAsync(string pomeriumSid, CancellationToken cancellationToken = default);
+    Task<string?> GetPomeriumSidByKeycloakSessionAsync(string keycloakSessionId, CancellationToken cancellationToken = default);
 }

--- a/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/TerminateDeviceEndpoint.cs
@@ -8,7 +8,8 @@ namespace UserService.Api.Endpoints;
 public sealed class TerminateDeviceEndpoint(
     ISessionManager sessionManager,
     IDeviceRegistry deviceRegistry,
-    ISessionRevocationStore revocationStore)
+    ISessionRevocationStore revocationStore,
+    ILogger<TerminateDeviceEndpoint> logger)
     : EndpointWithoutRequest
 {
     public override void Configure()
@@ -19,12 +20,28 @@ public sealed class TerminateDeviceEndpoint(
 
     public override async Task HandleAsync(CancellationToken ct)
     {
-        var sessionId = Route<string>("SessionId")!;
-        await sessionManager.TerminateAsync(sessionId, ct).ConfigureAwait(false);
-        await deviceRegistry.RemoveAsync(sessionId, ct).ConfigureAwait(false);
+        var keycloakSessionId = Route<string>("SessionId")!;
+
+        // Resolve Pomerium sid BEFORE RemoveAsync (which deletes the mapping)
+        var pomeriumSid = await deviceRegistry.GetPomeriumSidByKeycloakSessionAsync(keycloakSessionId, ct)
+            .ConfigureAwait(false);
+
+        await sessionManager.TerminateAsync(keycloakSessionId, ct).ConfigureAwait(false);
+        await deviceRegistry.RemoveAsync(keycloakSessionId, ct).ConfigureAwait(false);
 
         var userId = HttpContext.User.GetUserId().ToString();
-        await revocationStore.RevokeSingleAsync(userId, sessionId, ct).ConfigureAwait(false);
+
+        if (pomeriumSid is not null)
+        {
+            await revocationStore.RevokeSingleAsync(userId, pomeriumSid, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            logger.LogWarning(
+                "No Pomerium mapping for Keycloak session {KeycloakSessionId}; "
+                + "middleware revocation skipped — session terminated via Keycloak only",
+                keycloakSessionId);
+        }
 
         await HttpContext.Response.SendNoContentAsync(ct).ConfigureAwait(false);
     }

--- a/src/Services/User/UserService.Api/Infrastructure/Devices/RedisDeviceRegistry.cs
+++ b/src/Services/User/UserService.Api/Infrastructure/Devices/RedisDeviceRegistry.cs
@@ -10,6 +10,7 @@ public sealed class RedisDeviceRegistry(IConnectionMultiplexer redis) : IDeviceR
     private static readonly TimeSpan Ttl = TimeSpan.FromDays(30);
     private const string KeyPrefix = "urfu:device:";
     private const string MappingPrefix = "urfu:session-map:";
+    private const string ReverseMappingPrefix = "urfu:session-revmap:";
 
     public async Task SaveAsync(string keycloakSessionId, string userAgent, CancellationToken cancellationToken = default)
     {
@@ -32,7 +33,19 @@ public sealed class RedisDeviceRegistry(IConnectionMultiplexer redis) : IDeviceR
     public async Task RemoveAsync(string keycloakSessionId, CancellationToken cancellationToken = default)
     {
         var db = redis.GetDatabase();
-        await db.KeyDeleteAsync(KeyPrefix + keycloakSessionId)
+        var pomeriumSid = await db.StringGetAsync(ReverseMappingPrefix + keycloakSessionId)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var keys = new List<RedisKey>
+        {
+            KeyPrefix + keycloakSessionId,
+            ReverseMappingPrefix + keycloakSessionId,
+        };
+        if (pomeriumSid.HasValue)
+            keys.Add(MappingPrefix + pomeriumSid.ToString());
+
+        await db.KeyDeleteAsync(keys.ToArray())
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
     }
@@ -41,25 +54,54 @@ public sealed class RedisDeviceRegistry(IConnectionMultiplexer redis) : IDeviceR
     {
         ArgumentNullException.ThrowIfNull(keycloakSessionIds);
         var db = redis.GetDatabase();
-        var keys = keycloakSessionIds.Select(id => (RedisKey)(KeyPrefix + id)).ToArray();
-        if (keys.Length > 0)
-            await db.KeyDeleteAsync(keys)
-                .WaitAsync(cancellationToken)
-                .ConfigureAwait(false);
+        var ids = keycloakSessionIds.ToList();
+        if (ids.Count == 0)
+            return;
+
+        var pomeriumSids = await Task.WhenAll(
+            ids.Select(id => db.StringGetAsync(ReverseMappingPrefix + id))
+        ).WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        var keys = new List<RedisKey>();
+        foreach (var id in ids)
+        {
+            keys.Add(KeyPrefix + id);
+            keys.Add(ReverseMappingPrefix + id);
+        }
+        foreach (var sid in pomeriumSids)
+        {
+            if (sid.HasValue)
+                keys.Add(MappingPrefix + sid.ToString());
+        }
+
+        await db.KeyDeleteAsync(keys.ToArray())
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task SavePomeriumMappingAsync(string pomeriumSid, string keycloakSessionId, CancellationToken cancellationToken = default)
     {
         var db = redis.GetDatabase();
-        await db.StringSetAsync(MappingPrefix + pomeriumSid, keycloakSessionId, Ttl)
-            .WaitAsync(cancellationToken)
-            .ConfigureAwait(false);
+        var batch = db.CreateBatch();
+        var t1 = batch.StringSetAsync(MappingPrefix + pomeriumSid, keycloakSessionId, Ttl);
+        var t2 = batch.StringSetAsync(ReverseMappingPrefix + keycloakSessionId, pomeriumSid, Ttl);
+        batch.Execute();
+        await Task.WhenAll(t1, t2).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<string?> GetKeycloakSessionIdAsync(string pomeriumSid, CancellationToken cancellationToken = default)
     {
         var db = redis.GetDatabase();
         var value = await db.StringGetAsync(MappingPrefix + pomeriumSid)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return value.HasValue ? value.ToString() : null;
+    }
+
+    public async Task<string?> GetPomeriumSidByKeycloakSessionAsync(string keycloakSessionId, CancellationToken cancellationToken = default)
+    {
+        var db = redis.GetDatabase();
+        var value = await db.StringGetAsync(ReverseMappingPrefix + keycloakSessionId)
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
         return value.HasValue ? value.ToString() : null;

--- a/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/DeviceEndpointTests.cs
@@ -60,15 +60,35 @@ public sealed class DeviceEndpointTests(UserServiceFactory factory)
     }
 
     [Fact]
-    public async Task TerminateDeviceShouldRevokeSingleSessionNotAll()
+    public async Task TerminateDeviceShouldRevokeByPomeriumSidWhenMappingExists()
     {
         var revocationStore = factory.Services.GetRequiredService<ISessionRevocationStore>();
+        revocationStore.ClearReceivedCalls();
+        var deviceRegistry = factory.Services.GetRequiredService<IDeviceRegistry>();
+        await deviceRegistry.SavePomeriumMappingAsync("pom-sid-for-002", "test-session-002");
 
         var client = CreateAuthenticatedClient();
         await client.DeleteAsync(new Uri("/api/v1/me/devices/test-session-002", UriKind.Relative));
 
         await revocationStore.Received(1)
-            .RevokeSingleAsync(TestAuthHandler.DefaultUserId, "test-session-002", Arg.Any<CancellationToken>());
+            .RevokeSingleAsync(TestAuthHandler.DefaultUserId, "pom-sid-for-002", Arg.Any<CancellationToken>());
+        await revocationStore.DidNotReceive()
+            .RevokeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TerminateDeviceShouldSkipRevocationWhenNoMappingExists()
+    {
+        var revocationStore = factory.Services.GetRequiredService<ISessionRevocationStore>();
+        revocationStore.ClearReceivedCalls();
+
+        var client = CreateAuthenticatedClient();
+        var response = await client.DeleteAsync(
+            new Uri("/api/v1/me/devices/test-session-002", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await revocationStore.DidNotReceive()
+            .RevokeSingleAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         await revocationStore.DidNotReceive()
             .RevokeAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }

--- a/tests/integration/UserService.IntegrationTests/Helpers/FakeDeviceRegistry.cs
+++ b/tests/integration/UserService.IntegrationTests/Helpers/FakeDeviceRegistry.cs
@@ -6,6 +6,7 @@ public sealed class FakeDeviceRegistry : IDeviceRegistry
 {
     private readonly Dictionary<string, string> _devices = new(StringComparer.Ordinal);
     private readonly Dictionary<string, string> _mappings = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _reverseMappings = new(StringComparer.Ordinal);
 
     public Task SaveAsync(string keycloakSessionId, string userAgent, CancellationToken cancellationToken = default)
     {
@@ -22,6 +23,8 @@ public sealed class FakeDeviceRegistry : IDeviceRegistry
     public Task RemoveAsync(string keycloakSessionId, CancellationToken cancellationToken = default)
     {
         _devices.Remove(keycloakSessionId);
+        if (_reverseMappings.Remove(keycloakSessionId, out var pomeriumSid))
+            _mappings.Remove(pomeriumSid);
         return Task.CompletedTask;
     }
 
@@ -29,13 +32,18 @@ public sealed class FakeDeviceRegistry : IDeviceRegistry
     {
         ArgumentNullException.ThrowIfNull(keycloakSessionIds);
         foreach (var id in keycloakSessionIds)
+        {
             _devices.Remove(id);
+            if (_reverseMappings.Remove(id, out var pomeriumSid))
+                _mappings.Remove(pomeriumSid);
+        }
         return Task.CompletedTask;
     }
 
     public Task SavePomeriumMappingAsync(string pomeriumSid, string keycloakSessionId, CancellationToken cancellationToken = default)
     {
         _mappings[pomeriumSid] = keycloakSessionId;
+        _reverseMappings[keycloakSessionId] = pomeriumSid;
         return Task.CompletedTask;
     }
 
@@ -43,5 +51,11 @@ public sealed class FakeDeviceRegistry : IDeviceRegistry
     {
         _mappings.TryGetValue(pomeriumSid, out var id);
         return Task.FromResult(id);
+    }
+
+    public Task<string?> GetPomeriumSidByKeycloakSessionAsync(string keycloakSessionId, CancellationToken cancellationToken = default)
+    {
+        _reverseMappings.TryGetValue(keycloakSessionId, out var sid);
+        return Task.FromResult(sid);
     }
 }


### PR DESCRIPTION
## Summary
- `TerminateDeviceEndpoint` хранил **Keycloak session ID** в Redis denied set, но `SessionRevocationMiddleware` проверяет **Pomerium session ID** из JWT — они никогда не совпадали, ревокация одного устройства не работала на уровне middleware
- Добавлен двусторонний маппинг Pomerium↔Keycloak в `RedisDeviceRegistry` (`urfu:session-revmap:{keycloakSessionId}` → `pomeriumSid`)
- `TerminateDeviceEndpoint` теперь резолвит Pomerium sid через reverse mapping перед вызовом `RevokeSingleAsync`
- Если маппинг отсутствует (устройство не посещало страницу устройств) — Keycloak-сессия всё равно терминируется, ревокация через middleware пропускается с warning-логом

## Затронутые файлы
- `IDeviceRegistry.cs` — новый метод `GetPomeriumSidByKeycloakSessionAsync`
- `RedisDeviceRegistry.cs` — bidirectional mapping, cleanup в `RemoveAsync`/`RemoveAllAsync`
- `TerminateDeviceEndpoint.cs` — основной фикс: resolve Pomerium sid → revoke
- `FakeDeviceRegistry.cs` — поддержка reverse mapping
- `DeviceEndpointTests.cs` — 2 новых теста вместо 1 старого

## Test plan
- [x] `dotnet test tests/unit/SessionRevocation.Tests/` — 14/14 passed
- [x] `dotnet test tests/integration/UserService.IntegrationTests/` — 18/18 passed
- [x] `dotnet test tests/unit/UserService.UnitTests/` — passed
- [ ] Ручная проверка после деплоя: отозвать устройство → повторный вход без redirect loop

Closes #183