### PR TITLE
refactor(#206): apply MediaConstraints in ListMyAssetsEndpoint

### DIFF
--- a/src/Services/Media/MediaService.Api/Endpoints/ListMyAssetsEndpoint.cs
+++ b/src/Services/Media/MediaService.Api/Endpoints/ListMyAssetsEndpoint.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediaService.Api.Application.Contracts.Responses;
+using MediaService.Api.Application.Limits;
 using MediaService.Api.Domain.Interfaces;
 using MediaService.Api.Infrastructure.Auth;
 
@@ -8,9 +9,7 @@ namespace MediaService.Api.Endpoints;
 public sealed class ListMyAssetsRequest
 {
     public Guid? Cursor { get; set; }
-    public int Limit { get; set; } = DefaultLimit;
-    public const int DefaultLimit = 20;
-    public const int MaxLimit = 100;
+    public int Limit { get; set; } = MediaConstraints.DefaultListLimit;
 }
 
 public sealed class ListMyAssetsEndpoint(IMediaAssetRepository assetRepository)
@@ -27,7 +26,7 @@ public sealed class ListMyAssetsEndpoint(IMediaAssetRepository assetRepository)
     {
         ArgumentNullException.ThrowIfNull(req);
 
-        var limit = Math.Clamp(req.Limit, 1, ListMyAssetsRequest.MaxLimit);
+        var limit = Math.Clamp(req.Limit, 1, MediaConstraints.MaxListLimit);
         var ownerId = HttpContext.User.GetUserId();
 
         var page = await assetRepository.ListByOwnerAsync(ownerId, req.Cursor, limit, ct).ConfigureAwait(false);


### PR DESCRIPTION
Followup для #218: переводит `ListMyAssetsRequest`/`ListMyAssetsEndpoint` на централизованные `MediaConstraints.DefaultListLimit` и `MediaConstraints.MaxListLimit` вместо локальных констант `DefaultLimit`/`MaxLimit`.

## Что сделано
- Удалены локальные `const int DefaultLimit = 20; const int MaxLimit = 100;` в `ListMyAssetsRequest`.
- `Limit` теперь по умолчанию `MediaConstraints.DefaultListLimit`.
- `Math.Clamp` использует `MediaConstraints.MaxListLimit`.

## Как проверить
- `dotnet build src/Services/Media/MediaService.Api`
- `dotnet test tests/integration/MediaService.IntegrationTests --filter ListMyAssets`