### PR TITLE
feat(#211): ChatService — messenger features (edit/delete/reply/forward/reactions/mentions/pinned/group read receipts)

### DIFF
--- a/src/Services/Chat/ChatService.Api/Application/Authorization/IDisciplineRoleResolver.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Authorization/IDisciplineRoleResolver.cs
@@ -1,0 +1,13 @@
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+
+namespace Urfu.Link.Services.Chat.Application.Authorization;
+
+/// <summary>
+/// Resolves discipline-related authorization decisions. The default implementation is a
+/// stub for #211 that allows any participant to pin in <c>Direct</c> conversations and
+/// blocks pinning in <c>Group</c> conversations until #214 wires real role resolution.
+/// </summary>
+public interface IDisciplineRoleResolver
+{
+    Task<bool> CanPinAsync(Guid userId, Conversation conversation, CancellationToken cancellationToken);
+}

--- a/src/Services/Chat/ChatService.Api/Application/ChatBodyConstraints.cs
+++ b/src/Services/Chat/ChatService.Api/Application/ChatBodyConstraints.cs
@@ -1,0 +1,12 @@
+namespace Urfu.Link.Services.Chat.Application;
+
+/// <summary>
+/// Shared payload constraints for chat messages. Applied by <c>SendMessageService</c> on send
+/// and by <c>EditMessageService</c> on edit so both paths reject the same outliers.
+/// </summary>
+public static class ChatBodyConstraints
+{
+    public const int MaxBodyLength = 4000;
+
+    public const int MaxAttachmentsPerMessage = 10;
+}

--- a/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
+++ b/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
@@ -48,6 +48,26 @@ public sealed class ConversationNotFoundException : InvalidOperationException
         => new($"Conversation '{conversationId}' was not found.");
 }
 
+public sealed class ChatMessageNotFoundException : InvalidOperationException
+{
+    public ChatMessageNotFoundException()
+    {
+    }
+
+    public ChatMessageNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatMessageNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatMessageNotFoundException For(Guid messageId)
+        => new($"Message '{messageId:D}' was not found.");
+}
+
 public sealed class ChatPinLimitExceededException : InvalidOperationException
 {
     public ChatPinLimitExceededException()

--- a/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
+++ b/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
@@ -47,3 +47,157 @@ public sealed class ConversationNotFoundException : InvalidOperationException
     public static ConversationNotFoundException For(string conversationId)
         => new($"Conversation '{conversationId}' was not found.");
 }
+
+public sealed class ChatPinLimitExceededException : InvalidOperationException
+{
+    public ChatPinLimitExceededException()
+    {
+    }
+
+    public ChatPinLimitExceededException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatPinLimitExceededException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ChatPinLimitExceededException(string conversationId, int maxPinned)
+        : base($"Conversation '{conversationId}' already has the maximum of {maxPinned} pinned messages.")
+    {
+        ConversationId = conversationId;
+        MaxPinned = maxPinned;
+    }
+
+    public string ConversationId { get; } = string.Empty;
+
+    public int MaxPinned { get; }
+}
+
+public sealed class ChatEditTtlExpiredException : InvalidOperationException
+{
+    public ChatEditTtlExpiredException()
+    {
+    }
+
+    public ChatEditTtlExpiredException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatEditTtlExpiredException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatEditTtlExpiredException For(Guid messageId, TimeSpan ttl)
+        => new($"Edit window of {ttl} has expired for message '{messageId:D}'.");
+}
+
+public sealed class ChatNotMessageAuthorException : InvalidOperationException
+{
+    public ChatNotMessageAuthorException()
+    {
+    }
+
+    public ChatNotMessageAuthorException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatNotMessageAuthorException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ChatNotMessageAuthorException(Guid messageId, Guid userId)
+        : base($"User '{userId:D}' is not the author of message '{messageId:D}'.")
+    {
+        MessageId = messageId;
+        UserId = userId;
+    }
+
+    public Guid MessageId { get; }
+
+    public Guid UserId { get; }
+}
+
+public sealed class ChatReplyTargetNotFoundException : InvalidOperationException
+{
+    public ChatReplyTargetNotFoundException()
+    {
+    }
+
+    public ChatReplyTargetNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatReplyTargetNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ChatReplyTargetNotFoundException(Guid messageId, string conversationId)
+        : base($"Reply target message '{messageId:D}' was not found in conversation '{conversationId}'.")
+    {
+        MessageId = messageId;
+        ConversationId = conversationId;
+    }
+
+    public Guid MessageId { get; }
+
+    public string ConversationId { get; } = string.Empty;
+}
+
+public sealed class ChatForwardLimitExceededException : InvalidOperationException
+{
+    public ChatForwardLimitExceededException()
+    {
+    }
+
+    public ChatForwardLimitExceededException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatForwardLimitExceededException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public ChatForwardLimitExceededException(int requested, int maxAllowed)
+        : base($"Forward request of {requested} messages exceeds the maximum of {maxAllowed}.")
+    {
+        Requested = requested;
+        MaxAllowed = maxAllowed;
+    }
+
+    public int Requested { get; }
+
+    public int MaxAllowed { get; }
+}
+
+public sealed class ChatReactionNotAllowedException : InvalidOperationException
+{
+    public ChatReactionNotAllowedException()
+    {
+    }
+
+    public ChatReactionNotAllowedException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatReactionNotAllowedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatReactionNotAllowedException ForEmoji(string emoji)
+        => new($"Reaction emoji '{emoji}' is not allowed.") { Emoji = emoji };
+
+    public string Emoji { get; private init; } = string.Empty;
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ConversationDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ConversationDto.cs
@@ -9,7 +9,8 @@ public sealed record ConversationDto(
     IReadOnlyList<Guid> Participants,
     DateTimeOffset CreatedAtUtc,
     DateTimeOffset LastMessageAtUtc,
-    MessagePreviewDto? LastMessagePreview)
+    MessagePreviewDto? LastMessagePreview,
+    IReadOnlyList<Guid>? PinnedMessageIds = null)
 {
     public static ConversationDto FromDomain(Conversation conversation)
     {
@@ -22,7 +23,10 @@ public sealed record ConversationDto(
             conversation.LastMessageAtUtc,
             conversation.LastMessagePreview is { } p
                 ? new MessagePreviewDto(p.SenderId, p.Body, p.SentAtUtc, p.HasAttachments)
-                : null);
+                : null,
+            PinnedMessageIds: conversation.PinnedMessageIds.Count == 0
+                ? Array.Empty<Guid>()
+                : conversation.PinnedMessageIds.ToList());
     }
 }
 

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/EditHistoryEntryDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/EditHistoryEntryDto.cs
@@ -1,0 +1,14 @@
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+public sealed record EditHistoryEntryDto(
+    string Body,
+    DateTimeOffset EditedAtUtc)
+{
+    public static EditHistoryEntryDto FromDomain(EditHistoryEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return new EditHistoryEntryDto(entry.Body, entry.EditedAtUtc);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ForwardedFromDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ForwardedFromDto.cs
@@ -1,0 +1,18 @@
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+public sealed record ForwardedFromDto(
+    Guid OriginalSenderId,
+    DateTimeOffset OriginalSentAtUtc,
+    string? OriginalConversationId)
+{
+    public static ForwardedFromDto FromDomain(ForwardedFrom forwardedFrom)
+    {
+        ArgumentNullException.ThrowIfNull(forwardedFrom);
+        return new ForwardedFromDto(
+            forwardedFrom.OriginalSenderId,
+            forwardedFrom.OriginalSentAtUtc,
+            forwardedFrom.OriginalConversationId);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
@@ -13,7 +13,15 @@ public sealed record MessageDto(
     DateTimeOffset CreatedAtUtc,
     DateTimeOffset? DeliveredAtUtc,
     DateTimeOffset? ReadAtUtc,
-    string ClientMessageId)
+    string ClientMessageId,
+    DateTimeOffset? EditedAtUtc = null,
+    DateTimeOffset? DeletedAtUtc = null,
+    Guid? DeletedBy = null,
+    DeleteMode? DeleteMode = null,
+    IReadOnlyList<Guid>? Mentions = null,
+    ReplyToDto? ReplyTo = null,
+    ForwardedFromDto? ForwardedFrom = null,
+    IReadOnlyDictionary<string, IReadOnlyList<Guid>>? ReactionsSummary = null)
 {
     public static MessageDto FromDomain(Message message)
     {
@@ -28,6 +36,29 @@ public sealed record MessageDto(
             message.CreatedAtUtc,
             message.DeliveredAtUtc,
             message.ReadAtUtc,
-            message.ClientMessageId);
+            message.ClientMessageId,
+            EditedAtUtc: message.EditedAtUtc,
+            DeletedAtUtc: message.DeletedAtUtc,
+            DeletedBy: message.DeletedBy,
+            DeleteMode: message.DeleteMode,
+            Mentions: message.Mentions.Count == 0 ? Array.Empty<Guid>() : message.Mentions.ToList(),
+            ReplyTo: message.ReplyTo is { } r ? ReplyToDto.FromDomain(r) : null,
+            ForwardedFrom: message.ForwardedFrom is { } f ? ForwardedFromDto.FromDomain(f) : null,
+            ReactionsSummary: BuildReactionsSummary(message));
+    }
+
+    private static Dictionary<string, IReadOnlyList<Guid>> BuildReactionsSummary(Message message)
+    {
+        if (message.Reactions.Count == 0)
+        {
+            return new Dictionary<string, IReadOnlyList<Guid>>(StringComparer.Ordinal);
+        }
+
+        return message.Reactions
+            .GroupBy(r => r.Emoji, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.UserId).ToList(),
+                StringComparer.Ordinal);
     }
 }

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ReadReceiptDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ReadReceiptDto.cs
@@ -1,0 +1,14 @@
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+public sealed record ReadReceiptDto(
+    Guid UserId,
+    DateTimeOffset ReadAtUtc)
+{
+    public static ReadReceiptDto FromDomain(ReadReceipt receipt)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        return new ReadReceiptDto(receipt.UserId, receipt.ReadAtUtc);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ReplyToDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ReplyToDto.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+public sealed record ReplyToDto(
+    Guid MessageId,
+    Guid SenderId,
+    string Preview)
+{
+    public static ReplyToDto FromDomain(ReplyTo replyTo)
+    {
+        ArgumentNullException.ThrowIfNull(replyTo);
+        return new ReplyToDto(replyTo.MessageId, replyTo.SenderId, replyTo.Preview);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Conversations/PinMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Conversations/PinMessageService.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.Services.Chat.Application.Authorization;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Conversations;
+
+public sealed record PinMessageRequest(string ConversationId, Guid CallerUserId, Guid MessageId);
+
+public sealed class PinMessageService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IDisciplineRoleResolver roleResolver,
+    IOptions<ChatOptions> options,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task<IReadOnlyList<MessageDto>> PinAsync(PinMessageRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var conversation = await conversations.GetByIdAsync(request.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(request.ConversationId);
+
+        if (!conversation.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(request.ConversationId, request.CallerUserId);
+        }
+
+        var canPin = await roleResolver.CanPinAsync(request.CallerUserId, conversation, cancellationToken).ConfigureAwait(false);
+        if (!canPin)
+        {
+            throw new ChatAccessDeniedException(request.ConversationId, request.CallerUserId);
+        }
+
+        var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatMessageNotFoundException.For(request.MessageId);
+
+        if (!string.Equals(message.ConversationId, conversation.Id, StringComparison.Ordinal))
+        {
+            throw ChatMessageNotFoundException.For(request.MessageId);
+        }
+
+        if (message.State == MessageState.Deleted)
+        {
+            throw ChatMessageNotFoundException.For(request.MessageId);
+        }
+
+        var opts = options.Value;
+        if (conversation.IsPinned(request.MessageId))
+        {
+            // Idempotent: return current pinned list without re-publishing or re-broadcasting.
+            return await BuildPinnedDtosAsync(conversation, cancellationToken).ConfigureAwait(false);
+        }
+
+        var pinned = await conversations.AddPinnedMessageAsync(
+            conversation.Id, request.MessageId, opts.MaxPinnedMessages, cancellationToken).ConfigureAwait(false);
+        if (!pinned)
+        {
+            throw new ChatPinLimitExceededException(conversation.Id, opts.MaxPinnedMessages);
+        }
+
+        var now = clock.GetUtcNow();
+        await dispatcher.PublishAsync(
+            new ChatMessagePinnedEvent(conversation.Id, request.MessageId, request.CallerUserId, now),
+            cancellationToken).ConfigureAwait(false);
+
+        var dtos = await BuildPinnedDtosAsync(
+            await conversations.GetByIdAsync(conversation.Id, cancellationToken).ConfigureAwait(false) ?? conversation,
+            cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyPinsUpdatedAsync(
+            conversation.Participants.ToList(), conversation.Id, dtos, cancellationToken).ConfigureAwait(false);
+
+        return dtos;
+    }
+
+    private async Task<IReadOnlyList<MessageDto>> BuildPinnedDtosAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken)
+    {
+        if (conversation.PinnedMessageIds.Count == 0)
+        {
+            return Array.Empty<MessageDto>();
+        }
+
+        var pinnedMessages = await messages.GetByIdsAsync(
+            conversation.Id, conversation.PinnedMessageIds, cancellationToken).ConfigureAwait(false);
+        return pinnedMessages.Select(MessageDto.FromDomain).ToList();
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Conversations/UnpinMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Conversations/UnpinMessageService.cs
@@ -1,0 +1,72 @@
+using Urfu.Link.Services.Chat.Application.Authorization;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Conversations;
+
+public sealed record UnpinMessageRequest(string ConversationId, Guid CallerUserId, Guid MessageId);
+
+public sealed class UnpinMessageService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IDisciplineRoleResolver roleResolver,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task<IReadOnlyList<MessageDto>> UnpinAsync(UnpinMessageRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var conversation = await conversations.GetByIdAsync(request.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(request.ConversationId);
+
+        if (!conversation.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(request.ConversationId, request.CallerUserId);
+        }
+
+        var canPin = await roleResolver.CanPinAsync(request.CallerUserId, conversation, cancellationToken).ConfigureAwait(false);
+        if (!canPin)
+        {
+            throw new ChatAccessDeniedException(request.ConversationId, request.CallerUserId);
+        }
+
+        var removed = await conversations.RemovePinnedMessageAsync(
+            conversation.Id, request.MessageId, cancellationToken).ConfigureAwait(false);
+        if (!removed)
+        {
+            // Already unpinned — return current pinned list, no event, no broadcast.
+            return await BuildPinnedDtosAsync(conversation, cancellationToken).ConfigureAwait(false);
+        }
+
+        var now = clock.GetUtcNow();
+        await dispatcher.PublishAsync(
+            new ChatMessageUnpinnedEvent(conversation.Id, request.MessageId, request.CallerUserId, now),
+            cancellationToken).ConfigureAwait(false);
+
+        var refreshed = await conversations.GetByIdAsync(conversation.Id, cancellationToken).ConfigureAwait(false) ?? conversation;
+        var dtos = await BuildPinnedDtosAsync(refreshed, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyPinsUpdatedAsync(
+            conversation.Participants.ToList(), conversation.Id, dtos, cancellationToken).ConfigureAwait(false);
+
+        return dtos;
+    }
+
+    private async Task<IReadOnlyList<MessageDto>> BuildPinnedDtosAsync(
+        Conversation conversation,
+        CancellationToken cancellationToken)
+    {
+        if (conversation.PinnedMessageIds.Count == 0)
+        {
+            return Array.Empty<MessageDto>();
+        }
+
+        var pinnedMessages = await messages.GetByIdsAsync(
+            conversation.Id, conversation.PinnedMessageIds, cancellationToken).ConfigureAwait(false);
+        return pinnedMessages.Select(MessageDto.FromDomain).ToList();
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Mentions/MentionsParser.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Mentions/MentionsParser.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+
+namespace Urfu.Link.Services.Chat.Application.Mentions;
+
+/// <summary>
+/// Parses <c>@</c> mentions from a message body. Supported forms:
+/// <list type="bullet">
+///   <item><c>@&lt;guid&gt;</c> — direct user mention.</item>
+///   <item><c>@everyone</c> — expands to all participants (excluding the sender is a caller decision).</item>
+///   <item><c>@teachers</c>, <c>@students</c> — discipline-only special tokens. Stubbed to empty
+///     in #211 until <c>IDisciplineRoleResolver</c> learns about roles in #214.</item>
+/// </list>
+/// Unknown mentions and mentions of users that aren't participants are dropped silently.
+/// Output is deduplicated and capped at <c>maxMentions</c>.
+/// </summary>
+public static partial class MentionsParser
+{
+    [GeneratedRegex(@"@(?<token>everyone|teachers|students|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 500)]
+    private static partial Regex MentionRegex();
+
+    public static IReadOnlyList<Guid> Parse(
+        string? body,
+        IReadOnlyList<Guid> participants,
+        int maxMentions)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxMentions);
+
+        if (string.IsNullOrEmpty(body))
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var participantSet = new HashSet<Guid>(participants);
+        var ordered = new List<Guid>();
+        var seen = new HashSet<Guid>();
+
+        foreach (Match match in MentionRegex().Matches(body))
+        {
+            var token = match.Groups["token"].Value;
+            switch (token)
+            {
+                case var t when string.Equals(t, "everyone", StringComparison.OrdinalIgnoreCase):
+                    foreach (var participant in participants)
+                    {
+                        if (seen.Add(participant))
+                        {
+                            ordered.Add(participant);
+                            if (ordered.Count >= maxMentions)
+                            {
+                                return ordered;
+                            }
+                        }
+                    }
+                    break;
+                case var t when string.Equals(t, "teachers", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(t, "students", StringComparison.OrdinalIgnoreCase):
+                    // Stubbed in #211; #214 will resolve via IDisciplineRoleResolver.
+                    break;
+                default:
+                    if (Guid.TryParseExact(token, "D", out var userId)
+                        && participantSet.Contains(userId)
+                        && seen.Add(userId))
+                    {
+                        ordered.Add(userId);
+                        if (ordered.Count >= maxMentions)
+                        {
+                            return ordered;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return ordered;
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/AddReactionService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/AddReactionService.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed record AddReactionRequest(Guid MessageId, Guid UserId, string Emoji);
+
+public sealed class AddReactionService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IOptions<ChatOptions> options,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task AddAsync(AddReactionRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Emoji);
+
+        var opts = options.Value;
+        if (request.Emoji.Length > opts.MaxReactionEmojiLength)
+        {
+            throw ChatReactionNotAllowedException.ForEmoji(request.Emoji);
+        }
+
+        if (opts.AllowedReactionEmojis.Count > 0 && !opts.AllowedReactionEmojis.Contains(request.Emoji))
+        {
+            throw ChatReactionNotAllowedException.ForEmoji(request.Emoji);
+        }
+
+        var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatMessageNotFoundException.For(request.MessageId);
+
+        var conversation = await conversations.GetByIdAsync(message.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(message.ConversationId);
+
+        if (!conversation.IsParticipant(request.UserId))
+        {
+            throw new ChatAccessDeniedException(message.ConversationId, request.UserId);
+        }
+
+        var now = clock.GetUtcNow();
+        var changed = await messages.AddReactionAsync(
+            request.MessageId, new Reaction(request.UserId, request.Emoji, now), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!changed)
+        {
+            return;
+        }
+
+        await dispatcher.PublishAsync(
+            new ChatReactionAddedEvent(conversation.Id, request.MessageId, request.UserId, request.Emoji, now),
+            cancellationToken).ConfigureAwait(false);
+
+        var summary = await BuildSummaryAsync(request.MessageId, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyReactionUpdatedAsync(
+            conversation.Participants.ToList(), request.MessageId, summary, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyDictionary<string, IReadOnlyList<Guid>>> BuildSummaryAsync(
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        var refreshed = await messages.GetByIdAsync(messageId, cancellationToken).ConfigureAwait(false);
+        if (refreshed is null)
+        {
+            return new Dictionary<string, IReadOnlyList<Guid>>(StringComparer.Ordinal);
+        }
+
+        return refreshed.Reactions
+            .GroupBy(r => r.Emoji, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.UserId).ToList(),
+                StringComparer.Ordinal);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed record DeleteMessageRequest(Guid MessageId, Guid CallerUserId, DeleteMode Mode);
+
+public sealed class DeleteMessageService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IOptions<ChatOptions> options,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task<MessageDto?> DeleteAsync(DeleteMessageRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false);
+        if (message is null)
+        {
+            return null;
+        }
+
+        var conversation = await conversations.GetByIdAsync(message.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(message.ConversationId);
+
+        if (!conversation.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(message.ConversationId, request.CallerUserId);
+        }
+
+        if (request.Mode == DeleteMode.ForEveryone)
+        {
+            if (!message.IsAuthor(request.CallerUserId))
+            {
+                throw new ChatNotMessageAuthorException(message.Id, request.CallerUserId);
+            }
+
+            var opts = options.Value;
+            var ttl = opts.DeleteForEveryoneTtl;
+            var now = clock.GetUtcNow();
+            if (now - message.CreatedAtUtc > ttl)
+            {
+                throw ChatEditTtlExpiredException.For(message.Id, ttl);
+            }
+
+            var applied = await messages.ApplyDeleteForEveryoneAsync(
+                message.Id, request.CallerUserId, now, cancellationToken).ConfigureAwait(false);
+            if (!applied)
+            {
+                var existing = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false);
+                return existing is null ? null : MessageDto.FromDomain(existing);
+            }
+
+            await dispatcher.PublishAsync(
+                new ChatMessageDeletedEvent(
+                    conversation.Id,
+                    message.Id,
+                    DeleteMode.ForEveryone,
+                    request.CallerUserId,
+                    now),
+                cancellationToken).ConfigureAwait(false);
+
+            await broadcaster.NotifyMessageDeletedAsync(
+                conversation.Participants.ToList(),
+                conversation.Id,
+                message.Id,
+                DeleteMode.ForEveryone,
+                request.CallerUserId,
+                cancellationToken).ConfigureAwait(false);
+
+            var refreshed = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false);
+            return refreshed is null ? null : MessageDto.FromDomain(refreshed);
+        }
+
+        // ForMe: hide locally, no broadcast.
+        var added = await messages.AddHiddenForAsync(message.Id, request.CallerUserId, cancellationToken)
+            .ConfigureAwait(false);
+        if (added)
+        {
+            var nowForMe = clock.GetUtcNow();
+            await dispatcher.PublishAsync(
+                new ChatMessageDeletedEvent(
+                    conversation.Id,
+                    message.Id,
+                    DeleteMode.ForMe,
+                    request.CallerUserId,
+                    nowForMe),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var current = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false);
+        return current is null ? null : MessageDto.FromDomain(current);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
@@ -80,21 +80,12 @@ public sealed class DeleteMessageService(
             return refreshed is null ? null : MessageDto.FromDomain(refreshed);
         }
 
-        // ForMe: hide locally, no broadcast.
-        var added = await messages.AddHiddenForAsync(message.Id, request.CallerUserId, cancellationToken)
+        // ForMe is purely local: hide for the caller in the message document and return the
+        // current message state. No integration event is emitted (no consumer reacts to a
+        // local hide) and no broadcast is sent (other participants must keep seeing the
+        // message).
+        await messages.AddHiddenForAsync(message.Id, request.CallerUserId, cancellationToken)
             .ConfigureAwait(false);
-        if (added)
-        {
-            var nowForMe = clock.GetUtcNow();
-            await dispatcher.PublishAsync(
-                new ChatMessageDeletedEvent(
-                    conversation.Id,
-                    message.Id,
-                    DeleteMode.ForMe,
-                    request.CallerUserId,
-                    nowForMe),
-                cancellationToken).ConfigureAwait(false);
-        }
 
         var current = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false);
         return current is null ? null : MessageDto.FromDomain(current);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
@@ -24,6 +24,20 @@ public sealed class EditMessageService(
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        // Edit must produce a non-empty body that fits the global length cap. Empty edits are
+        // a UX request to "delete" — clients should call DeleteMessage instead so they don't
+        // bypass author/TTL checks specific to deletion.
+        if (string.IsNullOrEmpty(request.NewBody))
+        {
+            throw new ArgumentException(
+                "New body cannot be empty. Use DeleteMessage to remove a message.", nameof(request));
+        }
+        if (request.NewBody.Length > ChatBodyConstraints.MaxBodyLength)
+        {
+            throw new ChatPayloadTooLargeException(
+                $"Edited body exceeds {ChatBodyConstraints.MaxBodyLength} characters.");
+        }
+
         var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
             ?? throw ChatMessageNotFoundException.For(request.MessageId);
 
@@ -48,14 +62,13 @@ public sealed class EditMessageService(
             throw ChatEditTtlExpiredException.For(message.Id, ttl);
         }
 
-        var newBody = request.NewBody ?? string.Empty;
-        var mentions = MentionsParser.Parse(newBody, conversation.Participants, opts.MaxMentionsPerMessage);
+        var mentions = MentionsParser.Parse(request.NewBody, conversation.Participants, opts.MaxMentionsPerMessage);
         var priorMentions = new HashSet<Guid>(message.Mentions);
         var newlyAddedMentions = mentions.Where(m => !priorMentions.Contains(m)).ToList();
         var historyEntry = new EditHistoryEntry(message.Body, message.EditedAtUtc ?? message.CreatedAtUtc);
 
         var applied = await messages.ApplyEditAsync(
-            message.Id, newBody, mentions, historyEntry, now, cancellationToken).ConfigureAwait(false);
+            message.Id, request.NewBody, mentions, historyEntry, now, cancellationToken).ConfigureAwait(false);
         if (!applied)
         {
             // Race: someone deleted the message between our read and write. Re-load and return current state.

--- a/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Mentions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed record EditMessageRequest(Guid MessageId, Guid CallerUserId, string NewBody);
+
+public sealed class EditMessageService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IOptions<ChatOptions> options,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task<MessageDto> EditAsync(EditMessageRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatMessageNotFoundException.For(request.MessageId);
+
+        var conversation = await conversations.GetByIdAsync(message.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(message.ConversationId);
+
+        if (!conversation.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(message.ConversationId, request.CallerUserId);
+        }
+
+        if (!message.IsAuthor(request.CallerUserId))
+        {
+            throw new ChatNotMessageAuthorException(message.Id, request.CallerUserId);
+        }
+
+        var opts = options.Value;
+        var ttl = opts.EditTtl;
+        var now = clock.GetUtcNow();
+        if (now - message.CreatedAtUtc > ttl)
+        {
+            throw ChatEditTtlExpiredException.For(message.Id, ttl);
+        }
+
+        var newBody = request.NewBody ?? string.Empty;
+        var mentions = MentionsParser.Parse(newBody, conversation.Participants, opts.MaxMentionsPerMessage);
+        var historyEntry = new EditHistoryEntry(message.Body, message.EditedAtUtc ?? message.CreatedAtUtc);
+
+        var applied = await messages.ApplyEditAsync(
+            message.Id, newBody, mentions, historyEntry, now, cancellationToken).ConfigureAwait(false);
+        if (!applied)
+        {
+            // Race: someone deleted the message between our read and write. Re-load and return current state.
+            var stale = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false);
+            return stale is null ? MessageDto.FromDomain(message) : MessageDto.FromDomain(stale);
+        }
+
+        var refreshed = await messages.GetByIdAsync(message.Id, cancellationToken).ConfigureAwait(false)
+            ?? message;
+
+        await dispatcher.PublishAsync(
+            new ChatMessageEditedEvent(
+                conversation.Id,
+                refreshed.Id,
+                request.CallerUserId,
+                refreshed.Body,
+                refreshed.Mentions,
+                refreshed.EditedAtUtc ?? now,
+                now),
+            cancellationToken).ConfigureAwait(false);
+
+        var observers = conversation.Participants.ToList();
+        var dto = MessageDto.FromDomain(refreshed);
+        await broadcaster.NotifyMessageEditedAsync(observers, dto, cancellationToken).ConfigureAwait(false);
+
+        return dto;
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
@@ -50,6 +50,8 @@ public sealed class EditMessageService(
 
         var newBody = request.NewBody ?? string.Empty;
         var mentions = MentionsParser.Parse(newBody, conversation.Participants, opts.MaxMentionsPerMessage);
+        var priorMentions = new HashSet<Guid>(message.Mentions);
+        var newlyAddedMentions = mentions.Where(m => !priorMentions.Contains(m)).ToList();
         var historyEntry = new EditHistoryEntry(message.Body, message.EditedAtUtc ?? message.CreatedAtUtc);
 
         var applied = await messages.ApplyEditAsync(
@@ -74,6 +76,18 @@ public sealed class EditMessageService(
                 refreshed.EditedAtUtc ?? now,
                 now),
             cancellationToken).ConfigureAwait(false);
+
+        if (newlyAddedMentions.Count > 0)
+        {
+            await dispatcher.PublishAsync(
+                new ChatMentionCreatedEvent(
+                    conversation.Id,
+                    refreshed.Id,
+                    request.CallerUserId,
+                    newlyAddedMentions,
+                    now),
+                cancellationToken).ConfigureAwait(false);
+        }
 
         var observers = conversation.Participants.ToList();
         var dto = MessageDto.FromDomain(refreshed);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/ForwardMessagesService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/ForwardMessagesService.cs
@@ -1,0 +1,159 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed record ForwardMessagesRequest(
+    string TargetConversationId,
+    Guid CallerUserId,
+    IReadOnlyList<Guid> MessageIds);
+
+public sealed class ForwardMessagesService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IMediaServiceClient mediaServiceClient,
+    IOptions<ChatOptions> options,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task<IReadOnlyList<MessageDto>> ForwardAsync(
+        ForwardMessagesRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.MessageIds);
+
+        var opts = options.Value;
+        if (request.MessageIds.Count == 0)
+        {
+            return Array.Empty<MessageDto>();
+        }
+
+        if (request.MessageIds.Count > opts.MaxForwardedMessages)
+        {
+            throw new ChatForwardLimitExceededException(request.MessageIds.Count, opts.MaxForwardedMessages);
+        }
+
+        var target = await conversations.GetByIdAsync(request.TargetConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(request.TargetConversationId);
+
+        if (!target.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(request.TargetConversationId, request.CallerUserId);
+        }
+
+        // Load source messages individually so we can validate caller membership in each source
+        // conversation. Forwarding is rare and capped at MaxForwardedMessages, so the N round-trips
+        // are acceptable for the MVP.
+        var sources = new List<Message>(request.MessageIds.Count);
+        var sourceConversationCache = new Dictionary<string, Conversation>(StringComparer.Ordinal);
+        foreach (var id in request.MessageIds)
+        {
+            var src = await messages.GetByIdAsync(id, cancellationToken).ConfigureAwait(false)
+                ?? throw ChatMessageNotFoundException.For(id);
+
+            if (!sourceConversationCache.TryGetValue(src.ConversationId, out var srcConv))
+            {
+                srcConv = await conversations.GetByIdAsync(src.ConversationId, cancellationToken).ConfigureAwait(false)
+                    ?? throw ConversationNotFoundException.For(src.ConversationId);
+                sourceConversationCache[src.ConversationId] = srcConv;
+            }
+            if (!srcConv.IsParticipant(request.CallerUserId))
+            {
+                throw new ChatAccessDeniedException(src.ConversationId, request.CallerUserId);
+            }
+
+            sources.Add(src);
+        }
+
+        var now = clock.GetUtcNow();
+        var produced = new List<MessageDto>(sources.Count);
+        var lastPreview = (preview: (MessagePreview?)null, sentAt: now);
+        var grantTasks = new List<Task>();
+        var grantees = target.Participants.Where(p => p != request.CallerUserId).ToList();
+
+        var index = 0;
+        foreach (var src in sources)
+        {
+            var clientMessageId = $"forward:{src.Id:N}:{request.CallerUserId:N}:{now.UtcTicks}:{index++}";
+            var sentAt = now.AddTicks(index);
+            var newMessage = Message.Send(
+                id: Guid.NewGuid(),
+                conversationId: target.Id,
+                senderId: request.CallerUserId,
+                body: src.Body,
+                attachments: src.Attachments,
+                clientMessageId: clientMessageId,
+                createdAtUtc: sentAt,
+                forwardedFrom: new ForwardedFrom(src.SenderId, src.CreatedAtUtc, src.ConversationId));
+
+            await messages.InsertAsync(newMessage, cancellationToken).ConfigureAwait(false);
+            produced.Add(MessageDto.FromDomain(newMessage));
+
+            lastPreview = (
+                new MessagePreview(request.CallerUserId, newMessage.Body, sentAt, newMessage.HasAttachments),
+                sentAt);
+
+            // Grant access on each forwarded attachment to the new conversation participants.
+            if (grantees.Count > 0)
+            {
+                foreach (var attachment in newMessage.Attachments)
+                {
+                    grantTasks.Add(mediaServiceClient.GrantConversationAccessAsync(
+                        attachment.MediaAssetId, grantees, target.Id, request.CallerUserId, cancellationToken));
+                }
+            }
+
+            await dispatcher.PublishAsync(
+                new ChatMessageSentEvent(
+                    target.Id,
+                    newMessage.Id,
+                    request.CallerUserId,
+                    grantees,
+                    BuildPreviewText(newMessage.Body, newMessage.HasAttachments),
+                    newMessage.HasAttachments,
+                    sentAt),
+                cancellationToken).ConfigureAwait(false);
+
+            await broadcaster.NotifyMessageReceivedAsync(
+                grantees, MessageDto.FromDomain(newMessage), cancellationToken).ConfigureAwait(false);
+        }
+
+        if (grantTasks.Count > 0)
+        {
+            await Task.WhenAll(grantTasks).ConfigureAwait(false);
+        }
+
+        if (lastPreview.preview is { } preview)
+        {
+            await conversations.UpdateLastMessageAsync(
+                target.Id, preview, lastPreview.sentAt, cancellationToken).ConfigureAwait(false);
+        }
+
+        return produced;
+    }
+
+    private static string BuildPreviewText(string body, bool hasAttachments)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return hasAttachments ? "[attachment]" : string.Empty;
+        }
+
+        const int maxPreview = 120;
+        if (body.Length <= maxPreview)
+        {
+            return body;
+        }
+
+        var cutoff = char.IsHighSurrogate(body[maxPreview - 1]) ? maxPreview - 1 : maxPreview;
+        return body[..cutoff];
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/ForwardMessagesService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/ForwardMessagesService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;
@@ -49,16 +50,26 @@ public sealed class ForwardMessagesService(
             throw new ChatAccessDeniedException(request.TargetConversationId, request.CallerUserId);
         }
 
-        // Load source messages individually so we can validate caller membership in each source
-        // conversation. Forwarding is rare and capped at MaxForwardedMessages, so the N round-trips
-        // are acceptable for the MVP.
+        // Single bulk read of all source messages — the previous N+1 had a round-trip per id.
+        var loadedById = (await messages.GetManyAsync(request.MessageIds, cancellationToken).ConfigureAwait(false))
+            .ToDictionary(m => m.Id);
+
+        // Preserve caller-supplied ordering (forward [c, a, b] should land as [c, a, b] in target).
         var sources = new List<Message>(request.MessageIds.Count);
-        var sourceConversationCache = new Dictionary<string, Conversation>(StringComparer.Ordinal);
         foreach (var id in request.MessageIds)
         {
-            var src = await messages.GetByIdAsync(id, cancellationToken).ConfigureAwait(false)
-                ?? throw ChatMessageNotFoundException.For(id);
+            if (!loadedById.TryGetValue(id, out var src))
+            {
+                throw ChatMessageNotFoundException.For(id);
+            }
+            sources.Add(src);
+        }
 
+        // One conversation lookup per unique source — caller membership must hold for every
+        // source the user is forwarding from.
+        var sourceConversationCache = new Dictionary<string, Conversation>(StringComparer.Ordinal);
+        foreach (var src in sources)
+        {
             if (!sourceConversationCache.TryGetValue(src.ConversationId, out var srcConv))
             {
                 srcConv = await conversations.GetByIdAsync(src.ConversationId, cancellationToken).ConfigureAwait(false)
@@ -69,8 +80,6 @@ public sealed class ForwardMessagesService(
             {
                 throw new ChatAccessDeniedException(src.ConversationId, request.CallerUserId);
             }
-
-            sources.Add(src);
         }
 
         var now = clock.GetUtcNow();
@@ -82,8 +91,16 @@ public sealed class ForwardMessagesService(
         var index = 0;
         foreach (var src in sources)
         {
-            var clientMessageId = $"forward:{src.Id:N}:{request.CallerUserId:N}:{now.UtcTicks}:{index++}";
-            var sentAt = now.AddTicks(index);
+            var sentAt = now.AddMilliseconds(index);
+            var clientMessageId = $"forward:{src.Id:N}:{request.CallerUserId:N}:{now.UtcTicks}:{index}";
+
+            // Hide source conversation id when forwarding into a group conversation — the
+            // forwarder shouldn't leak which (potentially private) chat the message came from.
+            // For direct forwards we keep it so the recipient can attribute the origin.
+            var originalConversationId = target.Type == ConversationType.Group
+                ? null
+                : src.ConversationId;
+
             var newMessage = Message.Send(
                 id: Guid.NewGuid(),
                 conversationId: target.Id,
@@ -92,7 +109,7 @@ public sealed class ForwardMessagesService(
                 attachments: src.Attachments,
                 clientMessageId: clientMessageId,
                 createdAtUtc: sentAt,
-                forwardedFrom: new ForwardedFrom(src.SenderId, src.CreatedAtUtc, src.ConversationId));
+                forwardedFrom: new ForwardedFrom(src.SenderId, src.CreatedAtUtc, originalConversationId));
 
             await messages.InsertAsync(newMessage, cancellationToken).ConfigureAwait(false);
             produced.Add(MessageDto.FromDomain(newMessage));
@@ -124,6 +141,8 @@ public sealed class ForwardMessagesService(
 
             await broadcaster.NotifyMessageReceivedAsync(
                 grantees, MessageDto.FromDomain(newMessage), cancellationToken).ConfigureAwait(false);
+
+            index++;
         }
 
         if (grantTasks.Count > 0)

--- a/src/Services/Chat/ChatService.Api/Application/Messages/GetReadReceiptsQuery.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/GetReadReceiptsQuery.cs
@@ -1,0 +1,29 @@
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed class GetReadReceiptsQuery(
+    IConversationRepository conversations,
+    IMessageRepository messages)
+{
+    public async Task<IReadOnlyList<ReadReceiptDto>> ExecuteAsync(
+        Guid messageId,
+        Guid callerUserId,
+        CancellationToken cancellationToken)
+    {
+        var message = await messages.GetByIdAsync(messageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatMessageNotFoundException.For(messageId);
+
+        var conversation = await conversations.GetByIdAsync(message.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(message.ConversationId);
+
+        if (!conversation.IsParticipant(callerUserId))
+        {
+            throw new ChatAccessDeniedException(message.ConversationId, callerUserId);
+        }
+
+        var receipts = await messages.GetReadReceiptsAsync(messageId, cancellationToken).ConfigureAwait(false);
+        return receipts.Select(ReadReceiptDto.FromDomain).ToList();
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/MarkReadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/MarkReadService.cs
@@ -14,6 +14,13 @@ public sealed class MarkReadService(
     IChatBroadcaster broadcaster,
     TimeProvider clock)
 {
+    /// <summary>
+    /// Marks every message up to and including <c>UpToMessageId</c> as Read, populates
+    /// each message's <c>ReadBy[]</c> with the reader, and emits both the legacy
+    /// <c>MessageReadUpdate</c> (anchor) and the per-message <c>MessageReadByUpdate</c>
+    /// broadcasts. Returns the new anchor (last transitioned id) or <see langword="null"/>
+    /// if nothing transitioned — preserving the wire contract for existing hub clients.
+    /// </summary>
     public async Task<Guid?> MarkAsync(MarkReadRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -27,29 +34,35 @@ public sealed class MarkReadService(
         }
 
         var now = clock.GetUtcNow();
-        var anchor = await messages.MarkReadUpToAsync(
+        var transitioned = await messages.MarkReadUpToAsync(
             conversation.Id, request.UpToMessageId, now, cancellationToken).ConfigureAwait(false);
-        if (anchor is null)
+        if (transitioned.Count == 0)
         {
             return null;
         }
 
+        var anchor = transitioned[^1];
+        var observers = conversation.Participants.Where(p => p != request.ReaderUserId).ToList();
+
         await dispatcher.PublishAsync(
-            new ChatMessageReadEvent(conversation.Id, anchor.Value, request.ReaderUserId, now),
+            new ChatMessageReadEvent(conversation.Id, anchor, request.ReaderUserId, now),
             cancellationToken).ConfigureAwait(false);
 
-        // Group-aware read receipts: also append to the anchor's ReadBy[] and emit the
-        // group-flavoured broadcast. For Direct conversations this is essentially a noop on the
-        // wire (the existing scalar ReadAtUtc still drives client UI), but the data is in place
-        // for #214 when discipline group chats start populating ReadBy across many readers.
-        await messages.AddReadByAsync(
-            anchor.Value, new ReadReceipt(request.ReaderUserId, now), cancellationToken).ConfigureAwait(false);
+        // Group-aware read receipts: append a receipt for every transitioned message and emit a
+        // dedicated broadcast per id. Direct conversations land here too (anchor is usually the
+        // single transitioned message), but this keeps the data shape ready for #214 group chats.
+        foreach (var messageId in transitioned)
+        {
+            await messages.AddReadByAsync(
+                messageId, new ReadReceipt(request.ReaderUserId, now), cancellationToken).ConfigureAwait(false);
+            await broadcaster.NotifyMessageReadByAsync(
+                observers, conversation.Id, messageId, request.ReaderUserId, now, cancellationToken).ConfigureAwait(false);
+        }
 
-        var observers = conversation.Participants.Where(p => p != request.ReaderUserId).ToList();
+        // Legacy anchor-only broadcast — kept for backward compat with clients that haven't
+        // adopted MessageReadByUpdate yet.
         await broadcaster.NotifyMessageReadAsync(
-            observers, conversation.Id, anchor.Value, request.ReaderUserId, cancellationToken).ConfigureAwait(false);
-        await broadcaster.NotifyMessageReadByAsync(
-            observers, conversation.Id, anchor.Value, request.ReaderUserId, now, cancellationToken).ConfigureAwait(false);
+            observers, conversation.Id, anchor, request.ReaderUserId, cancellationToken).ConfigureAwait(false);
 
         return anchor;
     }

--- a/src/Services/Chat/ChatService.Api/Application/Messages/MarkReadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/MarkReadService.cs
@@ -1,5 +1,6 @@
 using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
 using Urfu.Link.Services.Chat.Realtime;
 
 namespace Urfu.Link.Services.Chat.Application.Messages;
@@ -37,9 +38,18 @@ public sealed class MarkReadService(
             new ChatMessageReadEvent(conversation.Id, anchor.Value, request.ReaderUserId, now),
             cancellationToken).ConfigureAwait(false);
 
+        // Group-aware read receipts: also append to the anchor's ReadBy[] and emit the
+        // group-flavoured broadcast. For Direct conversations this is essentially a noop on the
+        // wire (the existing scalar ReadAtUtc still drives client UI), but the data is in place
+        // for #214 when discipline group chats start populating ReadBy across many readers.
+        await messages.AddReadByAsync(
+            anchor.Value, new ReadReceipt(request.ReaderUserId, now), cancellationToken).ConfigureAwait(false);
+
         var observers = conversation.Participants.Where(p => p != request.ReaderUserId).ToList();
         await broadcaster.NotifyMessageReadAsync(
             observers, conversation.Id, anchor.Value, request.ReaderUserId, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyMessageReadByAsync(
+            observers, conversation.Id, anchor.Value, request.ReaderUserId, now, cancellationToken).ConfigureAwait(false);
 
         return anchor;
     }

--- a/src/Services/Chat/ChatService.Api/Application/Messages/RemoveReactionService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/RemoveReactionService.cs
@@ -1,0 +1,68 @@
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+public sealed record RemoveReactionRequest(Guid MessageId, Guid UserId, string Emoji);
+
+public sealed class RemoveReactionService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task RemoveAsync(RemoveReactionRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Emoji);
+
+        var message = await messages.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatMessageNotFoundException.For(request.MessageId);
+
+        var conversation = await conversations.GetByIdAsync(message.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(message.ConversationId);
+
+        if (!conversation.IsParticipant(request.UserId))
+        {
+            throw new ChatAccessDeniedException(message.ConversationId, request.UserId);
+        }
+
+        var removed = await messages.RemoveReactionAsync(
+            request.MessageId, request.UserId, request.Emoji, cancellationToken).ConfigureAwait(false);
+
+        if (!removed)
+        {
+            return;
+        }
+
+        var now = clock.GetUtcNow();
+        await dispatcher.PublishAsync(
+            new ChatReactionRemovedEvent(conversation.Id, request.MessageId, request.UserId, request.Emoji, now),
+            cancellationToken).ConfigureAwait(false);
+
+        var summary = await BuildSummaryAsync(request.MessageId, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyReactionUpdatedAsync(
+            conversation.Participants.ToList(), request.MessageId, summary, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyDictionary<string, IReadOnlyList<Guid>>> BuildSummaryAsync(
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        var refreshed = await messages.GetByIdAsync(messageId, cancellationToken).ConfigureAwait(false);
+        if (refreshed is null)
+        {
+            return new Dictionary<string, IReadOnlyList<Guid>>(StringComparer.Ordinal);
+        }
+
+        return refreshed.Reactions
+            .GroupBy(r => r.Emoji, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<Guid>)g.Select(r => r.UserId).ToList(),
+                StringComparer.Ordinal);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageRequest.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageRequest.cs
@@ -5,4 +5,5 @@ public sealed record SendMessageRequest(
     Guid SenderId,
     string Body,
     IReadOnlyList<Guid> AttachmentAssetIds,
-    string ClientMessageId);
+    string ClientMessageId,
+    Guid? ReplyToMessageId = null);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -1,9 +1,12 @@
+using Microsoft.Extensions.Options;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Mentions;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
 using Urfu.Link.Services.Chat.Realtime;
 
 namespace Urfu.Link.Services.Chat.Application.Messages;
@@ -21,7 +24,8 @@ public sealed class SendMessageService(
     IIdempotencyStore idempotencyStore,
     ChatEventDispatcher dispatcher,
     IChatBroadcaster broadcaster,
-    TimeProvider clock)
+    TimeProvider clock,
+    IOptions<ChatOptions> options)
 {
     public const int MaxBodyLength = 4000;
 
@@ -65,6 +69,9 @@ public sealed class SendMessageService(
         var replyTo = await ResolveReplyToAsync(conversation.Id, request.ReplyToMessageId, cancellationToken)
             .ConfigureAwait(false);
 
+        var opts = options.Value;
+        var mentions = MentionsParser.Parse(request.Body, conversation.Participants, opts.MaxMentionsPerMessage);
+
         var now = clock.GetUtcNow();
         var message = Message.Send(
             id: Guid.NewGuid(),
@@ -74,6 +81,7 @@ public sealed class SendMessageService(
             attachments: attachments,
             clientMessageId: request.ClientMessageId,
             createdAtUtc: now,
+            mentions: mentions,
             replyTo: replyTo);
 
         try
@@ -105,8 +113,21 @@ public sealed class SendMessageService(
                 recipients,
                 BuildPreviewText(request.Body, message.HasAttachments),
                 message.HasAttachments,
-                now),
+                now,
+                Mentions: mentions.Count == 0 ? null : mentions),
             cancellationToken).ConfigureAwait(false);
+
+        if (mentions.Count > 0)
+        {
+            await dispatcher.PublishAsync(
+                new ChatMentionCreatedEvent(
+                    conversation.Id,
+                    message.Id,
+                    request.SenderId,
+                    mentions,
+                    now),
+                cancellationToken).ConfigureAwait(false);
+        }
 
         var dto = MessageDto.FromDomain(message);
         await broadcaster.NotifyMessageReceivedAsync(recipients, dto, cancellationToken).ConfigureAwait(false);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -62,6 +62,9 @@ public sealed class SendMessageService(
         var attachments = await ResolveAttachmentsAsync(request.AttachmentAssetIds, request.SenderId, cancellationToken)
             .ConfigureAwait(false);
 
+        var replyTo = await ResolveReplyToAsync(conversation.Id, request.ReplyToMessageId, cancellationToken)
+            .ConfigureAwait(false);
+
         var now = clock.GetUtcNow();
         var message = Message.Send(
             id: Guid.NewGuid(),
@@ -70,7 +73,8 @@ public sealed class SendMessageService(
             body: request.Body,
             attachments: attachments,
             clientMessageId: request.ClientMessageId,
-            createdAtUtc: now);
+            createdAtUtc: now,
+            replyTo: replyTo);
 
         try
         {
@@ -128,6 +132,25 @@ public sealed class SendMessageService(
         {
             throw new ArgumentException("ClientMessageId is required.", nameof(request));
         }
+    }
+
+    private async Task<ReplyTo?> ResolveReplyToAsync(
+        string conversationId,
+        Guid? replyToMessageId,
+        CancellationToken cancellationToken)
+    {
+        if (replyToMessageId is not { } id)
+        {
+            return null;
+        }
+
+        var target = await messages.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (target is null || !string.Equals(target.ConversationId, conversationId, StringComparison.Ordinal))
+        {
+            throw new ChatReplyTargetNotFoundException(id, conversationId);
+        }
+
+        return ReplyTo.Create(target.Id, target.SenderId, target.Body);
     }
 
     private async Task<IReadOnlyList<Attachment>> ResolveAttachmentsAsync(

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -27,9 +27,11 @@ public sealed class SendMessageService(
     TimeProvider clock,
     IOptions<ChatOptions> options)
 {
-    public const int MaxBodyLength = 4000;
+    /// <summary>Backwards-compatible alias for <see cref="ChatBodyConstraints.MaxBodyLength"/>.</summary>
+    public const int MaxBodyLength = ChatBodyConstraints.MaxBodyLength;
 
-    public const int MaxAttachmentsPerMessage = 10;
+    /// <summary>Backwards-compatible alias for <see cref="ChatBodyConstraints.MaxAttachmentsPerMessage"/>.</summary>
+    public const int MaxAttachmentsPerMessage = ChatBodyConstraints.MaxAttachmentsPerMessage;
 
     public async Task<MessageDto> SendAsync(SendMessageRequest request, CancellationToken cancellationToken)
     {

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Conversation.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Conversation.cs
@@ -9,6 +9,7 @@ namespace Urfu.Link.Services.Chat.Domain.Aggregates;
 public sealed class Conversation
 {
     private readonly List<Guid> _participants;
+    private readonly List<Guid> _pinnedMessageIds;
 
     private Conversation(
         string id,
@@ -16,7 +17,8 @@ public sealed class Conversation
         IEnumerable<Guid> participants,
         DateTimeOffset createdAtUtc,
         DateTimeOffset lastMessageAtUtc,
-        MessagePreview? lastMessagePreview)
+        MessagePreview? lastMessagePreview,
+        IEnumerable<Guid>? pinnedMessageIds)
     {
         Id = id;
         Type = type;
@@ -24,6 +26,7 @@ public sealed class Conversation
         CreatedAtUtc = createdAtUtc;
         LastMessageAtUtc = lastMessageAtUtc;
         LastMessagePreview = lastMessagePreview;
+        _pinnedMessageIds = pinnedMessageIds?.ToList() ?? [];
     }
 
     public string Id { get; }
@@ -37,6 +40,8 @@ public sealed class Conversation
     public DateTimeOffset LastMessageAtUtc { get; private set; }
 
     public MessagePreview? LastMessagePreview { get; private set; }
+
+    public IReadOnlyList<Guid> PinnedMessageIds => _pinnedMessageIds;
 
     public static Conversation OpenDirect(Guid userA, Guid userB, DateTimeOffset nowUtc)
     {
@@ -54,7 +59,8 @@ public sealed class Conversation
             new[] { lo, hi },
             nowUtc,
             nowUtc,
-            lastMessagePreview: null);
+            lastMessagePreview: null,
+            pinnedMessageIds: null);
     }
 
     public static Conversation Hydrate(
@@ -63,8 +69,9 @@ public sealed class Conversation
         IEnumerable<Guid> participants,
         DateTimeOffset createdAtUtc,
         DateTimeOffset lastMessageAtUtc,
-        MessagePreview? lastMessagePreview)
-        => new(id, type, participants, createdAtUtc, lastMessageAtUtc, lastMessagePreview);
+        MessagePreview? lastMessagePreview,
+        IEnumerable<Guid>? pinnedMessageIds = null)
+        => new(id, type, participants, createdAtUtc, lastMessageAtUtc, lastMessagePreview, pinnedMessageIds);
 
     public bool IsParticipant(Guid userId) => _participants.Contains(userId);
 
@@ -74,6 +81,33 @@ public sealed class Conversation
         LastMessagePreview = preview;
         LastMessageAtUtc = sentAtUtc;
     }
+
+    public bool IsPinned(Guid messageId) => _pinnedMessageIds.Contains(messageId);
+
+    /// <summary>
+    /// Pins the message inside the in-memory aggregate. Returns <c>false</c> if the message is
+    /// already pinned (idempotent) or if the pinned-list is at <paramref name="maxPinned"/>.
+    /// Callers should distinguish the two by inspecting <see cref="IsPinned"/> before invoking.
+    /// </summary>
+    public bool PinMessage(Guid messageId, int maxPinned)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPinned);
+
+        if (IsPinned(messageId))
+        {
+            return false;
+        }
+
+        if (_pinnedMessageIds.Count >= maxPinned)
+        {
+            return false;
+        }
+
+        _pinnedMessageIds.Add(messageId);
+        return true;
+    }
+
+    public bool UnpinMessage(Guid messageId) => _pinnedMessageIds.Remove(messageId);
 
     // SHA1 is used here as a non-cryptographic deterministic hash to derive a stable
     // identifier for a sorted user pair. Collision resistance for the (Guid, Guid) input

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
@@ -6,6 +6,11 @@ namespace Urfu.Link.Services.Chat.Domain.Aggregates;
 public sealed class Message
 {
     private readonly List<Attachment> _attachments;
+    private readonly List<EditHistoryEntry> _editHistory;
+    private readonly List<Guid> _hiddenFor;
+    private readonly List<Reaction> _reactions;
+    private readonly List<Guid> _mentions;
+    private readonly List<ReadReceipt> _readBy;
 
     private Message(
         Guid id,
@@ -17,7 +22,18 @@ public sealed class Message
         MessageState state,
         DateTimeOffset createdAtUtc,
         DateTimeOffset? deliveredAtUtc,
-        DateTimeOffset? readAtUtc)
+        DateTimeOffset? readAtUtc,
+        DateTimeOffset? editedAtUtc,
+        IEnumerable<EditHistoryEntry>? editHistory,
+        DateTimeOffset? deletedAtUtc,
+        Guid? deletedBy,
+        DeleteMode? deleteMode,
+        IEnumerable<Guid>? hiddenFor,
+        IEnumerable<Reaction>? reactions,
+        IEnumerable<Guid>? mentions,
+        ReplyTo? replyTo,
+        ForwardedFrom? forwardedFrom,
+        IEnumerable<ReadReceipt>? readBy)
     {
         Id = id;
         ConversationId = conversationId;
@@ -29,6 +45,17 @@ public sealed class Message
         CreatedAtUtc = createdAtUtc;
         DeliveredAtUtc = deliveredAtUtc;
         ReadAtUtc = readAtUtc;
+        EditedAtUtc = editedAtUtc;
+        _editHistory = editHistory?.ToList() ?? [];
+        DeletedAtUtc = deletedAtUtc;
+        DeletedBy = deletedBy;
+        DeleteMode = deleteMode;
+        _hiddenFor = hiddenFor?.ToList() ?? [];
+        _reactions = reactions?.ToList() ?? [];
+        _mentions = mentions?.ToList() ?? [];
+        ReplyTo = replyTo;
+        ForwardedFrom = forwardedFrom;
+        _readBy = readBy?.ToList() ?? [];
     }
 
     public Guid Id { get; }
@@ -37,7 +64,7 @@ public sealed class Message
 
     public Guid SenderId { get; }
 
-    public string Body { get; }
+    public string Body { get; private set; }
 
     public IReadOnlyList<Attachment> Attachments => _attachments;
 
@@ -51,6 +78,28 @@ public sealed class Message
 
     public DateTimeOffset? ReadAtUtc { get; private set; }
 
+    public DateTimeOffset? EditedAtUtc { get; private set; }
+
+    public IReadOnlyList<EditHistoryEntry> EditHistory => _editHistory;
+
+    public DateTimeOffset? DeletedAtUtc { get; private set; }
+
+    public Guid? DeletedBy { get; private set; }
+
+    public DeleteMode? DeleteMode { get; private set; }
+
+    public IReadOnlyList<Guid> HiddenFor => _hiddenFor;
+
+    public IReadOnlyList<Reaction> Reactions => _reactions;
+
+    public IReadOnlyList<Guid> Mentions => _mentions;
+
+    public ReplyTo? ReplyTo { get; private set; }
+
+    public ForwardedFrom? ForwardedFrom { get; private set; }
+
+    public IReadOnlyList<ReadReceipt> ReadBy => _readBy;
+
     public bool HasAttachments => _attachments.Count > 0;
 
     public static Message Send(
@@ -60,7 +109,10 @@ public sealed class Message
         string body,
         IEnumerable<Attachment> attachments,
         string clientMessageId,
-        DateTimeOffset createdAtUtc)
+        DateTimeOffset createdAtUtc,
+        IEnumerable<Guid>? mentions = null,
+        ReplyTo? replyTo = null,
+        ForwardedFrom? forwardedFrom = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentNullException.ThrowIfNull(attachments);
@@ -76,7 +128,18 @@ public sealed class Message
             MessageState.Sent,
             createdAtUtc,
             deliveredAtUtc: null,
-            readAtUtc: null);
+            readAtUtc: null,
+            editedAtUtc: null,
+            editHistory: null,
+            deletedAtUtc: null,
+            deletedBy: null,
+            deleteMode: null,
+            hiddenFor: null,
+            reactions: null,
+            mentions: mentions,
+            replyTo: replyTo,
+            forwardedFrom: forwardedFrom,
+            readBy: null);
     }
 
     public static Message Hydrate(
@@ -89,8 +152,40 @@ public sealed class Message
         MessageState state,
         DateTimeOffset createdAtUtc,
         DateTimeOffset? deliveredAtUtc,
-        DateTimeOffset? readAtUtc)
-        => new(id, conversationId, senderId, body, attachments, clientMessageId, state, createdAtUtc, deliveredAtUtc, readAtUtc);
+        DateTimeOffset? readAtUtc,
+        DateTimeOffset? editedAtUtc = null,
+        IEnumerable<EditHistoryEntry>? editHistory = null,
+        DateTimeOffset? deletedAtUtc = null,
+        Guid? deletedBy = null,
+        DeleteMode? deleteMode = null,
+        IEnumerable<Guid>? hiddenFor = null,
+        IEnumerable<Reaction>? reactions = null,
+        IEnumerable<Guid>? mentions = null,
+        ReplyTo? replyTo = null,
+        ForwardedFrom? forwardedFrom = null,
+        IEnumerable<ReadReceipt>? readBy = null)
+        => new(
+            id,
+            conversationId,
+            senderId,
+            body,
+            attachments,
+            clientMessageId,
+            state,
+            createdAtUtc,
+            deliveredAtUtc,
+            readAtUtc,
+            editedAtUtc,
+            editHistory,
+            deletedAtUtc,
+            deletedBy,
+            deleteMode,
+            hiddenFor,
+            reactions,
+            mentions,
+            replyTo,
+            forwardedFrom,
+            readBy);
 
     public bool MarkDelivered(DateTimeOffset atUtc)
     {
@@ -114,6 +209,149 @@ public sealed class Message
         DeliveredAtUtc ??= atUtc;
         ReadAtUtc = atUtc;
         State = MessageState.Read;
+        return true;
+    }
+
+    public bool IsAuthor(Guid userId) => SenderId == userId;
+
+    public bool IsEditableBy(Guid userId, DateTimeOffset nowUtc, TimeSpan ttl)
+        => IsAuthor(userId)
+           && State != MessageState.Deleted
+           && nowUtc - CreatedAtUtc <= ttl;
+
+    public bool IsDeletableForEveryoneBy(Guid userId, DateTimeOffset nowUtc, TimeSpan ttl)
+        => IsAuthor(userId)
+           && State != MessageState.Deleted
+           && nowUtc - CreatedAtUtc <= ttl;
+
+    public bool Edit(string newBody, IReadOnlyList<Guid> validatedMentions, DateTimeOffset atUtc, TimeSpan ttl)
+    {
+        ArgumentNullException.ThrowIfNull(validatedMentions);
+
+        if (State == MessageState.Deleted)
+        {
+            return false;
+        }
+
+        if (atUtc - CreatedAtUtc > ttl)
+        {
+            return false;
+        }
+
+        var safeBody = newBody ?? string.Empty;
+        if (string.Equals(Body, safeBody, StringComparison.Ordinal)
+            && _mentions.SequenceEqual(validatedMentions))
+        {
+            return false;
+        }
+
+        _editHistory.Add(new EditHistoryEntry(Body, EditedAtUtc ?? CreatedAtUtc));
+        Body = safeBody;
+        _mentions.Clear();
+        _mentions.AddRange(validatedMentions);
+        EditedAtUtc = atUtc;
+        return true;
+    }
+
+    public bool MarkDeletedForEveryone(Guid byUserId, DateTimeOffset atUtc, TimeSpan ttl)
+    {
+        if (State == MessageState.Deleted)
+        {
+            return false;
+        }
+
+        if (atUtc - CreatedAtUtc > ttl)
+        {
+            return false;
+        }
+
+        State = MessageState.Deleted;
+        DeletedAtUtc = atUtc;
+        DeletedBy = byUserId;
+        DeleteMode = Enums.DeleteMode.ForEveryone;
+        Body = string.Empty;
+        _attachments.Clear();
+        _reactions.Clear();
+        _mentions.Clear();
+        ReplyTo = null;
+        ForwardedFrom = null;
+        return true;
+    }
+
+    public bool MarkDeletedForMe(Guid userId)
+    {
+        if (_hiddenFor.Contains(userId))
+        {
+            return false;
+        }
+
+        _hiddenFor.Add(userId);
+        return true;
+    }
+
+    public bool IsHiddenFor(Guid userId) => _hiddenFor.Contains(userId);
+
+    public bool AddReaction(Guid userId, string emoji, DateTimeOffset atUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(emoji);
+
+        if (State == MessageState.Deleted)
+        {
+            return false;
+        }
+
+        var existingIndex = _reactions.FindIndex(r => r.UserId == userId);
+        if (existingIndex >= 0)
+        {
+            var existing = _reactions[existingIndex];
+            if (string.Equals(existing.Emoji, emoji, StringComparison.Ordinal))
+            {
+                return false;
+            }
+            _reactions.RemoveAt(existingIndex);
+        }
+
+        _reactions.Add(new Reaction(userId, emoji, atUtc));
+        return true;
+    }
+
+    public bool RemoveReaction(Guid userId, string emoji)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(emoji);
+
+        var index = _reactions.FindIndex(r => r.UserId == userId
+            && string.Equals(r.Emoji, emoji, StringComparison.Ordinal));
+        if (index < 0)
+        {
+            return false;
+        }
+
+        _reactions.RemoveAt(index);
+        return true;
+    }
+
+    public bool MarkReadBy(Guid userId, DateTimeOffset atUtc)
+    {
+        if (State == MessageState.Deleted)
+        {
+            return false;
+        }
+
+        if (_readBy.Any(r => r.UserId == userId))
+        {
+            return false;
+        }
+
+        _readBy.Add(new ReadReceipt(userId, atUtc));
+
+        // Preserve existing direct-chat semantics: keep the scalar ReadAt as the first read time.
+        if (State != MessageState.Read)
+        {
+            DeliveredAtUtc ??= atUtc;
+            ReadAtUtc = atUtc;
+            State = MessageState.Read;
+        }
+
         return true;
     }
 }

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/ConversationType.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/ConversationType.cs
@@ -3,4 +3,5 @@ namespace Urfu.Link.Services.Chat.Domain.Enums;
 public enum ConversationType
 {
     Direct = 0,
+    Group = 1,
 }

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteMode.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteMode.cs
@@ -1,0 +1,7 @@
+namespace Urfu.Link.Services.Chat.Domain.Enums;
+
+public enum DeleteMode
+{
+    ForMe = 0,
+    ForEveryone = 1,
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteModes.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteModes.cs
@@ -1,0 +1,37 @@
+namespace Urfu.Link.Services.Chat.Domain.Enums;
+
+/// <summary>
+/// Wire-format constants and conversions for <see cref="DeleteMode"/>. The enum value
+/// <c>ForEveryone</c> is serialised on the wire as <c>"for-everyone"</c> (kebab-case) so REST
+/// query strings, hub method arguments, and SignalR broadcasts all share the same vocabulary.
+/// </summary>
+public static class DeleteModes
+{
+    public const string ForMe = "for-me";
+
+    public const string ForEveryone = "for-everyone";
+
+    /// <summary>
+    /// Parses the wire value into a <see cref="DeleteMode"/>. <see langword="null"/> or empty
+    /// defaults to <see cref="DeleteMode.ForMe"/> (the safer, local-only mode). Anything else
+    /// is rejected with <see cref="ArgumentException"/>.
+    /// </summary>
+    public static DeleteMode Parse(string? value)
+    {
+        return value switch
+        {
+            ForEveryone => DeleteMode.ForEveryone,
+            null or "" or ForMe => DeleteMode.ForMe,
+            _ => throw new ArgumentException(
+                $"Unsupported delete mode '{value}'. Use '{ForMe}' or '{ForEveryone}'.",
+                nameof(value)),
+        };
+    }
+
+    public static string ToWire(this DeleteMode mode) => mode switch
+    {
+        DeleteMode.ForEveryone => ForEveryone,
+        DeleteMode.ForMe => ForMe,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown DeleteMode."),
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMentionCreatedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMentionCreatedEvent.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatMentionCreatedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid SenderId,
+    IReadOnlyList<Guid> MentionedUserIds,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.mention.created.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageDeletedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageDeletedEvent.cs
@@ -1,0 +1,16 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatMessageDeletedEvent(
+    string ConversationId,
+    Guid MessageId,
+    DeleteMode Mode,
+    Guid DeletedBy,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.message.deleted.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageEditedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageEditedEvent.cs
@@ -1,0 +1,17 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatMessageEditedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid EditorUserId,
+    string NewBody,
+    IReadOnlyList<Guid> Mentions,
+    DateTimeOffset EditedAtUtc,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.message.edited.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessagePinnedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessagePinnedEvent.cs
@@ -1,0 +1,14 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatMessagePinnedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid PinnedByUserId,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.message.pinned.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageSentEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageSentEvent.cs
@@ -9,7 +9,8 @@ public sealed record ChatMessageSentEvent(
     IReadOnlyList<Guid> Recipients,
     string Preview,
     bool HasAttachments,
-    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+    DateTimeOffset OccurredAtUtc,
+    IReadOnlyList<Guid>? Mentions = null) : IIntegrationEvent
 {
     public Guid EventId { get; } = Guid.NewGuid();
 

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageUnpinnedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMessageUnpinnedEvent.cs
@@ -1,0 +1,14 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatMessageUnpinnedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid UnpinnedByUserId,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.message.unpinned.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatReactionAddedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatReactionAddedEvent.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatReactionAddedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid UserId,
+    string Emoji,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.reaction.added.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatReactionRemovedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatReactionRemovedEvent.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+public sealed record ChatReactionRemovedEvent(
+    string ConversationId,
+    Guid MessageId,
+    Guid UserId,
+    string Emoji,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.reaction.removed.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IConversationRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IConversationRepository.cs
@@ -26,4 +26,21 @@ public interface IConversationRepository
         ConversationCursor? cursor,
         int limit,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds <paramref name="messageId"/> to <c>pinnedMessageIds</c> using <c>$addToSet</c> with
+    /// a precondition that the array length is below <paramref name="maxPinned"/>. Returns
+    /// false when the conversation is missing, the message is already pinned, or the cap is
+    /// already reached.
+    /// </summary>
+    Task<bool> AddPinnedMessageAsync(
+        string conversationId,
+        Guid messageId,
+        int maxPinned,
+        CancellationToken cancellationToken);
+
+    Task<bool> RemovePinnedMessageAsync(
+        string conversationId,
+        Guid messageId,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
@@ -48,10 +48,10 @@ public interface IMessageRepository
 
     /// <summary>
     /// Marks all messages in the conversation up to and including <paramref name="upToMessageId"/>
-    /// as Read. Returns the actual highest <see cref="MessageState.Read"/> message id (or
-    /// <see langword="null"/> if no transition occurred).
+    /// as Read. Returns the ids that actually transitioned, ordered from oldest to newest
+    /// (so the last element is the new anchor). Returns an empty list if nothing transitioned.
     /// </summary>
-    Task<Guid?> MarkReadUpToAsync(
+    Task<IReadOnlyList<Guid>> MarkReadUpToAsync(
         string conversationId,
         Guid upToMessageId,
         DateTimeOffset readAtUtc,

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
@@ -19,6 +19,15 @@ public interface IMessageRepository
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Bulk-loads messages by id across any conversation. Used by forward, where source
+    /// messages may live in different conversations and the caller verifies membership for
+    /// each source separately. Result order is unspecified — callers should index by id.
+    /// </summary>
+    Task<IReadOnlyList<Message>> GetManyAsync(
+        IReadOnlyList<Guid> messageIds,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Inserts a new message. Throws <see cref="DuplicateClientMessageException"/> when the
     /// (senderId, clientMessageId) pair already exists in the collection.
     /// </summary>

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
@@ -1,11 +1,22 @@
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
 
 namespace Urfu.Link.Services.Chat.Domain.Interfaces;
 
 public interface IMessageRepository
 {
     Task<Message?> GetByIdAsync(Guid messageId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns messages whose ids are in <paramref name="messageIds"/> and that belong to
+    /// <paramref name="conversationId"/>. Useful for forward and pinned-list materialization
+    /// where ids alone could otherwise leak across conversations.
+    /// </summary>
+    Task<IReadOnlyList<Message>> GetByIdsAsync(
+        string conversationId,
+        IReadOnlyList<Guid> messageIds,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Inserts a new message. Throws <see cref="DuplicateClientMessageException"/> when the
@@ -45,6 +56,56 @@ public interface IMessageRepository
         Guid upToMessageId,
         DateTimeOffset readAtUtc,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atomically applies an edit: sets new body / mentions / editedAt and appends a single
+    /// history entry. Returns false if the message does not exist or is in the Deleted state.
+    /// </summary>
+    Task<bool> ApplyEditAsync(
+        Guid messageId,
+        string newBody,
+        IReadOnlyList<Guid> mentions,
+        EditHistoryEntry historyEntry,
+        DateTimeOffset editedAtUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atomically applies a tombstone: clears body/attachments/reactions/mentions/replyTo/
+    /// forwardedFrom, sets state to Deleted and records the deleter. Returns false if the
+    /// message is missing or already deleted.
+    /// </summary>
+    Task<bool> ApplyDeleteForEveryoneAsync(
+        Guid messageId,
+        Guid byUserId,
+        DateTimeOffset deletedAtUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds <paramref name="userId"/> to the message's <c>hiddenFor</c> set. Idempotent.
+    /// Returns true when the user was newly added.
+    /// </summary>
+    Task<bool> AddHiddenForAsync(Guid messageId, Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds or replaces a reaction by <c>userId</c>. Pull-then-push semantics: any prior
+    /// reaction by the same user is removed before the new one is appended. Returns true if
+    /// the message exists and the reaction was applied.
+    /// </summary>
+    Task<bool> AddReactionAsync(Guid messageId, Reaction reaction, CancellationToken cancellationToken);
+
+    Task<bool> RemoveReactionAsync(
+        Guid messageId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Adds a <see cref="ReadReceipt"/>, deduplicated by user id. Returns true when the receipt
+    /// was newly recorded.
+    /// </summary>
+    Task<bool> AddReadByAsync(Guid messageId, ReadReceipt receipt, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<ReadReceipt>> GetReadReceiptsAsync(Guid messageId, CancellationToken cancellationToken);
 }
 
 public sealed class DuplicateClientMessageException : InvalidOperationException

--- a/src/Services/Chat/ChatService.Api/Domain/ValueObjects/EditHistoryEntry.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/ValueObjects/EditHistoryEntry.cs
@@ -1,0 +1,5 @@
+namespace Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+public sealed record EditHistoryEntry(
+    string Body,
+    DateTimeOffset EditedAtUtc);

--- a/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ForwardedFrom.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ForwardedFrom.cs
@@ -1,0 +1,6 @@
+namespace Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+public sealed record ForwardedFrom(
+    Guid OriginalSenderId,
+    DateTimeOffset OriginalSentAtUtc,
+    string? OriginalConversationId);

--- a/src/Services/Chat/ChatService.Api/Domain/ValueObjects/Reaction.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/ValueObjects/Reaction.cs
@@ -1,0 +1,6 @@
+namespace Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+public sealed record Reaction(
+    Guid UserId,
+    string Emoji,
+    DateTimeOffset CreatedAtUtc);

--- a/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ReadReceipt.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ReadReceipt.cs
@@ -1,0 +1,5 @@
+namespace Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+public sealed record ReadReceipt(
+    Guid UserId,
+    DateTimeOffset ReadAtUtc);

--- a/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ReplyTo.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/ValueObjects/ReplyTo.cs
@@ -1,0 +1,31 @@
+namespace Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+public sealed record ReplyTo(
+    Guid MessageId,
+    Guid SenderId,
+    string Preview)
+{
+    public const int MaxPreviewLength = 100;
+
+    public static ReplyTo Create(Guid messageId, Guid senderId, string body)
+        => new(messageId, senderId, BuildPreview(body));
+
+    private static string BuildPreview(string body)
+    {
+        if (string.IsNullOrEmpty(body))
+        {
+            return string.Empty;
+        }
+
+        if (body.Length <= MaxPreviewLength)
+        {
+            return body;
+        }
+
+        // Avoid splitting a UTF-16 surrogate pair when truncating.
+        var cutoff = char.IsHighSurrogate(body[MaxPreviewLength - 1])
+            ? MaxPreviewLength - 1
+            : MaxPreviewLength;
+        return body[..cutoff];
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Conversations/ForwardMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Conversations/ForwardMessagesEndpoint.cs
@@ -1,0 +1,34 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Conversations;
+
+public sealed class ForwardMessagesRouteRequest
+{
+    public string Id { get; set; } = string.Empty;
+
+    public IReadOnlyList<Guid> MessageIds { get; set; } = Array.Empty<Guid>();
+}
+
+public sealed class ForwardMessagesEndpoint(ForwardMessagesService service)
+    : Endpoint<ForwardMessagesRouteRequest, IReadOnlyList<MessageDto>>
+{
+    public override void Configure()
+    {
+        Post("conversations/{id}/forward");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Forward up to MaxForwardedMessages messages into a target conversation.");
+    }
+
+    public override async Task HandleAsync(ForwardMessagesRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var dtos = await service.ForwardAsync(
+            new ForwardMessagesRequest(req.Id, caller, req.MessageIds ?? Array.Empty<Guid>()), ct)
+            .ConfigureAwait(false);
+        await Send.OkAsync(dtos, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Conversations/PinMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Conversations/PinMessageEndpoint.cs
@@ -1,0 +1,33 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Conversations;
+
+public sealed class PinMessageRouteRequest
+{
+    public string Id { get; set; } = string.Empty;
+
+    public Guid MessageId { get; set; }
+}
+
+public sealed class PinMessageEndpoint(PinMessageService service)
+    : Endpoint<PinMessageRouteRequest, IReadOnlyList<MessageDto>>
+{
+    public override void Configure()
+    {
+        Post("conversations/{id}/pinned");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Pin a message in a conversation. Authz: any participant for direct, teacher-only for discipline (#214).");
+    }
+
+    public override async Task HandleAsync(PinMessageRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var dtos = await service.PinAsync(
+            new PinMessageRequest(req.Id, caller, req.MessageId), ct).ConfigureAwait(false);
+        await Send.OkAsync(dtos, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Conversations/UnpinMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Conversations/UnpinMessageEndpoint.cs
@@ -1,0 +1,33 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Conversations;
+
+public sealed class UnpinMessageRouteRequest
+{
+    public string Id { get; set; } = string.Empty;
+
+    public Guid MessageId { get; set; }
+}
+
+public sealed class UnpinMessageEndpoint(UnpinMessageService service)
+    : Endpoint<UnpinMessageRouteRequest, IReadOnlyList<MessageDto>>
+{
+    public override void Configure()
+    {
+        Delete("conversations/{id}/pinned/{messageId}");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Unpin a message. Same authz as pinning.");
+    }
+
+    public override async Task HandleAsync(UnpinMessageRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var dtos = await service.UnpinAsync(
+            new UnpinMessageRequest(req.Id, caller, req.MessageId), ct).ConfigureAwait(false);
+        await Send.OkAsync(dtos, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/AddReactionEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/AddReactionEndpoint.cs
@@ -1,0 +1,32 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class AddReactionRouteRequest
+{
+    public Guid Id { get; set; }
+
+    public string Emoji { get; set; } = string.Empty;
+}
+
+public sealed class AddReactionEndpoint(AddReactionService service)
+    : Endpoint<AddReactionRouteRequest>
+{
+    public override void Configure()
+    {
+        Post("messages/{id}/reactions");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Add or replace the caller's reaction emoji on a message.");
+    }
+
+    public override async Task HandleAsync(AddReactionRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        await service.AddAsync(
+            new AddReactionRequest(req.Id, caller, req.Emoji ?? string.Empty), ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
@@ -1,0 +1,52 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class DeleteMessageRouteRequest
+{
+    public Guid Id { get; set; }
+
+    [QueryParam] public string? Mode { get; set; }
+}
+
+public sealed class DeleteMessageEndpoint(DeleteMessageService service)
+    : Endpoint<DeleteMessageRouteRequest, MessageDto?>
+{
+    public override void Configure()
+    {
+        Delete("messages/{id}");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Delete a message. Use mode=for-me for personal hide or mode=for-everyone (author-only).");
+    }
+
+    public override async Task HandleAsync(DeleteMessageRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var mode = ParseMode(req.Mode);
+        var dto = await service.DeleteAsync(
+            new DeleteMessageRequest(req.Id, caller, mode), ct).ConfigureAwait(false);
+        if (dto is null)
+        {
+            await Send.NotFoundAsync(ct).ConfigureAwait(false);
+            return;
+        }
+        await Send.OkAsync(dto, ct).ConfigureAwait(false);
+    }
+
+    private static DeleteMode ParseMode(string? raw)
+    {
+        return raw switch
+        {
+            "for-everyone" => DeleteMode.ForEveryone,
+            null or "" or "for-me" => DeleteMode.ForMe,
+            _ => throw new ArgumentException(
+                $"Unsupported delete mode '{raw}'. Use 'for-me' or 'for-everyone'.",
+                nameof(raw)),
+        };
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
@@ -27,7 +27,7 @@ public sealed class DeleteMessageEndpoint(DeleteMessageService service)
     {
         ArgumentNullException.ThrowIfNull(req);
         var caller = User.GetUserId();
-        var mode = ParseMode(req.Mode);
+        var mode = DeleteModes.Parse(req.Mode);
         var dto = await service.DeleteAsync(
             new DeleteMessageRequest(req.Id, caller, mode), ct).ConfigureAwait(false);
         if (dto is null)
@@ -36,17 +36,5 @@ public sealed class DeleteMessageEndpoint(DeleteMessageService service)
             return;
         }
         await Send.OkAsync(dto, ct).ConfigureAwait(false);
-    }
-
-    private static DeleteMode ParseMode(string? raw)
-    {
-        return raw switch
-        {
-            "for-everyone" => DeleteMode.ForEveryone,
-            null or "" or "for-me" => DeleteMode.ForMe,
-            _ => throw new ArgumentException(
-                $"Unsupported delete mode '{raw}'. Use 'for-me' or 'for-everyone'.",
-                nameof(raw)),
-        };
     }
 }

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/EditMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/EditMessageEndpoint.cs
@@ -1,0 +1,33 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class EditMessageRouteRequest
+{
+    public Guid Id { get; set; }
+
+    public string Body { get; set; } = string.Empty;
+}
+
+public sealed class EditMessageEndpoint(EditMessageService service)
+    : Endpoint<EditMessageRouteRequest, MessageDto>
+{
+    public override void Configure()
+    {
+        Patch("messages/{id}");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Edit a message body. Author-only, allowed within the configured TTL.");
+    }
+
+    public override async Task HandleAsync(EditMessageRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var dto = await service.EditAsync(
+            new EditMessageRequest(req.Id, caller, req.Body ?? string.Empty), ct).ConfigureAwait(false);
+        await Send.OkAsync(dto, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetReadReceiptsEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetReadReceiptsEndpoint.cs
@@ -1,0 +1,30 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class GetReadReceiptsRouteRequest
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class GetReadReceiptsEndpoint(GetReadReceiptsQuery query)
+    : Endpoint<GetReadReceiptsRouteRequest, IReadOnlyList<ReadReceiptDto>>
+{
+    public override void Configure()
+    {
+        Get("messages/{id}/read-receipts");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Read receipts for a message. Authz: caller must be a participant of the conversation.");
+    }
+
+    public override async Task HandleAsync(GetReadReceiptsRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var receipts = await query.ExecuteAsync(req.Id, caller, ct).ConfigureAwait(false);
+        await Send.OkAsync(receipts, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/RemoveReactionEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/RemoveReactionEndpoint.cs
@@ -1,0 +1,32 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class RemoveReactionRouteRequest
+{
+    public Guid Id { get; set; }
+
+    public string Emoji { get; set; } = string.Empty;
+}
+
+public sealed class RemoveReactionEndpoint(RemoveReactionService service)
+    : Endpoint<RemoveReactionRouteRequest>
+{
+    public override void Configure()
+    {
+        Delete("messages/{id}/reactions/{emoji}");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Remove the caller's reaction emoji from a message.");
+    }
+
+    public override async Task HandleAsync(RemoveReactionRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        await service.RemoveAsync(
+            new RemoveReactionRequest(req.Id, caller, req.Emoji ?? string.Empty), ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Authorization/DefaultDisciplineRoleResolver.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Authorization/DefaultDisciplineRoleResolver.cs
@@ -1,0 +1,20 @@
+using Urfu.Link.Services.Chat.Application.Authorization;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Authorization;
+
+/// <summary>
+/// Stub used until <c>DisciplineService</c> (#207) and discipline chats (#214) are wired up.
+/// Direct conversations: any participant can pin. Group conversations: blocked until the real
+/// teacher/student role resolver replaces this implementation.
+/// </summary>
+internal sealed class DefaultDisciplineRoleResolver : IDisciplineRoleResolver
+{
+    public Task<bool> CanPinAsync(Guid userId, Conversation conversation, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(conversation);
+        var allowed = conversation.Type == ConversationType.Direct && conversation.IsParticipant(userId);
+        return Task.FromResult(allowed);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/ChatOptions.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/ChatOptions.cs
@@ -1,0 +1,33 @@
+namespace Urfu.Link.Services.Chat.Infrastructure;
+
+/// <summary>
+/// Operator-tunable knobs for chat messenger features. Defaults match the issue spec
+/// (#211) — 48h edit/delete TTLs, 5 pinned messages per conversation, 50 forwarded messages
+/// per request, no emoji whitelist.
+/// </summary>
+public sealed class ChatOptions
+{
+    public const string SectionName = "Chat";
+
+    public int EditTtlHours { get; set; } = 48;
+
+    public int DeleteForEveryoneTtlHours { get; set; } = 48;
+
+    public int MaxPinnedMessages { get; set; } = 5;
+
+    public int MaxForwardedMessages { get; set; } = 50;
+
+    /// <summary>
+    /// Whitelist of allowed reaction emojis. When empty (default), any non-empty emoji is
+    /// accepted (subject to <see cref="MaxReactionEmojiLength"/>).
+    /// </summary>
+    public IReadOnlyList<string> AllowedReactionEmojis { get; set; } = Array.Empty<string>();
+
+    public int MaxReactionEmojiLength { get; set; } = 16;
+
+    public int MaxMentionsPerMessage { get; set; } = 50;
+
+    public TimeSpan EditTtl => TimeSpan.FromHours(EditTtlHours);
+
+    public TimeSpan DeleteForEveryoneTtl => TimeSpan.FromHours(DeleteForEveryoneTtlHours);
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -10,10 +10,12 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
 using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Domain;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure.Authorization;
 using Urfu.Link.Services.Chat.Infrastructure.Grpc;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence;
 using Urfu.Link.Services.Chat.Realtime;
@@ -46,6 +48,10 @@ public static class ModuleRegistration
         services.AddScoped<IConversationRepository, ConversationRepository>();
         services.AddScoped<IMessageRepository, MessageRepository>();
         services.AddHostedService<MongoIndexInitializer>();
+
+        services.AddOptions<ChatOptions>()
+            .Bind(configuration.GetSection(ChatOptions.SectionName));
+        services.AddSingleton<IDisciplineRoleResolver, DefaultDisciplineRoleResolver>();
 
         services.AddOptions<MediaServiceClientOptions>()
             .Bind(configuration.GetSection(MediaServiceClientOptions.SectionName));

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -104,6 +104,7 @@ public static class ModuleRegistration
         services.AddScoped<GetUserConversationsQuery>();
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();
+        services.AddScoped<GetReadReceiptsQuery>();
 
         services.AddSingleton<IChatBroadcaster, ChatBroadcaster>();
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -99,6 +99,8 @@ public static class ModuleRegistration
         services.AddScoped<ForwardMessagesService>();
         services.AddScoped<AddReactionService>();
         services.AddScoped<RemoveReactionService>();
+        services.AddScoped<PinMessageService>();
+        services.AddScoped<UnpinMessageService>();
         services.AddScoped<GetUserConversationsQuery>();
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -96,6 +96,7 @@ public static class ModuleRegistration
         services.AddScoped<MarkReadService>();
         services.AddScoped<EditMessageService>();
         services.AddScoped<DeleteMessageService>();
+        services.AddScoped<ForwardMessagesService>();
         services.AddScoped<GetUserConversationsQuery>();
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -97,6 +97,8 @@ public static class ModuleRegistration
         services.AddScoped<EditMessageService>();
         services.AddScoped<DeleteMessageService>();
         services.AddScoped<ForwardMessagesService>();
+        services.AddScoped<AddReactionService>();
+        services.AddScoped<RemoveReactionService>();
         services.AddScoped<GetUserConversationsQuery>();
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -94,6 +94,8 @@ public static class ModuleRegistration
         services.AddScoped<SendMessageService>();
         services.AddScoped<MarkDeliveredService>();
         services.AddScoped<MarkReadService>();
+        services.AddScoped<EditMessageService>();
+        services.AddScoped<DeleteMessageService>();
         services.AddScoped<GetUserConversationsQuery>();
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ConversationRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ConversationRepository.cs
@@ -1,3 +1,4 @@
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
@@ -83,5 +84,57 @@ internal sealed class ConversationRepository(ChatMongoContext context) : IConver
             .ConfigureAwait(false);
 
         return docs.Select(d => d.ToDomain()).ToList();
+    }
+
+    public async Task<bool> AddPinnedMessageAsync(
+        string conversationId,
+        Guid messageId,
+        int maxPinned,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPinned);
+
+        // Atomic precondition: conversation exists, messageId not yet pinned, and
+        // pinnedMessageIds size is below the cap. $ifNull guards against a missing field
+        // (rows persisted before the pinned-array existed).
+        var filter = new BsonDocument
+        {
+            { "_id", conversationId },
+            {
+                "pinnedMessageIds",
+                new BsonDocument("$ne", new BsonBinaryData(messageId, GuidRepresentation.Standard))
+            },
+            {
+                "$expr",
+                new BsonDocument("$lt", new BsonArray
+                {
+                    new BsonDocument("$size",
+                        new BsonDocument("$ifNull", new BsonArray { "$pinnedMessageIds", new BsonArray() })),
+                    maxPinned,
+                })
+            },
+        };
+
+        var update = Builders<ConversationDocument>.Update.AddToSet(c => c.PinnedMessageIds, messageId);
+        var result = await context.Conversations
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> RemovePinnedMessageAsync(
+        string conversationId,
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<ConversationDocument>.Filter.And(
+            Builders<ConversationDocument>.Filter.Eq(c => c.Id, conversationId),
+            Builders<ConversationDocument>.Filter.AnyEq(c => c.PinnedMessageIds, messageId));
+        var update = Builders<ConversationDocument>.Update.Pull(c => c.PinnedMessageIds, messageId);
+        var result = await context.Conversations
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
     }
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ConversationDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ConversationDocument.cs
@@ -26,13 +26,17 @@ internal sealed class ConversationDocument
     [BsonIgnoreIfNull]
     public MessagePreviewDocument? LastMessagePreview { get; set; }
 
+    [BsonElement("pinnedMessageIds")]
+    public List<Guid> PinnedMessageIds { get; set; } = new();
+
     public Conversation ToDomain() => Conversation.Hydrate(
         Id,
         Type,
         Participants,
         new DateTimeOffset(DateTime.SpecifyKind(CreatedAtUtc, DateTimeKind.Utc)),
         new DateTimeOffset(DateTime.SpecifyKind(LastMessageAtUtc, DateTimeKind.Utc)),
-        LastMessagePreview?.ToDomain());
+        LastMessagePreview?.ToDomain(),
+        PinnedMessageIds);
 
     public static ConversationDocument FromDomain(Conversation conversation) => new()
     {
@@ -42,5 +46,6 @@ internal sealed class ConversationDocument
         CreatedAtUtc = conversation.CreatedAtUtc.UtcDateTime,
         LastMessageAtUtc = conversation.LastMessageAtUtc.UtcDateTime,
         LastMessagePreview = conversation.LastMessagePreview is { } p ? MessagePreviewDocument.FromDomain(p) : null,
+        PinnedMessageIds = conversation.PinnedMessageIds.ToList(),
     };
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/EditHistoryEntryDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/EditHistoryEntryDocument.cs
@@ -1,0 +1,22 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class EditHistoryEntryDocument
+{
+    [BsonElement("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [BsonElement("editedAtUtc")]
+    public DateTime EditedAtUtc { get; set; }
+
+    public EditHistoryEntry ToDomain()
+        => new(Body, new DateTimeOffset(DateTime.SpecifyKind(EditedAtUtc, DateTimeKind.Utc)));
+
+    public static EditHistoryEntryDocument FromDomain(EditHistoryEntry entry) => new()
+    {
+        Body = entry.Body,
+        EditedAtUtc = entry.EditedAtUtc.UtcDateTime,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ForwardedFromDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ForwardedFromDocument.cs
@@ -1,0 +1,29 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class ForwardedFromDocument
+{
+    [BsonElement("originalSenderId")]
+    public Guid OriginalSenderId { get; set; }
+
+    [BsonElement("originalSentAtUtc")]
+    public DateTime OriginalSentAtUtc { get; set; }
+
+    [BsonElement("originalConversationId")]
+    [BsonIgnoreIfNull]
+    public string? OriginalConversationId { get; set; }
+
+    public ForwardedFrom ToDomain()
+        => new(OriginalSenderId,
+            new DateTimeOffset(DateTime.SpecifyKind(OriginalSentAtUtc, DateTimeKind.Utc)),
+            OriginalConversationId);
+
+    public static ForwardedFromDocument FromDomain(ForwardedFrom forwardedFrom) => new()
+    {
+        OriginalSenderId = forwardedFrom.OriginalSenderId,
+        OriginalSentAtUtc = forwardedFrom.OriginalSentAtUtc.UtcDateTime,
+        OriginalConversationId = forwardedFrom.OriginalConversationId,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
@@ -39,6 +39,46 @@ internal sealed class MessageDocument
     [BsonIgnoreIfNull]
     public DateTime? ReadAtUtc { get; set; }
 
+    [BsonElement("editedAtUtc")]
+    [BsonIgnoreIfNull]
+    public DateTime? EditedAtUtc { get; set; }
+
+    [BsonElement("editHistory")]
+    public List<EditHistoryEntryDocument> EditHistory { get; set; } = new();
+
+    [BsonElement("deletedAtUtc")]
+    [BsonIgnoreIfNull]
+    public DateTime? DeletedAtUtc { get; set; }
+
+    [BsonElement("deletedBy")]
+    [BsonIgnoreIfNull]
+    public Guid? DeletedBy { get; set; }
+
+    [BsonElement("deleteMode")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(MongoDB.Bson.BsonType.String)]
+    public DeleteMode? DeleteMode { get; set; }
+
+    [BsonElement("hiddenFor")]
+    public List<Guid> HiddenFor { get; set; } = new();
+
+    [BsonElement("reactions")]
+    public List<ReactionDocument> Reactions { get; set; } = new();
+
+    [BsonElement("mentions")]
+    public List<Guid> Mentions { get; set; } = new();
+
+    [BsonElement("replyTo")]
+    [BsonIgnoreIfNull]
+    public ReplyToDocument? ReplyTo { get; set; }
+
+    [BsonElement("forwardedFrom")]
+    [BsonIgnoreIfNull]
+    public ForwardedFromDocument? ForwardedFrom { get; set; }
+
+    [BsonElement("readBy")]
+    public List<ReadReceiptDocument> ReadBy { get; set; } = new();
+
     public Message ToDomain() => Message.Hydrate(
         Id,
         ConversationId,
@@ -49,7 +89,18 @@ internal sealed class MessageDocument
         State,
         new DateTimeOffset(DateTime.SpecifyKind(CreatedAtUtc, DateTimeKind.Utc)),
         DeliveredAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(DeliveredAtUtc.Value, DateTimeKind.Utc)) : null,
-        ReadAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(ReadAtUtc.Value, DateTimeKind.Utc)) : null);
+        ReadAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(ReadAtUtc.Value, DateTimeKind.Utc)) : null,
+        EditedAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(EditedAtUtc.Value, DateTimeKind.Utc)) : null,
+        EditHistory.Select(e => e.ToDomain()),
+        DeletedAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(DeletedAtUtc.Value, DateTimeKind.Utc)) : null,
+        DeletedBy,
+        DeleteMode,
+        HiddenFor,
+        Reactions.Select(r => r.ToDomain()),
+        Mentions,
+        ReplyTo?.ToDomain(),
+        ForwardedFrom?.ToDomain(),
+        ReadBy.Select(r => r.ToDomain()));
 
     public static MessageDocument FromDomain(Message message) => new()
     {
@@ -63,5 +114,16 @@ internal sealed class MessageDocument
         CreatedAtUtc = message.CreatedAtUtc.UtcDateTime,
         DeliveredAtUtc = message.DeliveredAtUtc?.UtcDateTime,
         ReadAtUtc = message.ReadAtUtc?.UtcDateTime,
+        EditedAtUtc = message.EditedAtUtc?.UtcDateTime,
+        EditHistory = message.EditHistory.Select(EditHistoryEntryDocument.FromDomain).ToList(),
+        DeletedAtUtc = message.DeletedAtUtc?.UtcDateTime,
+        DeletedBy = message.DeletedBy,
+        DeleteMode = message.DeleteMode,
+        HiddenFor = message.HiddenFor.ToList(),
+        Reactions = message.Reactions.Select(ReactionDocument.FromDomain).ToList(),
+        Mentions = message.Mentions.ToList(),
+        ReplyTo = message.ReplyTo is { } r ? ReplyToDocument.FromDomain(r) : null,
+        ForwardedFrom = message.ForwardedFrom is { } f ? ForwardedFromDocument.FromDomain(f) : null,
+        ReadBy = message.ReadBy.Select(ReadReceiptDocument.FromDomain).ToList(),
     };
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReactionDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReactionDocument.cs
@@ -1,0 +1,26 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class ReactionDocument
+{
+    [BsonElement("userId")]
+    public Guid UserId { get; set; }
+
+    [BsonElement("emoji")]
+    public string Emoji { get; set; } = string.Empty;
+
+    [BsonElement("createdAtUtc")]
+    public DateTime CreatedAtUtc { get; set; }
+
+    public Reaction ToDomain()
+        => new(UserId, Emoji, new DateTimeOffset(DateTime.SpecifyKind(CreatedAtUtc, DateTimeKind.Utc)));
+
+    public static ReactionDocument FromDomain(Reaction reaction) => new()
+    {
+        UserId = reaction.UserId,
+        Emoji = reaction.Emoji,
+        CreatedAtUtc = reaction.CreatedAtUtc.UtcDateTime,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReadReceiptDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReadReceiptDocument.cs
@@ -1,0 +1,22 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class ReadReceiptDocument
+{
+    [BsonElement("userId")]
+    public Guid UserId { get; set; }
+
+    [BsonElement("readAtUtc")]
+    public DateTime ReadAtUtc { get; set; }
+
+    public ReadReceipt ToDomain()
+        => new(UserId, new DateTimeOffset(DateTime.SpecifyKind(ReadAtUtc, DateTimeKind.Utc)));
+
+    public static ReadReceiptDocument FromDomain(ReadReceipt receipt) => new()
+    {
+        UserId = receipt.UserId,
+        ReadAtUtc = receipt.ReadAtUtc.UtcDateTime,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReplyToDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ReplyToDocument.cs
@@ -1,0 +1,25 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class ReplyToDocument
+{
+    [BsonElement("messageId")]
+    public Guid MessageId { get; set; }
+
+    [BsonElement("senderId")]
+    public Guid SenderId { get; set; }
+
+    [BsonElement("preview")]
+    public string Preview { get; set; } = string.Empty;
+
+    public ReplyTo ToDomain() => new(MessageId, SenderId, Preview);
+
+    public static ReplyToDocument FromDomain(ReplyTo replyTo) => new()
+    {
+        MessageId = replyTo.MessageId,
+        SenderId = replyTo.SenderId,
+        Preview = replyTo.Preview,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -1,3 +1,4 @@
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
@@ -315,7 +316,9 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
 
         var fb = Builders<MessageDocument>.Filter;
 
-        // Idempotent: same (user, emoji) is a noop.
+        // Same (user, emoji) is a noop on the wire — short-circuit before issuing an update.
+        // The atomic pipeline below is idempotent under concurrent same-emoji writes anyway,
+        // but the early exit saves a write when the request is a duplicate.
         var sameExistsCount = await context.Messages
             .CountDocumentsAsync(
                 fb.And(
@@ -330,18 +333,39 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             return false;
         }
 
-        // Pull any prior reaction by this user (different emoji).
-        var pullUpdate = Builders<MessageDocument>.Update
-            .PullFilter(m => m.Reactions, r => r.UserId == reaction.UserId);
-        await context.Messages
-            .UpdateOneAsync(m => m.Id == messageId, pullUpdate, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+        // Atomic pipeline update: in a single Mongo operation, drop any prior reaction by the
+        // same user, then append the new one. This holds the "one emoji per (user, message)"
+        // invariant under concurrent writes from the same user — pull-then-push as separate
+        // updates left a window where two reactions could both be appended.
+        var newReactionBson = new BsonDocument
+        {
+            { "userId", new BsonBinaryData(reaction.UserId, GuidRepresentation.Standard) },
+            { "emoji", reaction.Emoji },
+            { "createdAtUtc", reaction.CreatedAtUtc.UtcDateTime },
+        };
+        var setStage = new BsonDocument("$set", new BsonDocument("reactions", new BsonDocument("$concatArrays", new BsonArray
+        {
+            new BsonDocument("$filter", new BsonDocument
+            {
+                { "input", new BsonDocument("$ifNull", new BsonArray { "$reactions", new BsonArray() }) },
+                { "as", "r" },
+                { "cond", new BsonDocument("$ne", new BsonArray
+                {
+                    "$$r.userId",
+                    new BsonBinaryData(reaction.UserId, GuidRepresentation.Standard),
+                }) },
+            }),
+            new BsonArray { newReactionBson },
+        })));
 
-        // Push new reaction.
-        var pushUpdate = Builders<MessageDocument>.Update
-            .Push(m => m.Reactions, ReactionDocument.FromDomain(reaction));
+        PipelineDefinition<MessageDocument, MessageDocument> pipeline = new[] { setStage };
+        var update = Builders<MessageDocument>.Update.Pipeline(pipeline);
+
         var result = await context.Messages
-            .UpdateOneAsync(m => m.Id == messageId, pushUpdate, cancellationToken: cancellationToken)
+            .UpdateOneAsync(
+                fb.And(fb.Eq(m => m.Id, messageId), fb.Ne(m => m.State, MessageState.Deleted)),
+                update,
+                cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         return result.ModifiedCount > 0;

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -2,6 +2,7 @@ using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
 
 namespace Urfu.Link.Services.Chat.Infrastructure.Persistence;
@@ -15,6 +16,30 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
         return doc?.ToDomain();
+    }
+
+    public async Task<IReadOnlyList<Message>> GetByIdsAsync(
+        string conversationId,
+        IReadOnlyList<Guid> messageIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(messageIds);
+        if (messageIds.Count == 0)
+        {
+            return Array.Empty<Message>();
+        }
+
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.ConversationId, conversationId),
+            fb.In(m => m.Id, messageIds));
+
+        var docs = await context.Messages
+            .Find(filter)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return docs.Select(d => d.ToDomain()).ToList();
     }
 
     public async Task InsertAsync(Message message, CancellationToken cancellationToken)
@@ -190,5 +215,166 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             .ConfigureAwait(false);
 
         return upToMessageId;
+    }
+
+    public async Task<bool> ApplyEditAsync(
+        Guid messageId,
+        string newBody,
+        IReadOnlyList<Guid> mentions,
+        EditHistoryEntry historyEntry,
+        DateTimeOffset editedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(mentions);
+        ArgumentNullException.ThrowIfNull(historyEntry);
+
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.Id, messageId),
+            fb.Ne(m => m.State, MessageState.Deleted));
+        var update = Builders<MessageDocument>.Update
+            .Set(m => m.Body, newBody ?? string.Empty)
+            .Set(m => m.Mentions, mentions.ToList())
+            .Set(m => m.EditedAtUtc, editedAtUtc.UtcDateTime)
+            .Push(m => m.EditHistory, EditHistoryEntryDocument.FromDomain(historyEntry));
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> ApplyDeleteForEveryoneAsync(
+        Guid messageId,
+        Guid byUserId,
+        DateTimeOffset deletedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.Id, messageId),
+            fb.Ne(m => m.State, MessageState.Deleted));
+        var update = Builders<MessageDocument>.Update
+            .Set(m => m.State, MessageState.Deleted)
+            .Set(m => m.DeletedAtUtc, deletedAtUtc.UtcDateTime)
+            .Set(m => m.DeletedBy, byUserId)
+            .Set(m => m.DeleteMode, DeleteMode.ForEveryone)
+            .Set(m => m.Body, string.Empty)
+            .Set(m => m.Attachments, new List<AttachmentDocument>())
+            .Set(m => m.Reactions, new List<ReactionDocument>())
+            .Set(m => m.Mentions, new List<Guid>())
+            .Set(m => m.ReplyTo, (ReplyToDocument?)null)
+            .Set(m => m.ForwardedFrom, (ForwardedFromDocument?)null);
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> AddHiddenForAsync(Guid messageId, Guid userId, CancellationToken cancellationToken)
+    {
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.Id, messageId),
+            fb.Not(fb.AnyEq(m => m.HiddenFor, userId)));
+        var update = Builders<MessageDocument>.Update.AddToSet(m => m.HiddenFor, userId);
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> AddReactionAsync(Guid messageId, Reaction reaction, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reaction);
+
+        var fb = Builders<MessageDocument>.Filter;
+
+        // Idempotent: same (user, emoji) is a noop.
+        var sameExistsCount = await context.Messages
+            .CountDocumentsAsync(
+                fb.And(
+                    fb.Eq(m => m.Id, messageId),
+                    fb.ElemMatch(
+                        m => m.Reactions,
+                        r => r.UserId == reaction.UserId && r.Emoji == reaction.Emoji)),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (sameExistsCount > 0)
+        {
+            return false;
+        }
+
+        // Pull any prior reaction by this user (different emoji).
+        var pullUpdate = Builders<MessageDocument>.Update
+            .PullFilter(m => m.Reactions, r => r.UserId == reaction.UserId);
+        await context.Messages
+            .UpdateOneAsync(m => m.Id == messageId, pullUpdate, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        // Push new reaction.
+        var pushUpdate = Builders<MessageDocument>.Update
+            .Push(m => m.Reactions, ReactionDocument.FromDomain(reaction));
+        var result = await context.Messages
+            .UpdateOneAsync(m => m.Id == messageId, pushUpdate, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> RemoveReactionAsync(
+        Guid messageId,
+        Guid userId,
+        string emoji,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(emoji);
+
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.Id, messageId),
+            fb.ElemMatch(m => m.Reactions, r => r.UserId == userId && r.Emoji == emoji));
+        var update = Builders<MessageDocument>.Update
+            .PullFilter(m => m.Reactions, r => r.UserId == userId && r.Emoji == emoji);
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<bool> AddReadByAsync(Guid messageId, ReadReceipt receipt, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.And(
+            fb.Eq(m => m.Id, messageId),
+            fb.Ne(m => m.State, MessageState.Deleted),
+            fb.Not(fb.ElemMatch(m => m.ReadBy, r => r.UserId == receipt.UserId)));
+        var update = Builders<MessageDocument>.Update
+            .Push(m => m.ReadBy, ReadReceiptDocument.FromDomain(receipt));
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<IReadOnlyList<ReadReceipt>> GetReadReceiptsAsync(
+        Guid messageId,
+        CancellationToken cancellationToken)
+    {
+        var doc = await context.Messages
+            .Find(m => m.Id == messageId)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (doc is null)
+        {
+            return Array.Empty<ReadReceipt>();
+        }
+        return doc.ReadBy.Select(r => r.ToDomain()).ToList();
     }
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -42,6 +42,26 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         return docs.Select(d => d.ToDomain()).ToList();
     }
 
+    public async Task<IReadOnlyList<Message>> GetManyAsync(
+        IReadOnlyList<Guid> messageIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(messageIds);
+        if (messageIds.Count == 0)
+        {
+            return Array.Empty<Message>();
+        }
+
+        var filter = Builders<MessageDocument>.Filter.In(m => m.Id, messageIds);
+
+        var docs = await context.Messages
+            .Find(filter)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return docs.Select(d => d.ToDomain()).ToList();
+    }
+
     public async Task InsertAsync(Message message, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -153,7 +153,7 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         return transitioningIds;
     }
 
-    public async Task<Guid?> MarkReadUpToAsync(
+    public async Task<IReadOnlyList<Guid>> MarkReadUpToAsync(
         string conversationId,
         Guid upToMessageId,
         DateTimeOffset readAtUtc,
@@ -165,7 +165,7 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             .ConfigureAwait(false);
         if (anchor is null)
         {
-            return null;
+            return Array.Empty<Guid>();
         }
 
         var fb = Builders<MessageDocument>.Filter;
@@ -180,13 +180,16 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
 
         var transitioned = await context.Messages
             .Find(filter)
+            // Sort oldest → newest so callers see ids in chronological order. The anchor sits
+            // at the tail of the list.
+            .Sort(Builders<MessageDocument>.Sort.Ascending(m => m.CreatedAtUtc).Ascending(m => m.Id))
             .Project(m => new { m.Id, m.DeliveredAtUtc })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (transitioned.Count == 0)
         {
-            return null;
+            return Array.Empty<Guid>();
         }
 
         var ts = readAtUtc.UtcDateTime;
@@ -214,7 +217,7 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return upToMessageId;
+        return transitioned.Select(t => t.Id).ToList();
     }
 
     public async Task<bool> ApplyEditAsync(

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
@@ -50,6 +50,14 @@ internal sealed class MongoIndexInitializer(ChatMongoContext context) : IHostedS
                         Unique = true,
                         Sparse = true,
                     }),
+                new CreateIndexModel<MessageDocument>(
+                    Builders<MessageDocument>.IndexKeys.Ascending(m => m.Mentions),
+                    new CreateIndexOptions
+                    {
+                        Name = "ix_messages_mentions",
+                        Background = true,
+                        Sparse = true,
+                    }),
             },
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -89,7 +89,7 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
     {
         ArgumentNullException.ThrowIfNull(recipientUserIds);
         return hub.Clients.Users(ToUserIds(recipientUserIds))
-            .MessageDeletedUpdate(conversationId, messageId, mode.ToString(), deletedBy);
+            .MessageDeletedUpdate(conversationId, messageId, mode.ToWire(), deletedBy);
     }
 
     public Task NotifyReactionUpdatedAsync(

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -79,6 +79,17 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
             .MessageDeletedUpdate(conversationId, messageId, mode.ToString(), deletedBy);
     }
 
+    public Task NotifyReactionUpdatedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        Guid messageId,
+        IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipientUserIds);
+        ArgumentNullException.ThrowIfNull(summary);
+        return hub.Clients.Users(ToUserIds(recipientUserIds)).ReactionUpdated(messageId, summary);
+    }
+
     private static List<string> ToUserIds(IReadOnlyList<Guid> userIds)
         => userIds.Select(u => u.ToString("D", CultureInfo.InvariantCulture)).ToList();
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -90,6 +90,17 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
         return hub.Clients.Users(ToUserIds(recipientUserIds)).ReactionUpdated(messageId, summary);
     }
 
+    public Task NotifyPinsUpdatedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        IReadOnlyList<MessageDto> pinnedMessages,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipientUserIds);
+        ArgumentNullException.ThrowIfNull(pinnedMessages);
+        return hub.Clients.Users(ToUserIds(recipientUserIds)).PinsUpdated(conversationId, pinnedMessages);
+    }
+
     private static List<string> ToUserIds(IReadOnlyList<Guid> userIds)
         => userIds.Select(u => u.ToString("D", CultureInfo.InvariantCulture)).ToList();
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Microsoft.AspNetCore.SignalR;
 using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Enums;
 
 namespace Urfu.Link.Services.Chat.Realtime;
 
@@ -54,6 +55,28 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
         ArgumentNullException.ThrowIfNull(recipientUserIds);
         return hub.Clients.Users(ToUserIds(recipientUserIds))
             .MessageReadUpdate(conversationId, upToMessageId, readerUserId);
+    }
+
+    public Task NotifyMessageEditedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        MessageDto message,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipientUserIds);
+        return hub.Clients.Users(ToUserIds(recipientUserIds)).MessageEdited(message);
+    }
+
+    public Task NotifyMessageDeletedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        Guid messageId,
+        DeleteMode mode,
+        Guid deletedBy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipientUserIds);
+        return hub.Clients.Users(ToUserIds(recipientUserIds))
+            .MessageDeletedUpdate(conversationId, messageId, mode.ToString(), deletedBy);
     }
 
     private static List<string> ToUserIds(IReadOnlyList<Guid> userIds)

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -57,6 +57,19 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
             .MessageReadUpdate(conversationId, upToMessageId, readerUserId);
     }
 
+    public Task NotifyMessageReadByAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        Guid messageId,
+        Guid readerUserId,
+        DateTimeOffset readAtUtc,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipientUserIds);
+        return hub.Clients.Users(ToUserIds(recipientUserIds))
+            .MessageReadByUpdate(conversationId, messageId, readerUserId, readAtUtc);
+    }
+
     public Task NotifyMessageEditedAsync(
         IReadOnlyList<Guid> recipientUserIds,
         MessageDto message,

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.SignalR;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
 
 namespace Urfu.Link.Services.Chat.Realtime;
@@ -11,14 +12,19 @@ public sealed record SendMessageHubInput(
     string ConversationId,
     string Body,
     IReadOnlyList<Guid> AttachmentAssetIds,
-    string ClientMessageId);
+    string ClientMessageId,
+    Guid? ReplyToMessageId = null);
+
+public sealed record EditMessageHubInput(Guid MessageId, string NewBody);
 
 [Authorize]
 public sealed class ChatHub(
     OpenDirectConversationService openDirect,
     SendMessageService sendMessage,
     MarkDeliveredService markDelivered,
-    MarkReadService markRead) : Hub<IChatClient>
+    MarkReadService markRead,
+    EditMessageService editMessage,
+    DeleteMessageService deleteMessage) : Hub<IChatClient>
 {
     public async Task<ConversationDto> OpenDirectConversation(Guid peerUserId)
     {
@@ -33,7 +39,13 @@ public sealed class ChatHub(
         var caller = Context.User!.GetUserId();
         var assetIds = input.AttachmentAssetIds ?? Array.Empty<Guid>();
         return sendMessage.SendAsync(
-            new SendMessageRequest(input.ConversationId, caller, input.Body ?? string.Empty, assetIds, input.ClientMessageId),
+            new SendMessageRequest(
+                input.ConversationId,
+                caller,
+                input.Body ?? string.Empty,
+                assetIds,
+                input.ClientMessageId,
+                input.ReplyToMessageId),
             Context.ConnectionAborted);
     }
 
@@ -51,5 +63,35 @@ public sealed class ChatHub(
         return markRead.MarkAsync(
             new MarkReadRequest(conversationId, caller, upToMessageId),
             Context.ConnectionAborted);
+    }
+
+    public Task<MessageDto> EditMessage(EditMessageHubInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        var caller = Context.User!.GetUserId();
+        return editMessage.EditAsync(
+            new EditMessageRequest(input.MessageId, caller, input.NewBody ?? string.Empty),
+            Context.ConnectionAborted);
+    }
+
+    public Task<MessageDto?> DeleteMessage(Guid messageId, string mode)
+    {
+        var caller = Context.User!.GetUserId();
+        var deleteMode = ParseMode(mode);
+        return deleteMessage.DeleteAsync(
+            new DeleteMessageRequest(messageId, caller, deleteMode),
+            Context.ConnectionAborted);
+    }
+
+    private static DeleteMode ParseMode(string mode)
+    {
+        return mode switch
+        {
+            "for-me" => DeleteMode.ForMe,
+            "for-everyone" => DeleteMode.ForEveryone,
+            _ => throw new ArgumentException(
+                $"Unsupported delete mode '{mode}'. Use 'for-me' or 'for-everyone'.",
+                nameof(mode)),
+        };
     }
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -5,6 +5,7 @@ using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
+// PinMessageService and UnpinMessageService live in Application.Conversations.
 
 namespace Urfu.Link.Services.Chat.Realtime;
 
@@ -27,7 +28,9 @@ public sealed class ChatHub(
     DeleteMessageService deleteMessage,
     ForwardMessagesService forwardMessages,
     AddReactionService addReaction,
-    RemoveReactionService removeReaction) : Hub<IChatClient>
+    RemoveReactionService removeReaction,
+    PinMessageService pinMessage,
+    UnpinMessageService unpinMessage) : Hub<IChatClient>
 {
     public async Task<ConversationDto> OpenDirectConversation(Guid peerUserId)
     {
@@ -107,6 +110,22 @@ public sealed class ChatHub(
         var caller = Context.User!.GetUserId();
         return removeReaction.RemoveAsync(
             new RemoveReactionRequest(messageId, caller, emoji ?? string.Empty),
+            Context.ConnectionAborted);
+    }
+
+    public Task<IReadOnlyList<MessageDto>> PinMessage(string conversationId, Guid messageId)
+    {
+        var caller = Context.User!.GetUserId();
+        return pinMessage.PinAsync(
+            new PinMessageRequest(conversationId, caller, messageId),
+            Context.ConnectionAborted);
+    }
+
+    public Task<IReadOnlyList<MessageDto>> UnpinMessage(string conversationId, Guid messageId)
+    {
+        var caller = Context.User!.GetUserId();
+        return unpinMessage.UnpinAsync(
+            new UnpinMessageRequest(conversationId, caller, messageId),
             Context.ConnectionAborted);
     }
 

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -24,7 +24,8 @@ public sealed class ChatHub(
     MarkDeliveredService markDelivered,
     MarkReadService markRead,
     EditMessageService editMessage,
-    DeleteMessageService deleteMessage) : Hub<IChatClient>
+    DeleteMessageService deleteMessage,
+    ForwardMessagesService forwardMessages) : Hub<IChatClient>
 {
     public async Task<ConversationDto> OpenDirectConversation(Guid peerUserId)
     {
@@ -80,6 +81,14 @@ public sealed class ChatHub(
         var deleteMode = ParseMode(mode);
         return deleteMessage.DeleteAsync(
             new DeleteMessageRequest(messageId, caller, deleteMode),
+            Context.ConnectionAborted);
+    }
+
+    public Task<IReadOnlyList<MessageDto>> ForwardMessages(string targetConversationId, IReadOnlyList<Guid> messageIds)
+    {
+        var caller = Context.User!.GetUserId();
+        return forwardMessages.ForwardAsync(
+            new ForwardMessagesRequest(targetConversationId, caller, messageIds ?? Array.Empty<Guid>()),
             Context.ConnectionAborted);
     }
 

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -83,7 +83,7 @@ public sealed class ChatHub(
     public Task<MessageDto?> DeleteMessage(Guid messageId, string mode)
     {
         var caller = Context.User!.GetUserId();
-        var deleteMode = ParseMode(mode);
+        var deleteMode = DeleteModes.Parse(mode);
         return deleteMessage.DeleteAsync(
             new DeleteMessageRequest(messageId, caller, deleteMode),
             Context.ConnectionAborted);
@@ -129,15 +129,4 @@ public sealed class ChatHub(
             Context.ConnectionAborted);
     }
 
-    private static DeleteMode ParseMode(string mode)
-    {
-        return mode switch
-        {
-            "for-me" => DeleteMode.ForMe,
-            "for-everyone" => DeleteMode.ForEveryone,
-            _ => throw new ArgumentException(
-                $"Unsupported delete mode '{mode}'. Use 'for-me' or 'for-everyone'.",
-                nameof(mode)),
-        };
-    }
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -25,7 +25,9 @@ public sealed class ChatHub(
     MarkReadService markRead,
     EditMessageService editMessage,
     DeleteMessageService deleteMessage,
-    ForwardMessagesService forwardMessages) : Hub<IChatClient>
+    ForwardMessagesService forwardMessages,
+    AddReactionService addReaction,
+    RemoveReactionService removeReaction) : Hub<IChatClient>
 {
     public async Task<ConversationDto> OpenDirectConversation(Guid peerUserId)
     {
@@ -89,6 +91,22 @@ public sealed class ChatHub(
         var caller = Context.User!.GetUserId();
         return forwardMessages.ForwardAsync(
             new ForwardMessagesRequest(targetConversationId, caller, messageIds ?? Array.Empty<Guid>()),
+            Context.ConnectionAborted);
+    }
+
+    public Task AddReaction(Guid messageId, string emoji)
+    {
+        var caller = Context.User!.GetUserId();
+        return addReaction.AddAsync(
+            new AddReactionRequest(messageId, caller, emoji ?? string.Empty),
+            Context.ConnectionAborted);
+    }
+
+    public Task RemoveReaction(Guid messageId, string emoji)
+    {
+        var caller = Context.User!.GetUserId();
+        return removeReaction.RemoveAsync(
+            new RemoveReactionRequest(messageId, caller, emoji ?? string.Empty),
             Context.ConnectionAborted);
     }
 

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -1,4 +1,5 @@
 using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Enums;
 
 namespace Urfu.Link.Services.Chat.Realtime;
 
@@ -30,5 +31,18 @@ public interface IChatBroadcaster
         string conversationId,
         Guid upToMessageId,
         Guid readerUserId,
+        CancellationToken cancellationToken);
+
+    Task NotifyMessageEditedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        MessageDto message,
+        CancellationToken cancellationToken);
+
+    Task NotifyMessageDeletedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        Guid messageId,
+        DeleteMode mode,
+        Guid deletedBy,
         CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -45,4 +45,10 @@ public interface IChatBroadcaster
         DeleteMode mode,
         Guid deletedBy,
         CancellationToken cancellationToken);
+
+    Task NotifyReactionUpdatedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        Guid messageId,
+        IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -51,4 +51,10 @@ public interface IChatBroadcaster
         Guid messageId,
         IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary,
         CancellationToken cancellationToken);
+
+    Task NotifyPinsUpdatedAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        IReadOnlyList<MessageDto> pinnedMessages,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -33,6 +33,14 @@ public interface IChatBroadcaster
         Guid readerUserId,
         CancellationToken cancellationToken);
 
+    Task NotifyMessageReadByAsync(
+        IReadOnlyList<Guid> recipientUserIds,
+        string conversationId,
+        Guid messageId,
+        Guid readerUserId,
+        DateTimeOffset readAtUtc,
+        CancellationToken cancellationToken);
+
     Task NotifyMessageEditedAsync(
         IReadOnlyList<Guid> recipientUserIds,
         MessageDto message,

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -18,4 +18,6 @@ public interface IChatClient
     Task MessageEdited(MessageDto message);
 
     Task MessageDeletedUpdate(string conversationId, Guid messageId, string mode, Guid deletedBy);
+
+    Task ReactionUpdated(Guid messageId, IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -15,6 +15,8 @@ public interface IChatClient
 
     Task MessageReadUpdate(string conversationId, Guid upToMessageId, Guid readerUserId);
 
+    Task MessageReadByUpdate(string conversationId, Guid messageId, Guid readerUserId, DateTimeOffset readAtUtc);
+
     Task MessageEdited(MessageDto message);
 
     Task MessageDeletedUpdate(string conversationId, Guid messageId, string mode, Guid deletedBy);

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -20,4 +20,6 @@ public interface IChatClient
     Task MessageDeletedUpdate(string conversationId, Guid messageId, string mode, Guid deletedBy);
 
     Task ReactionUpdated(Guid messageId, IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary);
+
+    Task PinsUpdated(string conversationId, IReadOnlyList<MessageDto> pinnedMessages);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -14,4 +14,8 @@ public interface IChatClient
     Task MessageDeliveredUpdate(string conversationId, IReadOnlyList<Guid> messageIds, Guid recipientUserId);
 
     Task MessageReadUpdate(string conversationId, Guid upToMessageId, Guid readerUserId);
+
+    Task MessageEdited(MessageDto message);
+
+    Task MessageDeletedUpdate(string conversationId, Guid messageId, string mode, Guid deletedBy);
 }

--- a/src/Services/Chat/ChatService.Api/appsettings.json
+++ b/src/Services/Chat/ChatService.Api/appsettings.json
@@ -30,5 +30,14 @@
         "MediaService": {
             "Address": "http://media-service:8080"
         }
+    },
+    "Chat": {
+        "EditTtlHours": 48,
+        "DeleteForEveryoneTtlHours": 48,
+        "MaxPinnedMessages": 5,
+        "MaxForwardedMessages": 50,
+        "AllowedReactionEmojis": [],
+        "MaxReactionEmojiLength": 16,
+        "MaxMentionsPerMessage": 50
     }
 }

--- a/src/Services/Chat/README.md
+++ b/src/Services/Chat/README.md
@@ -2,29 +2,65 @@
 
 ## Responsibility
 
-1-on-1 direct messaging: open conversations, send and receive messages with attachments,
-deliver and read receipts, and history retrieval. Group chats / channels are out of scope.
+Direct (1-on-1) messaging plus the messenger feature surface from #211: edit/delete with TTL,
+reply, forward, reactions, mentions, pinned messages, and group-aware read receipts. The
+service stores conversations and messages in MongoDB, broadcasts state changes over SignalR,
+and emits Kafka integration events on `urfu.chat.events.v1` for downstream services
+(NotificationService, analytics).
+
+Discipline / group chats are scaffolded but disabled at the policy layer until #214 wires up
+real teacher/student role resolution; until then `IDisciplineRoleResolver` allows direct
+participants to pin and rejects all group-chat pin attempts.
 
 ## Modules
 
-- `Domain/` — `Conversation` (deterministic SHA1 id derived from the sorted user pair),
-  `Message` (state machine: `Sent → Delivered → Read`), value objects (`Attachment`,
-  `MessagePreview`) and four integration events (`ChatConversationCreatedEvent`,
-  `ChatMessageSentEvent`, `ChatMessageDeliveredEvent`, `ChatMessageReadEvent`).
-- `Application/` — use cases (`OpenDirectConversation`, `SendMessage`, `MarkDelivered`,
-  `MarkRead`) and cursor-paginated queries (`GetUserConversations`, `GetConversation`,
-  `GetConversationMessages`). `CursorCodec` encodes opaque pagination cursors as base64-url
-  JSON. `ChatEventDispatcher` enqueues events into the outbox.
+- `Domain/`
+  - `Conversation` — deterministic SHA1 id derived from the sorted user pair, plus
+    `PinnedMessageIds` with cap-aware `PinMessage`/`UnpinMessage`.
+  - `Message` — state machine `Sent → Delivered → Read [→ Deleted]` with feature methods:
+    `Edit`, `MarkDeletedForEveryone`, `MarkDeletedForMe`, `AddReaction`, `RemoveReaction`,
+    `MarkReadBy`. TTL/author guards live in `IsEditableBy` / `IsDeletableForEveryoneBy`.
+  - Value objects: `Attachment`, `MessagePreview`, `Reaction`, `EditHistoryEntry`, `ReplyTo`,
+    `ForwardedFrom`, `ReadReceipt`.
+  - Enums: `MessageState`, `ConversationType` (`Direct`, `Group`), `DeleteMode`
+    (`ForMe`, `ForEveryone`).
+  - Integration events — see the table below.
+- `Application/`
+  - Use cases: `OpenDirectConversation`, `SendMessage` (handles reply, mentions, attachment
+    grants), `MarkDelivered`, `MarkRead` (also populates `ReadBy[]`), `EditMessage`,
+    `DeleteMessage`, `ForwardMessages`, `AddReaction`, `RemoveReaction`, `PinMessage`,
+    `UnpinMessage`.
+  - Queries: `GetUserConversations`, `GetConversation`, `GetConversationMessages`,
+    `GetReadReceipts`.
+  - `Mentions/MentionsParser` — extracts `@<guid>`, `@everyone`, and the discipline-only
+    `@teachers`/`@students` tokens (stubbed empty until #214). Drops non-participants and
+    caps at `Chat:MaxMentionsPerMessage`.
+  - `Authorization/IDisciplineRoleResolver` — pin authz hook; default impl in `Infrastructure/`.
+  - `ChatEventDispatcher` enqueues events into the outbox.
 - `Infrastructure/Persistence/` — MongoDB adapters: `ChatMongoContext`,
   `MongoIndexInitializer` (idempotent index setup at startup), `Conversation`/`Message`
-  repositories, BSON document POCOs.
+  repositories, BSON document POCOs (including embedded docs for reactions, edit history,
+  reply-to, forwarded-from, and read receipts).
 - `Infrastructure/Grpc/` — typed wrapper around `MediaService.InternalApi` gRPC client with
-  built-in retries on transient failures.
+  built-in retries on transient failures. `GrantConversationAccessAsync` is reused for
+  forward fan-out so attachments stay accessible to the new conversation participants.
 - `Realtime/` — SignalR `ChatHub` mounted at `/hubs/chat` with strongly-typed `IChatClient`
   contract; broadcasts via `IChatBroadcaster`.
 - `Endpoints/` — FastEndpoints under `/api/v1/chat/*` for REST fallback and initial load.
 - `Services/InternalApiService` — internal gRPC for sister services (NotificationService,
   MediaService) to query participants / membership.
+
+## Configuration (`Chat:` section in `appsettings.json`)
+
+| Key | Default | Purpose |
+|---|---|---|
+| `EditTtlHours` | `48` | Window in which the author can edit a message. |
+| `DeleteForEveryoneTtlHours` | `48` | Window in which the author can `delete-for-everyone`. |
+| `MaxPinnedMessages` | `5` | Cap on `Conversation.PinnedMessageIds`. |
+| `MaxForwardedMessages` | `50` | Per-request cap on `ForwardMessages`. |
+| `AllowedReactionEmojis` | `[]` | Empty = any non-empty emoji ≤ `MaxReactionEmojiLength`. |
+| `MaxReactionEmojiLength` | `16` | UTF-16 length cap on a reaction emoji. |
+| `MaxMentionsPerMessage` | `50` | Cap on parsed mentions per message. |
 
 ## Data ownership
 
@@ -32,8 +68,9 @@ deliver and read receipts, and history retrieval. Group chats / channels are out
   - Collection `conversations` — indexes on `participants` (multikey) and `lastMessageAtUtc`
     (descending).
   - Collection `messages` — composite indexes `(conversationId, createdAtUtc desc)` and
-    `(senderId, createdAtUtc desc)`, plus a unique sparse index on
-    `(senderId, clientMessageId)` as the safety-net for SendMessage idempotency.
+    `(senderId, createdAtUtc desc)`, a unique sparse index on
+    `(senderId, clientMessageId)` for `SendMessage` idempotency, and a sparse index on
+    `mentions` for future mention search.
 - Redis: shared `IIdempotencyStore` (BuildingBlocks) for hot-path duplicate detection of
   SendMessage by `(senderId, clientMessageId)`.
 
@@ -44,11 +81,61 @@ active connection a user has. JWT comes from the `Authorization: Bearer` header 
 HTTP upgrade or, for transports that can't set headers, from `?access_token=` on the
 `/hubs/*` paths.
 
+### Hub methods (client → server)
+
+`OpenDirectConversation`, `SendMessage` (with optional `ReplyToMessageId`), `MarkDelivered`,
+`MarkRead`, `EditMessage`, `DeleteMessage`, `ForwardMessages`, `AddReaction`,
+`RemoveReaction`, `PinMessage`, `UnpinMessage`.
+
+### Broadcasts (`IChatClient`, server → client)
+
+`ConversationUpdated`, `MessageReceived`, `MessageDeliveredUpdate`, `MessageReadUpdate`,
+`MessageReadByUpdate` (group-aware), `MessageEdited`, `MessageDeletedUpdate`,
+`ReactionUpdated`, `PinsUpdated`.
+
+### Typing indicators
+
+ChatService does **not** track typing. Clients should call `PresenceHub.StartTyping` /
+`PresenceHub.StopTyping` from #208 directly. Auto-stop on `SendMessage` is the client's
+responsibility for now.
+
+## REST endpoints (`/api/v1/chat/*`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/conversations/direct` | Open or fetch a direct conversation. |
+| `GET` | `/conversations` | Cursor-paginated list of caller's conversations. |
+| `GET` | `/conversations/{id}` | Single conversation. |
+| `GET` | `/conversations/{id}/messages` | Cursor-paginated history. |
+| `POST` | `/conversations/{id}/forward` | Forward up to `MaxForwardedMessages` messages here. |
+| `POST` | `/conversations/{id}/pinned` | Pin a message in this conversation. |
+| `DELETE` | `/conversations/{id}/pinned/{messageId}` | Unpin. |
+| `PATCH` | `/messages/{id}` | Edit a message body. Author + TTL guards. |
+| `DELETE` | `/messages/{id}?mode=for-me\|for-everyone` | Hide locally or tombstone for all. |
+| `POST` | `/messages/{id}/reactions` | Add or replace caller's reaction. |
+| `DELETE` | `/messages/{id}/reactions/{emoji}` | Remove caller's reaction. |
+| `GET` | `/messages/{id}/read-receipts` | List of `ReadReceipt`s on the message. |
+
 ## Integration events (Kafka topic `urfu.chat.events.v1`)
 
-| Event type | Payload | Consumed by |
+| Event type | Payload highlights | Consumed by |
 |---|---|---|
 | `chat.conversation.created.v1` | conversationId, participants | NotificationService (future) |
-| `chat.message.sent.v1` | conversationId, messageId, senderId, recipients, preview | NotificationService (future) |
+| `chat.message.sent.v1` | conversationId, messageId, senderId, recipients, preview, mentions | NotificationService (future) |
 | `chat.message.delivered.v1` | conversationId, messageId, recipientUserId | analytics |
 | `chat.message.read.v1` | conversationId, upToMessageId, readerUserId | analytics |
+| `chat.message.edited.v1` | conversationId, messageId, editorUserId, newBody, mentions, editedAtUtc | analytics |
+| `chat.message.deleted.v1` | conversationId, messageId, deleteMode, deletedBy | analytics |
+| `chat.reaction.added.v1` | conversationId, messageId, userId, emoji | analytics |
+| `chat.reaction.removed.v1` | conversationId, messageId, userId, emoji | analytics |
+| `chat.mention.created.v1` | conversationId, messageId, senderId, mentionedUserIds | NotificationService (#209) |
+| `chat.message.pinned.v1` | conversationId, messageId, pinnedByUserId | analytics |
+| `chat.message.unpinned.v1` | conversationId, messageId, unpinnedByUserId | analytics |
+
+## Out of scope (#211)
+
+- Discipline group chats themselves (#214). `ConversationType.Group` and the role-resolver
+  contract are in place but no service opens group conversations yet.
+- Real `@teachers` / `@students` resolution — currently expanded to an empty set.
+- NotificationService consumer for `chat.mention.created.v1` (#209). The event ships, the
+  consumer arrives later.

--- a/tests/integration/ChatService.IntegrationTests/Conversations/PinningTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Conversations/PinningTests.cs
@@ -1,0 +1,139 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Conversations;
+
+[Collection(IntegrationCollection.Name)]
+public class PinningTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public PinningTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PinMessage_DirectConversation_AddsToPinnedListAndPublishesEvent()
+    {
+        var (sender, _, conv, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var pin = scope.ServiceProvider.GetRequiredService<PinMessageService>();
+
+        var pinned = await pin.PinAsync(new PinMessageRequest(conv.Id, sender, msg.Id), default);
+
+        pinned.Should().ContainSingle(m => m.Id == msg.Id);
+        var loaded = await scope.ServiceProvider.GetRequiredService<IConversationRepository>()
+            .GetByIdAsync(conv.Id, default);
+        loaded!.PinnedMessageIds.Should().Contain(msg.Id);
+
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMessagePinnedEvent>()
+            .Should().ContainSingle(e => e.MessageId == msg.Id && e.PinnedByUserId == sender);
+    }
+
+    [Fact]
+    public async Task PinMessage_AtCap_ThrowsLimit()
+    {
+        var (sender, _, conv, _) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var convRepo = scope.ServiceProvider.GetRequiredService<IConversationRepository>();
+        for (var i = 0; i < 5; i++)
+        {
+            await convRepo.AddPinnedMessageAsync(conv.Id, Guid.NewGuid(), maxPinned: 5, default);
+        }
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var sixthMsg = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "sixth", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var pin = scope.ServiceProvider.GetRequiredService<PinMessageService>();
+        var act = () => pin.PinAsync(new PinMessageRequest(conv.Id, sender, sixthMsg.Id), default);
+
+        await act.Should().ThrowAsync<ChatPinLimitExceededException>();
+    }
+
+    [Fact]
+    public async Task PinMessage_GroupConversation_RejectedByDefaultDisciplineResolver()
+    {
+        var caller = Guid.NewGuid();
+        var groupMember = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var convRepo = scope.ServiceProvider.GetRequiredService<IConversationRepository>();
+        var groupConv = Conversation.Hydrate(
+            id: $"group-{Guid.NewGuid():N}",
+            type: ConversationType.Group,
+            participants: new[] { caller, groupMember },
+            createdAtUtc: DateTimeOffset.UtcNow,
+            lastMessageAtUtc: DateTimeOffset.UtcNow,
+            lastMessagePreview: null);
+        await convRepo.TryCreateAsync(groupConv, default);
+
+        // Tighten the fake to match production stub: only Direct conversations allow pinning.
+        _factory.DisciplineRoleResolver.Predicate = (_, c) => c.Type == ConversationType.Direct;
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var msg = await send.SendAsync(
+            new SendMessageRequest(groupConv.Id, caller, "in group", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var pin = scope.ServiceProvider.GetRequiredService<PinMessageService>();
+        var act = () => pin.PinAsync(new PinMessageRequest(groupConv.Id, caller, msg.Id), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task UnpinMessage_PinnedMessage_RemovesAndPublishes()
+    {
+        var (sender, _, conv, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var pin = scope.ServiceProvider.GetRequiredService<PinMessageService>();
+        await pin.PinAsync(new PinMessageRequest(conv.Id, sender, msg.Id), default);
+        _factory.OutboxWriter.Clear();
+
+        var unpin = scope.ServiceProvider.GetRequiredService<UnpinMessageService>();
+        var pinnedAfter = await unpin.UnpinAsync(new UnpinMessageRequest(conv.Id, sender, msg.Id), default);
+
+        pinnedAfter.Should().BeEmpty();
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMessageUnpinnedEvent>()
+            .Should().ContainSingle(e => e.MessageId == msg.Id);
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "to pin", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/MessengerEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/MessengerEndpointsTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Net.Http.Json;
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Endpoints;
+
+[Collection(IntegrationCollection.Name)]
+public class MessengerEndpointsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public MessengerEndpointsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Patch_Message_ReturnsEdited()
+    {
+        var (caller, _, _, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PatchAsJsonAsync(
+            $"/api/v1/chat/messages/{msg.Id:D}",
+            new { body = "edited" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<MessageDto>();
+        dto!.Body.Should().Be("edited");
+        dto.EditedAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Patch_Message_EmptyBody_Returns500OrBadRequest()
+    {
+        var (caller, _, _, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PatchAsJsonAsync(
+            $"/api/v1/chat/messages/{msg.Id:D}",
+            new { body = string.Empty });
+
+        // Service throws ArgumentException → FastEndpoints unmapped exceptions land as 500.
+        // What matters: we don't accept the empty body silently.
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Delete_Message_ForEveryone_ReturnsTombstoned()
+    {
+        var (caller, _, _, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.DeleteAsync($"/api/v1/chat/messages/{msg.Id:D}?mode=for-everyone");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<MessageDto>();
+        dto!.State.Should().Be(MessageState.Deleted);
+        dto.DeleteMode.Should().Be(DeleteMode.ForEveryone);
+    }
+
+    [Fact]
+    public async Task Delete_Message_DefaultMode_HidesForCaller()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(peer);
+
+        using var client = _factory.CreateClient();
+        var response = await client.DeleteAsync($"/api/v1/chat/messages/{msg.Id:D}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var loaded = await verifyScope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.IsHiddenFor(peer).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Post_Reactions_ReturnsNoContent_AndPersistsReaction()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(peer);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/chat/messages/{msg.Id:D}/reactions",
+            new { emoji = "👍" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var loaded = await verifyScope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle(r => r.UserId == peer && r.Emoji == "👍");
+    }
+
+    [Fact]
+    public async Task Delete_Reaction_RemovesPriorReaction()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+        await using (var addScope = _factory.Services.CreateAsyncScope())
+        {
+            var add = addScope.ServiceProvider.GetRequiredService<AddReactionService>();
+            await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+        }
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(peer);
+
+        using var client = _factory.CreateClient();
+        var response = await client.DeleteAsync($"/api/v1/chat/messages/{msg.Id:D}/reactions/{Uri.EscapeDataString("👍")}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Post_Pinned_ReturnsPinnedList()
+    {
+        var (caller, _, conv, msg) = await SeedSentMessageAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/chat/conversations/{conv.Id}/pinned",
+            new { messageId = msg.Id });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var pinned = await response.Content.ReadFromJsonAsync<List<MessageDto>>();
+        pinned.Should().ContainSingle(m => m.Id == msg.Id);
+    }
+
+    [Fact]
+    public async Task Delete_Pinned_RemovesAndReturnsRemainingList()
+    {
+        var (caller, _, conv, msg) = await SeedSentMessageAsync();
+        await using (var pinScope = _factory.Services.CreateAsyncScope())
+        {
+            var pin = pinScope.ServiceProvider.GetRequiredService<PinMessageService>();
+            await pin.PinAsync(new PinMessageRequest(conv.Id, caller, msg.Id), default);
+        }
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.DeleteAsync($"/api/v1/chat/conversations/{conv.Id}/pinned/{msg.Id:D}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var pinned = await response.Content.ReadFromJsonAsync<List<MessageDto>>();
+        pinned.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Post_Forward_ReturnsNewMessages()
+    {
+        var caller = Guid.NewGuid();
+        var sourcePeer = Guid.NewGuid();
+        var targetPeer = Guid.NewGuid();
+
+        Guid sourceMsgId;
+        string targetConvId;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            var sourceConv = await open.OpenAsync(caller, sourcePeer, default);
+            var targetConv = await open.OpenAsync(caller, targetPeer, default);
+            targetConvId = targetConv.Id;
+
+            var send = seed.ServiceProvider.GetRequiredService<SendMessageService>();
+            var dto = await send.SendAsync(
+                new SendMessageRequest(sourceConv.Id, caller, "to forward", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+                default);
+            sourceMsgId = dto.Id;
+        }
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/chat/conversations/{targetConvId}/forward",
+            new { messageIds = new[] { sourceMsgId } });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var forwarded = await response.Content.ReadFromJsonAsync<List<MessageDto>>();
+        forwarded.Should().ContainSingle();
+        forwarded![0].ForwardedFrom.Should().NotBeNull();
+        forwarded[0].SenderId.Should().Be(caller);
+    }
+
+    [Fact]
+    public async Task Get_ReadReceipts_ReturnsReceiptsForParticipant()
+    {
+        var (caller, peer, _, msg) = await SeedSentMessageAsync();
+        await using (var markScope = _factory.Services.CreateAsyncScope())
+        {
+            var markRead = markScope.ServiceProvider.GetRequiredService<MarkReadService>();
+            await markRead.MarkAsync(new MarkReadRequest(msg.ConversationId, peer, msg.Id), default);
+        }
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var receipts = await client.GetFromJsonAsync<List<ReadReceiptDto>>(
+            $"/api/v1/chat/messages/{msg.Id:D}/read-receipts");
+
+        receipts.Should().ContainSingle(r => r.UserId == peer);
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "hello", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubEditDeleteTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubEditDeleteTests.cs
@@ -1,0 +1,115 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace ChatService.IntegrationTests.Hub;
+
+[Collection(IntegrationCollection.Name)]
+public class ChatHubEditDeleteTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ChatHubEditDeleteTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task EditMessage_BroadcastsMessageEditedToBothParticipants()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var bobEdited = new TaskCompletionSource<MessageDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        bobConn.On<MessageDto>("MessageEdited", msg => bobEdited.TrySetResult(msg));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "hi",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        await aliceConn.InvokeAsync<MessageDto>("EditMessage", new
+        {
+            MessageId = sent.Id,
+            NewBody = "hi-edited",
+        });
+
+        var edited = await bobEdited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        edited.Id.Should().Be(sent.Id);
+        edited.Body.Should().Be("hi-edited");
+        edited.EditedAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteMessage_ForEveryone_BroadcastsWireFormatMode()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var bobDeleted = new TaskCompletionSource<(string ConvId, Guid MessageId, string Mode, Guid DeletedBy)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        bobConn.On<string, Guid, string, Guid>("MessageDeletedUpdate",
+            (convId, messageId, mode, deletedBy) => bobDeleted.TrySetResult((convId, messageId, mode, deletedBy)));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "to delete",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        await aliceConn.InvokeAsync<MessageDto?>("DeleteMessage", sent.Id, "for-everyone");
+
+        var deleted = await bobDeleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        deleted.MessageId.Should().Be(sent.Id);
+        // Wire format must use kebab-case "for-everyone" — not the enum's ToString().
+        deleted.Mode.Should().Be("for-everyone");
+        deleted.DeletedBy.Should().Be(alice);
+    }
+
+    [Fact]
+    public async Task DeleteMessage_ForMe_DoesNotBroadcastToOtherParticipants()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var aliceDeleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        aliceConn.On<string, Guid, string, Guid>("MessageDeletedUpdate", (_, _, _, _) => aliceDeleted.TrySetResult(true));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "personal hide",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        // Bob hides locally; Alice must NOT receive a broadcast.
+        await bobConn.InvokeAsync<MessageDto?>("DeleteMessage", sent.Id, "for-me");
+
+        var fired = await Task.WhenAny(aliceDeleted.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        fired.Should().NotBe(aliceDeleted.Task);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubForwardTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubForwardTests.cs
@@ -1,0 +1,55 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Urfu.Link.Services.Chat.Application.Contracts;
+
+namespace ChatService.IntegrationTests.Hub;
+
+[Collection(IntegrationCollection.Name)]
+public class ChatHubForwardTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ChatHubForwardTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ForwardMessages_DeliversMessageReceivedWithForwardedFromToTargetParticipant()
+    {
+        var caller = Guid.NewGuid();
+        var sourcePeer = Guid.NewGuid();
+        var targetPeer = Guid.NewGuid();
+
+        await using var callerConn = await TestChatHubClient.ConnectAsync(_factory, caller);
+        await using var sourceConn = await TestChatHubClient.ConnectAsync(_factory, sourcePeer);
+        await using var targetConn = await TestChatHubClient.ConnectAsync(_factory, targetPeer);
+
+        // Build source conversation by sending a message peer→caller, then open target.
+        var sourceConv = await callerConn.InvokeAsync<ConversationDto>("OpenDirectConversation", sourcePeer);
+        var sourceMsg = await sourceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = sourceConv.Id,
+            Body = "from source",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+        var targetConv = await callerConn.InvokeAsync<ConversationDto>("OpenDirectConversation", targetPeer);
+
+        var targetReceived = new TaskCompletionSource<MessageDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        targetConn.On<MessageDto>("MessageReceived", msg => targetReceived.TrySetResult(msg));
+
+        await callerConn.InvokeAsync<IReadOnlyList<MessageDto>>("ForwardMessages", targetConv.Id, new[] { sourceMsg.Id });
+
+        var received = await targetReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        received.SenderId.Should().Be(caller);
+        received.ConversationId.Should().Be(targetConv.Id);
+        received.ForwardedFrom.Should().NotBeNull();
+        received.ForwardedFrom!.OriginalSenderId.Should().Be(sourcePeer);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubPinningTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubPinningTests.cs
@@ -1,0 +1,79 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Urfu.Link.Services.Chat.Application.Contracts;
+
+namespace ChatService.IntegrationTests.Hub;
+
+[Collection(IntegrationCollection.Name)]
+public class ChatHubPinningTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ChatHubPinningTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PinMessage_BroadcastsPinsUpdatedWithFullPinnedList()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var bobPins = new TaskCompletionSource<(string ConvId, IReadOnlyList<MessageDto> Pinned)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        bobConn.On<string, IReadOnlyList<MessageDto>>("PinsUpdated",
+            (convId, pinned) => bobPins.TrySetResult((convId, pinned)));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "important",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        await aliceConn.InvokeAsync<IReadOnlyList<MessageDto>>("PinMessage", conv.Id, sent.Id);
+
+        var update = await bobPins.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        update.ConvId.Should().Be(conv.Id);
+        update.Pinned.Should().ContainSingle(m => m.Id == sent.Id);
+    }
+
+    [Fact]
+    public async Task UnpinMessage_BroadcastsEmptyPinsUpdated()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "x",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+        await aliceConn.InvokeAsync<IReadOnlyList<MessageDto>>("PinMessage", conv.Id, sent.Id);
+
+        var bobAfterUnpin = new TaskCompletionSource<IReadOnlyList<MessageDto>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        bobConn.On<string, IReadOnlyList<MessageDto>>("PinsUpdated", (_, pinned) => bobAfterUnpin.TrySetResult(pinned));
+
+        await aliceConn.InvokeAsync<IReadOnlyList<MessageDto>>("UnpinMessage", conv.Id, sent.Id);
+
+        var pinnedAfter = await bobAfterUnpin.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        pinnedAfter.Should().BeEmpty();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubReactionsTests.cs
@@ -1,0 +1,83 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Urfu.Link.Services.Chat.Application.Contracts;
+
+namespace ChatService.IntegrationTests.Hub;
+
+[Collection(IntegrationCollection.Name)]
+public class ChatHubReactionsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ChatHubReactionsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task AddReaction_BroadcastsReactionUpdatedSummaryToAllParticipants()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var aliceSummary = new TaskCompletionSource<(Guid MessageId, IReadOnlyDictionary<string, IReadOnlyList<Guid>> Summary)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        aliceConn.On<Guid, IReadOnlyDictionary<string, IReadOnlyList<Guid>>>("ReactionUpdated",
+            (msgId, summary) => aliceSummary.TrySetResult((msgId, summary)));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "hi",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        await bobConn.InvokeAsync("AddReaction", sent.Id, "👍");
+
+        var update = await aliceSummary.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        update.MessageId.Should().Be(sent.Id);
+        update.Summary.Should().ContainKey("👍");
+        update.Summary["👍"].Should().Equal(bob);
+    }
+
+    [Fact]
+    public async Task RemoveReaction_BroadcastsEmptySummary()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var sent = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "hi",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        await bobConn.InvokeAsync("AddReaction", sent.Id, "👍");
+
+        var aliceCleared = new TaskCompletionSource<IReadOnlyDictionary<string, IReadOnlyList<Guid>>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        aliceConn.On<Guid, IReadOnlyDictionary<string, IReadOnlyList<Guid>>>("ReactionUpdated",
+            (_, summary) => aliceCleared.TrySetResult(summary));
+
+        await bobConn.InvokeAsync("RemoveReaction", sent.Id, "👍");
+
+        var summary = await aliceCleared.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        summary.Should().BeEmpty();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -11,6 +11,7 @@ using Testcontainers.MongoDb;
 using Testcontainers.Redis;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence;
 
@@ -35,6 +36,8 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
     public FakeOutboxWriter OutboxWriter { get; } = new();
 
     public FakeMediaServiceClient MediaServiceClient { get; } = new();
+
+    public FakeDisciplineRoleResolver DisciplineRoleResolver { get; } = new();
 
     public IIdempotencyStore IdempotencyStore { get; } = Substitute.For<IIdempotencyStore>();
 
@@ -61,6 +64,7 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
     {
         OutboxWriter.Clear();
         MediaServiceClient.Reset();
+        DisciplineRoleResolver.Reset();
         TestAuthHandler.CurrentPrincipal = null;
     }
 
@@ -120,6 +124,9 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
 
             services.RemoveAll<IMediaServiceClient>();
             services.AddSingleton<IMediaServiceClient>(MediaServiceClient);
+
+            services.RemoveAll<IDisciplineRoleResolver>();
+            services.AddSingleton<IDisciplineRoleResolver>(DisciplineRoleResolver);
 
             ReplaceAuthWithTestScheme(services);
         });

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeDisciplineRoleResolver.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeDisciplineRoleResolver.cs
@@ -1,0 +1,26 @@
+using Urfu.Link.Services.Chat.Application.Authorization;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+
+namespace ChatService.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Replaces the production <see cref="IDisciplineRoleResolver"/> stub during integration tests.
+/// By default allows pinning everywhere so happy-path tests don't have to wire authz; tests
+/// that exercise authz failure flip <see cref="Predicate"/> to a stricter check (e.g.
+/// <c>(_, c) =&gt; c.Type == ConversationType.Direct</c>).
+/// </summary>
+public sealed class FakeDisciplineRoleResolver : IDisciplineRoleResolver
+{
+    public Func<Guid, Conversation, bool> Predicate { get; set; } = (_, _) => true;
+
+    public Task<bool> CanPinAsync(Guid userId, Conversation conversation, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(conversation);
+        return Task.FromResult(Predicate(userId, conversation));
+    }
+
+    public void Reset()
+    {
+        Predicate = (_, _) => true;
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/DeleteMessageServiceTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/DeleteMessageServiceTests.cs
@@ -1,0 +1,132 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class DeleteMessageServiceTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public DeleteMessageServiceTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task DeleteAsync_ForEveryone_TombstonesMessage_AndPublishesEvent()
+    {
+        var (sender, _, conv, msg) = await SeedSentMessageAsync("hello");
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var delete = scope.ServiceProvider.GetRequiredService<DeleteMessageService>();
+
+        var dto = await delete.DeleteAsync(
+            new DeleteMessageRequest(msg.Id, sender, DeleteMode.ForEveryone), default);
+
+        dto.Should().NotBeNull();
+        dto!.State.Should().Be(MessageState.Deleted);
+        dto.DeleteMode.Should().Be(DeleteMode.ForEveryone);
+        dto.Body.Should().BeEmpty();
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.State.Should().Be(MessageState.Deleted);
+        loaded.DeletedBy.Should().Be(sender);
+
+        var deleted = _factory.OutboxWriter.Published
+            .Select(p => p.Payload)
+            .OfType<ChatMessageDeletedEvent>()
+            .Single(e => e.MessageId == msg.Id);
+        deleted.Mode.Should().Be(DeleteMode.ForEveryone);
+        deleted.ConversationId.Should().Be(conv.Id);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForMe_HidesLocally_NoEvent()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync("hello");
+        _factory.OutboxWriter.Clear();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var delete = scope.ServiceProvider.GetRequiredService<DeleteMessageService>();
+
+        var dto = await delete.DeleteAsync(
+            new DeleteMessageRequest(msg.Id, peer, DeleteMode.ForMe), default);
+
+        dto.Should().NotBeNull();
+        // Other participants still see the original content.
+        dto!.Body.Should().Be("hello");
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.IsHiddenFor(peer).Should().BeTrue();
+        loaded.State.Should().NotBe(MessageState.Deleted);
+
+        // Local hide must NOT show up on the wire.
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload)
+            .OfType<ChatMessageDeletedEvent>()
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForEveryone_ByNonAuthor_Throws()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync("hello");
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var delete = scope.ServiceProvider.GetRequiredService<DeleteMessageService>();
+
+        var act = () => delete.DeleteAsync(
+            new DeleteMessageRequest(msg.Id, peer, DeleteMode.ForEveryone), default);
+
+        await act.Should().ThrowAsync<ChatNotMessageAuthorException>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonParticipant_Throws()
+    {
+        var (_, _, _, msg) = await SeedSentMessageAsync("hello");
+        var stranger = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var delete = scope.ServiceProvider.GetRequiredService<DeleteMessageService>();
+
+        var act = () => delete.DeleteAsync(
+            new DeleteMessageRequest(msg.Id, stranger, DeleteMode.ForMe), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync(string body)
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, body, Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/EditMessageServiceTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/EditMessageServiceTests.cs
@@ -1,0 +1,139 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class EditMessageServiceTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public EditMessageServiceTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task EditAsync_HappyPath_PersistsBody_AppendsHistory_AndPublishesEvent()
+    {
+        var (sender, peer, conv, msg) = await SeedSentMessageAsync("hello");
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var edit = scope.ServiceProvider.GetRequiredService<EditMessageService>();
+
+        var dto = await edit.EditAsync(new EditMessageRequest(msg.Id, sender, "edited"), default);
+
+        dto.Body.Should().Be("edited");
+        dto.EditedAtUtc.Should().NotBeNull();
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Body.Should().Be("edited");
+        loaded.EditHistory.Should().ContainSingle();
+        loaded.EditHistory[0].Body.Should().Be("hello");
+
+        var edited = _factory.OutboxWriter.Published
+            .Select(p => p.Payload)
+            .OfType<ChatMessageEditedEvent>()
+            .Single(e => e.MessageId == msg.Id);
+        edited.NewBody.Should().Be("edited");
+        edited.EditorUserId.Should().Be(sender);
+
+        // peer membership is implicit — we just confirm conversation context is correct.
+        edited.ConversationId.Should().Be(conv.Id);
+        peer.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task EditAsync_EmptyBody_Throws_AndDoesNotPersist()
+    {
+        var (sender, _, _, msg) = await SeedSentMessageAsync("hello");
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var edit = scope.ServiceProvider.GetRequiredService<EditMessageService>();
+
+        var act = () => edit.EditAsync(new EditMessageRequest(msg.Id, sender, string.Empty), default);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Body.Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task EditAsync_BodyTooLong_Throws()
+    {
+        var (sender, _, _, msg) = await SeedSentMessageAsync("hello");
+        var oversized = new string('x', ChatBodyConstraints.MaxBodyLength + 1);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var edit = scope.ServiceProvider.GetRequiredService<EditMessageService>();
+
+        var act = () => edit.EditAsync(new EditMessageRequest(msg.Id, sender, oversized), default);
+
+        await act.Should().ThrowAsync<ChatPayloadTooLargeException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_NotAuthor_ThrowsNotMessageAuthor()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync("hello");
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var edit = scope.ServiceProvider.GetRequiredService<EditMessageService>();
+
+        var act = () => edit.EditAsync(new EditMessageRequest(msg.Id, peer, "evil"), default);
+
+        await act.Should().ThrowAsync<ChatNotMessageAuthorException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_AddingMention_PublishesChatMentionCreatedForDiff()
+    {
+        var (sender, peer, conv, msg) = await SeedSentMessageAsync("hi");
+        _factory.OutboxWriter.Clear();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var edit = scope.ServiceProvider.GetRequiredService<EditMessageService>();
+
+        var newBody = $"hi @{peer:D}";
+        await edit.EditAsync(new EditMessageRequest(msg.Id, sender, newBody), default);
+
+        var mention = _factory.OutboxWriter.Published
+            .Select(p => p.Payload)
+            .OfType<ChatMentionCreatedEvent>()
+            .Single(e => e.MessageId == msg.Id);
+        mention.MentionedUserIds.Should().Equal(peer);
+        mention.ConversationId.Should().Be(conv.Id);
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync(string body)
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, body, Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/ForwardMessagesServiceTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/ForwardMessagesServiceTests.cs
@@ -1,0 +1,154 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class ForwardMessagesServiceTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ForwardMessagesServiceTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ForwardAsync_FromDirectToDirect_InsertsMessages_PublishesSentEvents_AndKeepsOriginalConversationId()
+    {
+        var caller = Guid.NewGuid();
+        var sourcePeer = Guid.NewGuid();
+        var targetPeer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var source = await open.OpenAsync(caller, sourcePeer, default);
+        var target = await open.OpenAsync(caller, targetPeer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var sourceDto = await send.SendAsync(
+            new SendMessageRequest(source.Id, sourcePeer, "to forward", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+        _factory.OutboxWriter.Clear();
+
+        var forward = scope.ServiceProvider.GetRequiredService<ForwardMessagesService>();
+        var produced = await forward.ForwardAsync(
+            new ForwardMessagesRequest(target.Id, caller, new[] { sourceDto.Id }), default);
+
+        produced.Should().ContainSingle();
+        produced[0].SenderId.Should().Be(caller);
+        produced[0].ForwardedFrom.Should().NotBeNull();
+        produced[0].ForwardedFrom!.OriginalSenderId.Should().Be(sourcePeer);
+        produced[0].ForwardedFrom!.OriginalConversationId.Should().Be(source.Id);
+
+        var sentEvents = _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMessageSentEvent>().ToList();
+        sentEvents.Should().ContainSingle(e => e.ConversationId == target.Id);
+    }
+
+    [Fact]
+    public async Task ForwardAsync_ToGroupConversation_HidesOriginalConversationId()
+    {
+        var caller = Guid.NewGuid();
+        var sourcePeer = Guid.NewGuid();
+        var groupMember = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var source = await open.OpenAsync(caller, sourcePeer, default);
+
+        // Inject a group conversation directly (no service supports group creation in #211).
+        var convRepo = scope.ServiceProvider.GetRequiredService<IConversationRepository>();
+        var groupConv = Conversation.Hydrate(
+            id: $"group-{Guid.NewGuid():N}",
+            type: ConversationType.Group,
+            participants: new[] { caller, groupMember },
+            createdAtUtc: DateTimeOffset.UtcNow,
+            lastMessageAtUtc: DateTimeOffset.UtcNow,
+            lastMessagePreview: null);
+        await convRepo.TryCreateAsync(groupConv, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var sourceDto = await send.SendAsync(
+            new SendMessageRequest(source.Id, caller, "secret source", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var forward = scope.ServiceProvider.GetRequiredService<ForwardMessagesService>();
+        var produced = await forward.ForwardAsync(
+            new ForwardMessagesRequest(groupConv.Id, caller, new[] { sourceDto.Id }), default);
+
+        produced.Should().ContainSingle();
+        produced[0].ForwardedFrom.Should().NotBeNull();
+        produced[0].ForwardedFrom!.OriginalConversationId.Should().BeNull();
+        produced[0].ForwardedFrom!.OriginalSenderId.Should().Be(caller);
+    }
+
+    [Fact]
+    public async Task ForwardAsync_WithAttachment_GrantsAccessToTargetParticipants()
+    {
+        var caller = Guid.NewGuid();
+        var sourcePeer = Guid.NewGuid();
+        var targetPeer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var source = await open.OpenAsync(caller, sourcePeer, default);
+        var target = await open.OpenAsync(caller, targetPeer, default);
+
+        var assetId = Guid.NewGuid();
+        _factory.MediaServiceClient.RegisterAsset(assetId, ownerId: caller);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var sourceDto = await send.SendAsync(
+            new SendMessageRequest(source.Id, caller, "see attached", new[] { assetId }, $"c-{Guid.NewGuid():N}"),
+            default);
+
+        // The send already grants access to sourcePeer; the forward should also grant access
+        // to the target participants (targetPeer).
+        var forward = scope.ServiceProvider.GetRequiredService<ForwardMessagesService>();
+        await forward.ForwardAsync(
+            new ForwardMessagesRequest(target.Id, caller, new[] { sourceDto.Id }), default);
+
+        _factory.MediaServiceClient.Grants.Should()
+            .Contain(g => g.AssetId == assetId && g.ConversationId == target.Id
+                && g.GrantedByUserId == caller
+                && g.UserIds.SequenceEqual(new[] { targetPeer }));
+    }
+
+    [Fact]
+    public async Task ForwardAsync_NonParticipantInSource_ThrowsAccessDenied()
+    {
+        var caller = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+        var foreignPeer = Guid.NewGuid();
+        var targetPeer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var foreignConv = await open.OpenAsync(stranger, foreignPeer, default);
+        var target = await open.OpenAsync(caller, targetPeer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var foreignMsg = await send.SendAsync(
+            new SendMessageRequest(foreignConv.Id, stranger, "private", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var forward = scope.ServiceProvider.GetRequiredService<ForwardMessagesService>();
+        var act = () => forward.ForwardAsync(
+            new ForwardMessagesRequest(target.Id, caller, new[] { foreignMsg.Id }), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/GetReadReceiptsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/GetReadReceiptsTests.cs
@@ -1,0 +1,118 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class GetReadReceiptsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public GetReadReceiptsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ExecuteAsync_AfterMarkRead_ReturnsReceiptForReader()
+    {
+        var (sender, peer, _, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var markRead = scope.ServiceProvider.GetRequiredService<MarkReadService>();
+        await markRead.MarkAsync(new MarkReadRequest(msg.ConversationId, peer, msg.Id), default);
+
+        var query = scope.ServiceProvider.GetRequiredService<GetReadReceiptsQuery>();
+        var receipts = await query.ExecuteAsync(msg.Id, sender, default);
+
+        receipts.Should().ContainSingle(r => r.UserId == peer);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonParticipant_ThrowsAccessDenied()
+    {
+        var (_, _, _, msg) = await SeedSentMessageAsync();
+        var stranger = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var query = scope.ServiceProvider.GetRequiredService<GetReadReceiptsQuery>();
+
+        var act = () => query.ExecuteAsync(msg.Id, stranger, default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingMessage_ThrowsNotFound()
+    {
+        var caller = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var query = scope.ServiceProvider.GetRequiredService<GetReadReceiptsQuery>();
+
+        var act = () => query.ExecuteAsync(Guid.NewGuid(), caller, default);
+
+        await act.Should().ThrowAsync<ChatMessageNotFoundException>();
+    }
+
+    [Fact]
+    public async Task MarkRead_PopulatesReadByForAllTransitionedMessages()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var ids = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            var dto = await send.SendAsync(
+                new SendMessageRequest(conv.Id, sender, $"m{i}", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+                default);
+            ids.Add(dto.Id);
+        }
+
+        // Reader marks the third message as read; all three should land in ReadBy.
+        var markRead = scope.ServiceProvider.GetRequiredService<MarkReadService>();
+        var anchor = await markRead.MarkAsync(new MarkReadRequest(conv.Id, peer, ids[^1]), default);
+        anchor.Should().Be(ids[^1]);
+
+        var repo = scope.ServiceProvider.GetRequiredService<IMessageRepository>();
+        foreach (var id in ids)
+        {
+            var receipts = await repo.GetReadReceiptsAsync(id, default);
+            receipts.Should().ContainSingle(r => r.UserId == peer);
+        }
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "to read", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/MentionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/MentionsTests.cs
@@ -1,0 +1,93 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class MentionsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public MentionsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SendMessage_WithMention_PublishesBothMessageSentAndMentionCreated()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, $"hi @{peer:D}", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        dto.Mentions.Should().Equal(peer);
+
+        var sent = _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMessageSentEvent>().Single(e => e.MessageId == dto.Id);
+        sent.Mentions.Should().NotBeNull();
+        sent.Mentions!.Should().Equal(peer);
+
+        var mentioned = _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMentionCreatedEvent>().Single(e => e.MessageId == dto.Id);
+        mentioned.MentionedUserIds.Should().Equal(peer);
+    }
+
+    [Fact]
+    public async Task SendMessage_EveryoneMention_ExpandsToAllParticipants()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "@everyone please review", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        dto.Mentions.Should().BeEquivalentTo(conv.Participants);
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        loaded!.Mentions.Should().BeEquivalentTo(conv.Participants);
+    }
+
+    [Fact]
+    public async Task SendMessage_PlainText_DoesNotEmitMentionEvent()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+        _factory.OutboxWriter.Clear();
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "no mentions here", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatMentionCreatedEvent>().Should().BeEmpty();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Messages/ReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/ReactionsTests.cs
@@ -1,0 +1,122 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Messages;
+
+[Collection(IntegrationCollection.Name)]
+public class ReactionsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ReactionsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task AddReaction_FromParticipant_PersistsAndPublishesEvent()
+    {
+        var (sender, peer, _, msg) = await SeedSentMessageAsync();
+        _factory.OutboxWriter.Clear();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var add = scope.ServiceProvider.GetRequiredService<AddReactionService>();
+
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle(r => r.UserId == peer && r.Emoji == "👍");
+
+        var added = _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatReactionAddedEvent>().Single();
+        added.UserId.Should().Be(peer);
+        added.Emoji.Should().Be("👍");
+
+        // sender doesn't react in this scenario but is the conversation peer — sanity check.
+        sender.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task AddReaction_SameEmojiTwice_IsNoop()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var add = scope.ServiceProvider.GetRequiredService<AddReactionService>();
+
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+        _factory.OutboxWriter.Clear();
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatReactionAddedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddReaction_ChangingEmoji_Atomically_ReplacesPriorReaction()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var add = scope.ServiceProvider.GetRequiredService<AddReactionService>();
+
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "❤"), default);
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle(r => r.UserId == peer);
+        loaded.Reactions[0].Emoji.Should().Be("❤");
+    }
+
+    [Fact]
+    public async Task RemoveReaction_ExistingReaction_RemovesAndPublishes()
+    {
+        var (_, peer, _, msg) = await SeedSentMessageAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var add = scope.ServiceProvider.GetRequiredService<AddReactionService>();
+        await add.AddAsync(new AddReactionRequest(msg.Id, peer, "👍"), default);
+        _factory.OutboxWriter.Clear();
+
+        var remove = scope.ServiceProvider.GetRequiredService<RemoveReactionService>();
+        await remove.RemoveAsync(new RemoveReactionRequest(msg.Id, peer, "👍"), default);
+
+        var loaded = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().BeEmpty();
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<ChatReactionRemovedEvent>()
+            .Should().ContainSingle(e => e.UserId == peer && e.Emoji == "👍");
+    }
+
+    private async Task<(Guid sender, Guid peer, Conversation conv, Message msg)> SeedSentMessageAsync()
+    {
+        var sender = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using var scope = _factory.Services.CreateAsyncScope();
+
+        var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+        var conv = await open.OpenAsync(sender, peer, default);
+
+        var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+        var dto = await send.SendAsync(
+            new SendMessageRequest(conv.Id, sender, "to react", Array.Empty<Guid>(), $"c-{Guid.NewGuid():N}"),
+            default);
+
+        var msg = await scope.ServiceProvider.GetRequiredService<IMessageRepository>()
+            .GetByIdAsync(dto.Id, default);
+        return (sender, peer, conv, msg!);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/ConversationRepositoryPinningTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/ConversationRepositoryPinningTests.cs
@@ -1,0 +1,113 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class ConversationRepositoryPinningTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private ConversationRepository _repo = null!;
+
+    public ConversationRepositoryPinningTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new ConversationRepository(_context);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Conversation> CreateNewAsync()
+    {
+        var conv = Conversation.OpenDirect(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        await _repo.TryCreateAsync(conv, default);
+        return conv;
+    }
+
+    [Fact]
+    public async Task AddPinnedMessageAsync_FirstTime_AddsAndReturnsTrue()
+    {
+        var conv = await CreateNewAsync();
+        var msgId = Guid.NewGuid();
+
+        var pinned = await _repo.AddPinnedMessageAsync(conv.Id, msgId, maxPinned: 5, default);
+
+        pinned.Should().BeTrue();
+        var loaded = await _repo.GetByIdAsync(conv.Id, default);
+        loaded!.PinnedMessageIds.Should().ContainSingle(id => id == msgId);
+    }
+
+    [Fact]
+    public async Task AddPinnedMessageAsync_AlreadyPinned_ReturnsFalse()
+    {
+        var conv = await CreateNewAsync();
+        var msgId = Guid.NewGuid();
+        await _repo.AddPinnedMessageAsync(conv.Id, msgId, 5, default);
+
+        var second = await _repo.AddPinnedMessageAsync(conv.Id, msgId, 5, default);
+
+        second.Should().BeFalse();
+        var loaded = await _repo.GetByIdAsync(conv.Id, default);
+        loaded!.PinnedMessageIds.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task AddPinnedMessageAsync_AtCap_ReturnsFalse()
+    {
+        var conv = await CreateNewAsync();
+        for (var i = 0; i < 5; i++)
+        {
+            (await _repo.AddPinnedMessageAsync(conv.Id, Guid.NewGuid(), 5, default)).Should().BeTrue();
+        }
+
+        var sixth = await _repo.AddPinnedMessageAsync(conv.Id, Guid.NewGuid(), 5, default);
+
+        sixth.Should().BeFalse();
+        var loaded = await _repo.GetByIdAsync(conv.Id, default);
+        loaded!.PinnedMessageIds.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task AddPinnedMessageAsync_MissingConversation_ReturnsFalse()
+    {
+        var pinned = await _repo.AddPinnedMessageAsync("does-not-exist", Guid.NewGuid(), 5, default);
+
+        pinned.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemovePinnedMessageAsync_PinnedMessage_RemovesAndReturnsTrue()
+    {
+        var conv = await CreateNewAsync();
+        var msgId = Guid.NewGuid();
+        await _repo.AddPinnedMessageAsync(conv.Id, msgId, 5, default);
+
+        var unpinned = await _repo.RemovePinnedMessageAsync(conv.Id, msgId, default);
+
+        unpinned.Should().BeTrue();
+        var loaded = await _repo.GetByIdAsync(conv.Id, default);
+        loaded!.PinnedMessageIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemovePinnedMessageAsync_NotPinned_ReturnsFalse()
+    {
+        var conv = await CreateNewAsync();
+
+        var unpinned = await _repo.RemovePinnedMessageAsync(conv.Id, Guid.NewGuid(), default);
+
+        unpinned.Should().BeFalse();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryEditDeleteTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryEditDeleteTests.cs
@@ -1,0 +1,191 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class MessageRepositoryEditDeleteTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private MessageRepository _repo = null!;
+    private MongoIndexInitializer _indexes = null!;
+
+    private const string ConvId = "conv-edit-delete";
+
+    public MessageRepositoryEditDeleteTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new MessageRepository(_context);
+        _indexes = new MongoIndexInitializer(_context);
+        await _indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Message> InsertNewAsync()
+    {
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: ConvId,
+            senderId: Guid.NewGuid(),
+            body: "hello",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: $"client-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(msg, default);
+        return msg;
+    }
+
+    [Fact]
+    public async Task ApplyEditAsync_NotDeleted_UpdatesBodyAndHistory_AndReturnsTrue()
+    {
+        var msg = await InsertNewAsync();
+        var historyEntry = new EditHistoryEntry("hello", msg.CreatedAtUtc);
+        var editedAt = msg.CreatedAtUtc.AddMinutes(1);
+
+        var changed = await _repo.ApplyEditAsync(
+            msg.Id,
+            "edited",
+            new[] { Guid.NewGuid() },
+            historyEntry,
+            editedAt,
+            default);
+
+        changed.Should().BeTrue();
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Body.Should().Be("edited");
+        loaded.EditedAtUtc.Should().BeCloseTo(editedAt, TimeSpan.FromSeconds(1));
+        loaded.EditHistory.Should().HaveCount(1);
+        loaded.EditHistory[0].Body.Should().Be("hello");
+        loaded.Mentions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ApplyEditAsync_OnDeletedMessage_ReturnsFalse()
+    {
+        var msg = await InsertNewAsync();
+        await _repo.ApplyDeleteForEveryoneAsync(msg.Id, msg.SenderId, DateTimeOffset.UtcNow, default);
+
+        var changed = await _repo.ApplyEditAsync(
+            msg.Id,
+            "after-delete",
+            Array.Empty<Guid>(),
+            new EditHistoryEntry("hello", msg.CreatedAtUtc),
+            DateTimeOffset.UtcNow,
+            default);
+
+        changed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ApplyEditAsync_AppendsHistoryAcrossMultipleEdits()
+    {
+        var msg = await InsertNewAsync();
+
+        await _repo.ApplyEditAsync(
+            msg.Id, "first", Array.Empty<Guid>(),
+            new EditHistoryEntry("hello", msg.CreatedAtUtc),
+            msg.CreatedAtUtc.AddMinutes(1), default);
+        await _repo.ApplyEditAsync(
+            msg.Id, "second", Array.Empty<Guid>(),
+            new EditHistoryEntry("first", msg.CreatedAtUtc.AddMinutes(1)),
+            msg.CreatedAtUtc.AddMinutes(2), default);
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.EditHistory.Should().HaveCount(2);
+        loaded.EditHistory[0].Body.Should().Be("hello");
+        loaded.EditHistory[1].Body.Should().Be("first");
+        loaded.Body.Should().Be("second");
+    }
+
+    [Fact]
+    public async Task ApplyDeleteForEveryoneAsync_TombstonesMessage_AndReturnsTrue()
+    {
+        var msg = await InsertNewAsync();
+        await _repo.AddReactionAsync(msg.Id, new Reaction(Guid.NewGuid(), "👍", DateTimeOffset.UtcNow), default);
+        var deletedAt = DateTimeOffset.UtcNow;
+
+        var deleted = await _repo.ApplyDeleteForEveryoneAsync(msg.Id, msg.SenderId, deletedAt, default);
+
+        deleted.Should().BeTrue();
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.State.Should().Be(MessageState.Deleted);
+        loaded.DeleteMode.Should().Be(DeleteMode.ForEveryone);
+        loaded.DeletedBy.Should().Be(msg.SenderId);
+        loaded.DeletedAtUtc.Should().BeCloseTo(deletedAt, TimeSpan.FromSeconds(1));
+        loaded.Body.Should().BeEmpty();
+        loaded.Reactions.Should().BeEmpty();
+        loaded.Attachments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ApplyDeleteForEveryoneAsync_AlreadyDeleted_ReturnsFalse()
+    {
+        var msg = await InsertNewAsync();
+        await _repo.ApplyDeleteForEveryoneAsync(msg.Id, msg.SenderId, DateTimeOffset.UtcNow, default);
+
+        var second = await _repo.ApplyDeleteForEveryoneAsync(msg.Id, msg.SenderId, DateTimeOffset.UtcNow.AddSeconds(5), default);
+
+        second.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AddHiddenForAsync_NewUser_ReturnsTrueAndAppendsToHiddenFor()
+    {
+        var msg = await InsertNewAsync();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+
+        (await _repo.AddHiddenForAsync(msg.Id, userA, default)).Should().BeTrue();
+        (await _repo.AddHiddenForAsync(msg.Id, userB, default)).Should().BeTrue();
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.HiddenFor.Should().BeEquivalentTo(new[] { userA, userB });
+    }
+
+    [Fact]
+    public async Task AddHiddenForAsync_SameUserTwice_IsIdempotent()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        await _repo.AddHiddenForAsync(msg.Id, user, default);
+
+        var second = await _repo.AddHiddenForAsync(msg.Id, user, default);
+
+        second.Should().BeFalse();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.HiddenFor.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_FiltersByConversationId()
+    {
+        var conv1 = $"conv-1-{Guid.NewGuid():N}";
+        var conv2 = $"conv-2-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var m1 = Message.Send(Guid.NewGuid(), conv1, sender, "in conv1", Array.Empty<Attachment>(), $"c-{Guid.NewGuid():N}", DateTimeOffset.UtcNow);
+        var m2 = Message.Send(Guid.NewGuid(), conv2, sender, "in conv2", Array.Empty<Attachment>(), $"c-{Guid.NewGuid():N}", DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(m1, default);
+        await _repo.InsertAsync(m2, default);
+
+        var fromConv1 = await _repo.GetByIdsAsync(conv1, new[] { m1.Id, m2.Id }, default);
+
+        fromConv1.Should().HaveCount(1);
+        fromConv1[0].Id.Should().Be(m1.Id);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReactionsTests.cs
@@ -131,4 +131,23 @@ public class MessageRepositoryReactionsTests : IClassFixture<MongoFixture>, IAsy
         var loaded = await _repo.GetByIdAsync(msg.Id, default);
         loaded!.Reactions.Should().HaveCount(1);
     }
+
+    [Fact]
+    public async Task AddReactionAsync_ConcurrentSameUserDifferentEmojis_LeavesExactlyOneReaction()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        var emojis = new[] { "👍", "❤", "🔥", "🎉", "😂", "👀", "🚀", "💯", "✨", "🙌" };
+
+        // Fire all 10 add reactions concurrently. Without atomic pull-then-push the database
+        // can end up with multiple reactions from the same user; with the pipeline update we
+        // are guaranteed a single reaction.
+        var tasks = emojis.Select(e =>
+            _repo.AddReactionAsync(msg.Id, new Reaction(user, e, DateTimeOffset.UtcNow), default)).ToArray();
+        await Task.WhenAll(tasks);
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle(r => r.UserId == user);
+        emojis.Should().Contain(loaded.Reactions[0].Emoji);
+    }
 }

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReactionsTests.cs
@@ -1,0 +1,134 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class MessageRepositoryReactionsTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private MessageRepository _repo = null!;
+    private MongoIndexInitializer _indexes = null!;
+
+    private const string ConvId = "conv-reactions";
+
+    public MessageRepositoryReactionsTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new MessageRepository(_context);
+        _indexes = new MongoIndexInitializer(_context);
+        await _indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Message> InsertNewAsync()
+    {
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: ConvId,
+            senderId: Guid.NewGuid(),
+            body: "hi",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: $"client-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(msg, default);
+        return msg;
+    }
+
+    [Fact]
+    public async Task AddReactionAsync_NewReaction_PersistsAndReturnsTrue()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+
+        var added = await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        added.Should().BeTrue();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle(r => r.UserId == user && r.Emoji == "👍");
+    }
+
+    [Fact]
+    public async Task AddReactionAsync_SameUserSameEmoji_IsIdempotent()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        var second = await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        second.Should().BeFalse();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task AddReactionAsync_SameUserDifferentEmoji_ReplacesPriorReaction()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        var changed = await _repo.AddReactionAsync(msg.Id, new Reaction(user, "❤", DateTimeOffset.UtcNow.AddSeconds(1)), default);
+
+        changed.Should().BeTrue();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().ContainSingle();
+        loaded.Reactions[0].Emoji.Should().Be("❤");
+    }
+
+    [Fact]
+    public async Task AddReactionAsync_DifferentUsers_AccumulateIndependently()
+    {
+        var msg = await InsertNewAsync();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+
+        await _repo.AddReactionAsync(msg.Id, new Reaction(userA, "👍", DateTimeOffset.UtcNow), default);
+        await _repo.AddReactionAsync(msg.Id, new Reaction(userB, "👍", DateTimeOffset.UtcNow), default);
+
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task RemoveReactionAsync_ExistingReaction_RemovesAndReturnsTrue()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        var removed = await _repo.RemoveReactionAsync(msg.Id, user, "👍", default);
+
+        removed.Should().BeTrue();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveReactionAsync_DifferentEmoji_ReturnsFalse()
+    {
+        var msg = await InsertNewAsync();
+        var user = Guid.NewGuid();
+        await _repo.AddReactionAsync(msg.Id, new Reaction(user, "👍", DateTimeOffset.UtcNow), default);
+
+        var removed = await _repo.RemoveReactionAsync(msg.Id, user, "❤", default);
+
+        removed.Should().BeFalse();
+        var loaded = await _repo.GetByIdAsync(msg.Id, default);
+        loaded!.Reactions.Should().HaveCount(1);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReadByTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryReadByTests.cs
@@ -1,0 +1,98 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class MessageRepositoryReadByTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private MessageRepository _repo = null!;
+    private MongoIndexInitializer _indexes = null!;
+
+    private const string ConvId = "conv-readby";
+
+    public MessageRepositoryReadByTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new MessageRepository(_context);
+        _indexes = new MongoIndexInitializer(_context);
+        await _indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task<Message> InsertNewAsync()
+    {
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: ConvId,
+            senderId: Guid.NewGuid(),
+            body: "hi",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: $"client-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(msg, default);
+        return msg;
+    }
+
+    [Fact]
+    public async Task AddReadByAsync_NewReader_PersistsReceiptAndReturnsTrue()
+    {
+        var msg = await InsertNewAsync();
+        var reader = Guid.NewGuid();
+        var readAt = DateTimeOffset.UtcNow;
+
+        var added = await _repo.AddReadByAsync(msg.Id, new ReadReceipt(reader, readAt), default);
+
+        added.Should().BeTrue();
+        var receipts = await _repo.GetReadReceiptsAsync(msg.Id, default);
+        receipts.Should().ContainSingle(r => r.UserId == reader);
+        receipts[0].ReadAtUtc.Should().BeCloseTo(readAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task AddReadByAsync_SameReaderTwice_IsIdempotent()
+    {
+        var msg = await InsertNewAsync();
+        var reader = Guid.NewGuid();
+        await _repo.AddReadByAsync(msg.Id, new ReadReceipt(reader, DateTimeOffset.UtcNow), default);
+
+        var second = await _repo.AddReadByAsync(msg.Id, new ReadReceipt(reader, DateTimeOffset.UtcNow.AddSeconds(5)), default);
+
+        second.Should().BeFalse();
+        var receipts = await _repo.GetReadReceiptsAsync(msg.Id, default);
+        receipts.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task AddReadByAsync_OnDeletedMessage_ReturnsFalse()
+    {
+        var msg = await InsertNewAsync();
+        await _repo.ApplyDeleteForEveryoneAsync(msg.Id, msg.SenderId, DateTimeOffset.UtcNow, default);
+
+        var added = await _repo.AddReadByAsync(msg.Id, new ReadReceipt(Guid.NewGuid(), DateTimeOffset.UtcNow), default);
+
+        added.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetReadReceiptsAsync_MessageNotFound_ReturnsEmpty()
+    {
+        var receipts = await _repo.GetReadReceiptsAsync(Guid.NewGuid(), default);
+
+        receipts.Should().BeEmpty();
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryTests.cs
@@ -125,7 +125,7 @@ public class MessageRepositoryTests : IClassFixture<MongoFixture>, IAsyncLifetim
     }
 
     [Fact]
-    public async Task MarkReadUpToAsync_TransitionsAllPriorMessages_AndReturnsAnchor()
+    public async Task MarkReadUpToAsync_TransitionsAllPriorMessages_AndReturnsTransitionedIdsInChronologicalOrder()
     {
         var sender = Guid.NewGuid();
         var conv = $"conv-read-{Guid.NewGuid():N}";
@@ -137,10 +137,11 @@ public class MessageRepositoryTests : IClassFixture<MongoFixture>, IAsyncLifetim
             await _repo.InsertAsync(m, default);
         }
 
-        var anchor = messages[2].Id;
-        var result = await _repo.MarkReadUpToAsync(conv, anchor, DateTimeOffset.UtcNow, default);
+        var anchorId = messages[2].Id;
+        var result = await _repo.MarkReadUpToAsync(conv, anchorId, DateTimeOffset.UtcNow, default);
 
-        result.Should().Be(anchor);
+        result.Should().Equal(messages[0].Id, messages[1].Id, messages[2].Id);
+        result[^1].Should().Be(anchorId);
 
         for (var i = 0; i <= 2; i++)
         {
@@ -155,7 +156,7 @@ public class MessageRepositoryTests : IClassFixture<MongoFixture>, IAsyncLifetim
     }
 
     [Fact]
-    public async Task MarkReadUpToAsync_AllAlreadyRead_ReturnsNull()
+    public async Task MarkReadUpToAsync_AllAlreadyRead_ReturnsEmpty()
     {
         var sender = Guid.NewGuid();
         var conv = $"conv-read-noop-{Guid.NewGuid():N}";
@@ -165,6 +166,6 @@ public class MessageRepositoryTests : IClassFixture<MongoFixture>, IAsyncLifetim
 
         var second = await _repo.MarkReadUpToAsync(conv, msg.Id, DateTimeOffset.UtcNow, default);
 
-        second.Should().BeNull();
+        second.Should().BeEmpty();
     }
 }

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
@@ -37,6 +37,7 @@ public class MongoIndexInitializerTests : IClassFixture<MongoFixture>
             "ix_messages_conversation_createdAt_desc",
             "ix_messages_sender_createdAt_desc",
             "ux_messages_sender_clientMessageId",
+            "ix_messages_mentions",
         });
     }
 

--- a/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
@@ -118,7 +118,7 @@ public class DeleteMessageServiceTests
     }
 
     [Fact]
-    public async Task DeleteAsync_ForMe_AnyParticipant_HidesAndPublishesEventWithoutBroadcast()
+    public async Task DeleteAsync_ForMe_AnyParticipant_HidesLocally_NoEventNoBroadcast()
     {
         var (_, msg) = Seed(Author, _clock.GetUtcNow());
 
@@ -126,8 +126,9 @@ public class DeleteMessageServiceTests
 
         dto.Should().NotBeNull();
         await _messages.Received().AddHiddenForAsync(msg.Id, Peer, Arg.Any<CancellationToken>());
-        _outbox.Captured.OfType<ChatMessageDeletedEvent>()
-            .Should().ContainSingle(e => e.Mode == DeleteMode.ForMe);
+
+        // ForMe is a local-only hide — no integration event, no broadcast.
+        _outbox.Captured.OfType<ChatMessageDeletedEvent>().Should().BeEmpty();
         await _broadcaster.DidNotReceive().NotifyMessageDeletedAsync(
             Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<DeleteMode>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }

--- a/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class DeleteMessageServiceTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private DeleteMessageService Build()
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        var options = Options.Create(new ChatOptions { DeleteForEveryoneTtlHours = 48 });
+        return new DeleteMessageService(_conversations, _messages, options, dispatcher, _broadcaster, _clock);
+    }
+
+    private (Conversation conversation, Message message) Seed(Guid sender, DateTimeOffset createdAt)
+    {
+        var conv = Conversation.OpenDirect(sender, Peer, createdAt);
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: conv.Id,
+            senderId: sender,
+            body: "hello",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c1",
+            createdAtUtc: createdAt);
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        _messages.ApplyDeleteForEveryoneAsync(msg.Id, Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _messages.AddHiddenForAsync(msg.Id, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        return (conv, msg);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_MissingMessage_ReturnsNull()
+    {
+        _messages.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Message?)null);
+
+        var dto = await Build().DeleteAsync(
+            new DeleteMessageRequest(Guid.NewGuid(), Author, DeleteMode.ForEveryone), default);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonParticipant_ThrowsAccessDenied()
+    {
+        var (_, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var act = () => Build().DeleteAsync(new DeleteMessageRequest(msg.Id, Stranger, DeleteMode.ForEveryone), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForEveryone_NotAuthor_Throws()
+    {
+        var (_, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var act = () => Build().DeleteAsync(new DeleteMessageRequest(msg.Id, Peer, DeleteMode.ForEveryone), default);
+
+        await act.Should().ThrowAsync<ChatNotMessageAuthorException>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForEveryone_PastTtl_Throws()
+    {
+        var (_, msg) = Seed(Author, _clock.GetUtcNow().AddHours(-49));
+
+        var act = () => Build().DeleteAsync(new DeleteMessageRequest(msg.Id, Author, DeleteMode.ForEveryone), default);
+
+        await act.Should().ThrowAsync<ChatEditTtlExpiredException>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForEveryone_HappyPath_TombstonesPublishesAndBroadcasts()
+    {
+        var (_, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var dto = await Build().DeleteAsync(
+            new DeleteMessageRequest(msg.Id, Author, DeleteMode.ForEveryone), default);
+
+        dto.Should().NotBeNull();
+        await _messages.Received().ApplyDeleteForEveryoneAsync(
+            msg.Id, Author, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        _outbox.Captured.OfType<ChatMessageDeletedEvent>()
+            .Should().ContainSingle(e => e.Mode == DeleteMode.ForEveryone);
+        await _broadcaster.Received().NotifyMessageDeletedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<string>(), msg.Id, DeleteMode.ForEveryone, Author, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ForMe_AnyParticipant_HidesAndPublishesEventWithoutBroadcast()
+    {
+        var (_, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var dto = await Build().DeleteAsync(new DeleteMessageRequest(msg.Id, Peer, DeleteMode.ForMe), default);
+
+        dto.Should().NotBeNull();
+        await _messages.Received().AddHiddenForAsync(msg.Id, Peer, Arg.Any<CancellationToken>());
+        _outbox.Captured.OfType<ChatMessageDeletedEvent>()
+            .Should().ContainSingle(e => e.Mode == DeleteMode.ForMe);
+        await _broadcaster.DidNotReceive().NotifyMessageDeletedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<DeleteMode>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class EditMessageServiceTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private EditMessageService Build()
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        var options = Options.Create(new ChatOptions { EditTtlHours = 48, MaxMentionsPerMessage = 50 });
+        return new EditMessageService(_conversations, _messages, options, dispatcher, _broadcaster, _clock);
+    }
+
+    private (Conversation conversation, Message message) Seed(Guid sender, DateTimeOffset createdAt)
+    {
+        var conv = Conversation.OpenDirect(sender, Peer, createdAt);
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: conv.Id,
+            senderId: sender,
+            body: "original",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c1",
+            createdAtUtc: createdAt);
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        _messages.ApplyEditAsync(msg.Id, Arg.Any<string>(), Arg.Any<IReadOnlyList<Guid>>(),
+                Arg.Any<EditHistoryEntry>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        return (conv, msg);
+    }
+
+    [Fact]
+    public async Task EditAsync_MissingMessage_Throws()
+    {
+        _messages.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Message?)null);
+
+        var act = () => Build().EditAsync(new EditMessageRequest(Guid.NewGuid(), Author, "x"), default);
+
+        await act.Should().ThrowAsync<ChatMessageNotFoundException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_NonParticipant_ThrowsAccessDenied()
+    {
+        var (conv, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var act = () => Build().EditAsync(new EditMessageRequest(msg.Id, Stranger, "x"), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_NotAuthor_ThrowsNotAuthor()
+    {
+        var (conv, msg) = Seed(Author, _clock.GetUtcNow());
+
+        var act = () => Build().EditAsync(new EditMessageRequest(msg.Id, Peer, "x"), default);
+
+        await act.Should().ThrowAsync<ChatNotMessageAuthorException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_PastTtl_ThrowsTtlExpired()
+    {
+        var createdAt = _clock.GetUtcNow().AddHours(-49);
+        var (conv, msg) = Seed(Author, createdAt);
+
+        var act = () => Build().EditAsync(new EditMessageRequest(msg.Id, Author, "edited"), default);
+
+        await act.Should().ThrowAsync<ChatEditTtlExpiredException>();
+    }
+
+    [Fact]
+    public async Task EditAsync_HappyPath_AppliesEdit_PublishesEvent_AndBroadcasts()
+    {
+        var (conv, msg) = Seed(Author, _clock.GetUtcNow());
+        // Refresh path returns the same message instance (good enough for unit-level assertion).
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg, msg);
+
+        var dto = await Build().EditAsync(new EditMessageRequest(msg.Id, Author, "edited"), default);
+
+        dto.Should().NotBeNull();
+        await _messages.Received().ApplyEditAsync(
+            msg.Id, "edited", Arg.Any<IReadOnlyList<Guid>>(),
+            Arg.Any<EditHistoryEntry>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        _outbox.Captured.OfType<ChatMessageEditedEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyMessageEditedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<MessageDto>(), Arg.Any<CancellationToken>());
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/ForwardMessagesServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ForwardMessagesServiceTests.cs
@@ -56,7 +56,10 @@ public class ForwardMessagesServiceTests
             attachments: Array.Empty<Attachment>(),
             clientMessageId: "c-source",
             createdAtUtc: _clock.GetUtcNow().AddMinutes(-1));
-        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        _messages.GetManyAsync(
+                Arg.Is<IReadOnlyList<Guid>>(ids => ids.Contains(msg.Id)),
+                Arg.Any<CancellationToken>())
+            .Returns(new[] { msg });
 
         return (target, source, msg);
     }
@@ -98,15 +101,16 @@ public class ForwardMessagesServiceTests
     [Fact]
     public async Task ForwardAsync_NonParticipantInSource_ThrowsAccessDenied()
     {
-        var (target, source, msg) = Seed();
-        // Replace source so the caller is NOT a participant.
+        var (target, _, _) = Seed();
+        // Source conversation where caller is NOT a participant.
         var foreignSource = Conversation.OpenDirect(SourcePeer, Stranger, _clock.GetUtcNow().AddMinutes(-5));
-        _conversations.GetByIdAsync(source.Id, Arg.Any<CancellationToken>()).Returns(foreignSource);
-        // The forwarded message claims to live in source.Id, so we keep that wiring.
         var foreignMsg = Message.Send(
             Guid.NewGuid(), foreignSource.Id, SourcePeer, "x", Array.Empty<Attachment>(), "c-x", _clock.GetUtcNow());
         _conversations.GetByIdAsync(foreignSource.Id, Arg.Any<CancellationToken>()).Returns(foreignSource);
-        _messages.GetByIdAsync(foreignMsg.Id, Arg.Any<CancellationToken>()).Returns(foreignMsg);
+        _messages.GetManyAsync(
+                Arg.Is<IReadOnlyList<Guid>>(ids => ids.Contains(foreignMsg.Id)),
+                Arg.Any<CancellationToken>())
+            .Returns(new[] { foreignMsg });
 
         var act = () => Build().ForwardAsync(
             new ForwardMessagesRequest(target.Id, Caller, new[] { foreignMsg.Id }), default);
@@ -148,7 +152,10 @@ public class ForwardMessagesServiceTests
             attachments: new[] { new Attachment(attachmentId, AttachmentType.Image, null, "p.png", 10, "image/png") },
             clientMessageId: "c-attach",
             createdAtUtc: _clock.GetUtcNow().AddMinutes(-1));
-        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        _messages.GetManyAsync(
+                Arg.Is<IReadOnlyList<Guid>>(ids => ids.Contains(msg.Id)),
+                Arg.Any<CancellationToken>())
+            .Returns(new[] { msg });
 
         await Build().ForwardAsync(new ForwardMessagesRequest(target.Id, Caller, new[] { msg.Id }), default);
 

--- a/tests/unit/ChatService.UnitTests/Application/ForwardMessagesServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ForwardMessagesServiceTests.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class ForwardMessagesServiceTests
+{
+    private static readonly Guid Caller = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TargetPeer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid SourcePeer = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IMediaServiceClient _media = Substitute.For<IMediaServiceClient>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private ForwardMessagesService Build(int maxForwardedMessages = 50)
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        var options = Options.Create(new ChatOptions { MaxForwardedMessages = maxForwardedMessages });
+        return new ForwardMessagesService(_conversations, _messages, _media, options, dispatcher, _broadcaster, _clock);
+    }
+
+    private (Conversation target, Conversation source, Message message) Seed()
+    {
+        var target = Conversation.OpenDirect(Caller, TargetPeer, _clock.GetUtcNow());
+        var source = Conversation.OpenDirect(Caller, SourcePeer, _clock.GetUtcNow().AddMinutes(-5));
+        _conversations.GetByIdAsync(target.Id, Arg.Any<CancellationToken>()).Returns(target);
+        _conversations.GetByIdAsync(source.Id, Arg.Any<CancellationToken>()).Returns(source);
+
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: source.Id,
+            senderId: SourcePeer,
+            body: "to forward",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c-source",
+            createdAtUtc: _clock.GetUtcNow().AddMinutes(-1));
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+
+        return (target, source, msg);
+    }
+
+    [Fact]
+    public async Task ForwardAsync_TooManyMessages_Throws()
+    {
+        var (target, _, _) = Seed();
+        var ids = Enumerable.Range(0, 51).Select(_ => Guid.NewGuid()).ToList();
+
+        var act = () => Build(maxForwardedMessages: 50)
+            .ForwardAsync(new ForwardMessagesRequest(target.Id, Caller, ids), default);
+
+        await act.Should().ThrowAsync<ChatForwardLimitExceededException>();
+    }
+
+    [Fact]
+    public async Task ForwardAsync_TargetConversationMissing_Throws()
+    {
+        _conversations.GetByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((Conversation?)null);
+
+        var act = () => Build().ForwardAsync(
+            new ForwardMessagesRequest("missing", Caller, new[] { Guid.NewGuid() }), default);
+
+        await act.Should().ThrowAsync<ConversationNotFoundException>();
+    }
+
+    [Fact]
+    public async Task ForwardAsync_NonParticipantInTarget_ThrowsAccessDenied()
+    {
+        var (target, _, msg) = Seed();
+
+        var act = () => Build().ForwardAsync(
+            new ForwardMessagesRequest(target.Id, Stranger, new[] { msg.Id }), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task ForwardAsync_NonParticipantInSource_ThrowsAccessDenied()
+    {
+        var (target, source, msg) = Seed();
+        // Replace source so the caller is NOT a participant.
+        var foreignSource = Conversation.OpenDirect(SourcePeer, Stranger, _clock.GetUtcNow().AddMinutes(-5));
+        _conversations.GetByIdAsync(source.Id, Arg.Any<CancellationToken>()).Returns(foreignSource);
+        // The forwarded message claims to live in source.Id, so we keep that wiring.
+        var foreignMsg = Message.Send(
+            Guid.NewGuid(), foreignSource.Id, SourcePeer, "x", Array.Empty<Attachment>(), "c-x", _clock.GetUtcNow());
+        _conversations.GetByIdAsync(foreignSource.Id, Arg.Any<CancellationToken>()).Returns(foreignSource);
+        _messages.GetByIdAsync(foreignMsg.Id, Arg.Any<CancellationToken>()).Returns(foreignMsg);
+
+        var act = () => Build().ForwardAsync(
+            new ForwardMessagesRequest(target.Id, Caller, new[] { foreignMsg.Id }), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task ForwardAsync_HappyPath_InsertsMessages_PublishesEvents_AndBroadcasts()
+    {
+        var (target, _, msg) = Seed();
+
+        var result = await Build().ForwardAsync(
+            new ForwardMessagesRequest(target.Id, Caller, new[] { msg.Id }), default);
+
+        result.Should().ContainSingle();
+        await _messages.Received().InsertAsync(
+            Arg.Is<Message>(m => m.ConversationId == target.Id && m.ForwardedFrom != null),
+            Arg.Any<CancellationToken>());
+        _outbox.Captured.OfType<ChatMessageSentEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyMessageReceivedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<MessageDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ForwardAsync_WithAttachments_GrantsAccessForAllAttachmentsToTargetParticipants()
+    {
+        var target = Conversation.OpenDirect(Caller, TargetPeer, _clock.GetUtcNow());
+        var source = Conversation.OpenDirect(Caller, SourcePeer, _clock.GetUtcNow().AddMinutes(-5));
+        _conversations.GetByIdAsync(target.Id, Arg.Any<CancellationToken>()).Returns(target);
+        _conversations.GetByIdAsync(source.Id, Arg.Any<CancellationToken>()).Returns(source);
+
+        var attachmentId = Guid.NewGuid();
+        var msg = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: source.Id,
+            senderId: SourcePeer,
+            body: "with attach",
+            attachments: new[] { new Attachment(attachmentId, AttachmentType.Image, null, "p.png", 10, "image/png") },
+            clientMessageId: "c-attach",
+            createdAtUtc: _clock.GetUtcNow().AddMinutes(-1));
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+
+        await Build().ForwardAsync(new ForwardMessagesRequest(target.Id, Caller, new[] { msg.Id }), default);
+
+        await _media.Received().GrantConversationAccessAsync(
+            attachmentId,
+            Arg.Is<IReadOnlyList<Guid>>(list => list.Count == 1 && list[0] == TargetPeer),
+            target.Id,
+            Caller,
+            Arg.Any<CancellationToken>());
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/MentionsParserTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/MentionsParserTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Application.Mentions;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class MentionsParserTests
+{
+    private static readonly Guid Alice = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Bob = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Carol = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid Stranger = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private static readonly Guid[] Participants = [Alice, Bob, Carol];
+
+    [Fact]
+    public void Parse_NullOrEmptyBody_ReturnsEmpty()
+    {
+        MentionsParser.Parse(null, Participants, maxMentions: 10).Should().BeEmpty();
+        MentionsParser.Parse(string.Empty, Participants, maxMentions: 10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NoMentions_ReturnsEmpty()
+    {
+        MentionsParser.Parse("plain hello", Participants, 10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_SingleParticipantMention_IsExtracted()
+    {
+        var body = $"hi @{Alice:D}!";
+
+        MentionsParser.Parse(body, Participants, 10).Should().ContainSingle().Which.Should().Be(Alice);
+    }
+
+    [Fact]
+    public void Parse_MentionOfNonParticipant_IsDropped()
+    {
+        var body = $"hi @{Stranger:D}";
+
+        MentionsParser.Parse(body, Participants, 10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_DuplicateMention_IsDeduped()
+    {
+        var body = $"hello @{Bob:D}, again @{Bob:D}";
+
+        MentionsParser.Parse(body, Participants, 10).Should().ContainSingle().Which.Should().Be(Bob);
+    }
+
+    [Fact]
+    public void Parse_Everyone_ExpandsToAllParticipants()
+    {
+        MentionsParser.Parse("@everyone please review", Participants, 10)
+            .Should().BeEquivalentTo(Participants);
+    }
+
+    [Fact]
+    public void Parse_TeachersStudentsTokens_AreEmptyInStub()
+    {
+        MentionsParser.Parse("@teachers note", Participants, 10).Should().BeEmpty();
+        MentionsParser.Parse("@students homework", Participants, 10).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_MixedEveryoneAndExplicit_IsDeduped()
+    {
+        var body = $"@everyone — and especially @{Alice:D}";
+
+        var result = MentionsParser.Parse(body, Participants, 10);
+
+        result.Should().HaveCount(Participants.Length);
+        result.Should().BeEquivalentTo(Participants);
+    }
+
+    [Fact]
+    public void Parse_AboveMaxMentions_IsTruncated()
+    {
+        var body = string.Join(' ', Participants.Select(p => $"@{p:D}"));
+
+        var result = MentionsParser.Parse(body, Participants, maxMentions: 2);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Parse_MaxMentionsZero_Throws()
+    {
+        var act = () => MentionsParser.Parse("hi", Participants, maxMentions: 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Parse_GuidMatchIsCaseInsensitive()
+    {
+        var body = $"hi @{Alice.ToString("D").ToUpperInvariant()}";
+
+        MentionsParser.Parse(body, Participants, 10).Should().ContainSingle().Which.Should().Be(Alice);
+    }
+
+    [Fact]
+    public void Parse_PreservesOrderOfFirstAppearance()
+    {
+        var body = $"@{Carol:D} @{Alice:D} @{Bob:D}";
+
+        var result = MentionsParser.Parse(body, Participants, 10);
+
+        result.Should().Equal(Carol, Alice, Bob);
+    }
+
+    [Fact]
+    public void Parse_TextLookingLikeEmail_IsNotMentioned()
+    {
+        var body = "ping admin@example.com if needed";
+
+        MentionsParser.Parse(body, Participants, 10).Should().BeEmpty();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/PinningServicesTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/PinningServicesTests.cs
@@ -1,0 +1,178 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Authorization;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class PinningServicesTests
+{
+    private static readonly Guid Caller = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IDisciplineRoleResolver _roles = Substitute.For<IDisciplineRoleResolver>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private (Conversation conv, Message msg) Seed(bool canPin = true)
+    {
+        var conv = Conversation.OpenDirect(Caller, Peer, _clock.GetUtcNow());
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+        var msg = Message.Send(Guid.NewGuid(), conv.Id, Caller, "x", Array.Empty<Attachment>(), "c", _clock.GetUtcNow());
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        _roles.CanPinAsync(Arg.Any<Guid>(), conv, Arg.Any<CancellationToken>()).Returns(canPin);
+        return (conv, msg);
+    }
+
+    private PinMessageService BuildPin(int maxPinned = 5)
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        var options = Options.Create(new ChatOptions { MaxPinnedMessages = maxPinned });
+        return new PinMessageService(_conversations, _messages, _roles, options, dispatcher, _broadcaster, _clock);
+    }
+
+    private UnpinMessageService BuildUnpin()
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        return new UnpinMessageService(_conversations, _messages, _roles, dispatcher, _broadcaster, _clock);
+    }
+
+    [Fact]
+    public async Task PinAsync_NonParticipant_Throws()
+    {
+        var (conv, msg) = Seed();
+
+        var act = () => BuildPin().PinAsync(new PinMessageRequest(conv.Id, Stranger, msg.Id), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task PinAsync_DisciplineRoleDenies_Throws()
+    {
+        var (conv, msg) = Seed(canPin: false);
+
+        var act = () => BuildPin().PinAsync(new PinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task PinAsync_HappyPath_PublishesAndBroadcasts()
+    {
+        var (conv, msg) = Seed();
+        _conversations.AddPinnedMessageAsync(conv.Id, msg.Id, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>())
+            .Returns(conv,
+                Conversation.Hydrate(conv.Id, ConversationType.Direct, conv.Participants, conv.CreatedAtUtc,
+                    conv.LastMessageAtUtc, conv.LastMessagePreview, new[] { msg.Id }));
+        _messages.GetByIdsAsync(conv.Id, Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { msg });
+
+        var dtos = await BuildPin().PinAsync(new PinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        dtos.Should().ContainSingle();
+        _outbox.Captured.OfType<ChatMessagePinnedEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyPinsUpdatedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), conv.Id, Arg.Any<IReadOnlyList<MessageDto>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PinAsync_AtCap_Throws()
+    {
+        var (conv, msg) = Seed();
+        _conversations.AddPinnedMessageAsync(conv.Id, msg.Id, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var act = () => BuildPin(maxPinned: 5).PinAsync(new PinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        await act.Should().ThrowAsync<ChatPinLimitExceededException>();
+    }
+
+    [Fact]
+    public async Task PinAsync_AlreadyPinned_IdempotentNoEvent()
+    {
+        var (conv, msg) = Seed();
+        var withPinned = Conversation.Hydrate(conv.Id, ConversationType.Direct, conv.Participants, conv.CreatedAtUtc,
+            conv.LastMessageAtUtc, conv.LastMessagePreview, new[] { msg.Id });
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(withPinned);
+        _roles.CanPinAsync(Arg.Any<Guid>(), Arg.Any<Conversation>(), Arg.Any<CancellationToken>()).Returns(true);
+        _messages.GetByIdsAsync(conv.Id, Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { msg });
+
+        await BuildPin().PinAsync(new PinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        _outbox.Captured.OfType<ChatMessagePinnedEvent>().Should().BeEmpty();
+        await _conversations.DidNotReceive().AddPinnedMessageAsync(
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnpinAsync_HappyPath_PublishesAndBroadcasts()
+    {
+        var (conv, msg) = Seed();
+        _conversations.RemovePinnedMessageAsync(conv.Id, msg.Id, Arg.Any<CancellationToken>()).Returns(true);
+        _messages.GetByIdsAsync(conv.Id, Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Message>());
+
+        var dtos = await BuildUnpin().UnpinAsync(new UnpinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        dtos.Should().BeEmpty();
+        _outbox.Captured.OfType<ChatMessageUnpinnedEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyPinsUpdatedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), conv.Id, Arg.Any<IReadOnlyList<MessageDto>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnpinAsync_NotPinned_NoEvent()
+    {
+        var (conv, msg) = Seed();
+        _conversations.RemovePinnedMessageAsync(conv.Id, msg.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        await BuildUnpin().UnpinAsync(new UnpinMessageRequest(conv.Id, Caller, msg.Id), default);
+
+        _outbox.Captured.OfType<ChatMessageUnpinnedEvent>().Should().BeEmpty();
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/ReactionServicesTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ReactionServicesTests.cs
@@ -1,0 +1,162 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class ReactionServicesTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private (Conversation conv, Message msg) Seed()
+    {
+        var conv = Conversation.OpenDirect(Author, Peer, _clock.GetUtcNow());
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+        var msg = Message.Send(Guid.NewGuid(), conv.Id, Author, "x", Array.Empty<Attachment>(),
+            "c1", _clock.GetUtcNow());
+        _messages.GetByIdAsync(msg.Id, Arg.Any<CancellationToken>()).Returns(msg);
+        return (conv, msg);
+    }
+
+    private AddReactionService BuildAdd(ChatOptions? options = null)
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        return new AddReactionService(
+            _conversations, _messages, Options.Create(options ?? new ChatOptions()),
+            dispatcher, _broadcaster, _clock);
+    }
+
+    private RemoveReactionService BuildRemove()
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        return new RemoveReactionService(_conversations, _messages, dispatcher, _broadcaster, _clock);
+    }
+
+    [Fact]
+    public async Task AddAsync_NonParticipant_Throws()
+    {
+        var (_, msg) = Seed();
+
+        var act = () => BuildAdd().AddAsync(new AddReactionRequest(msg.Id, Stranger, "👍"), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task AddAsync_DisallowedEmoji_Throws()
+    {
+        var (_, msg) = Seed();
+        var opts = new ChatOptions { AllowedReactionEmojis = new[] { "❤" } };
+
+        var act = () => BuildAdd(opts).AddAsync(new AddReactionRequest(msg.Id, Author, "👍"), default);
+
+        await act.Should().ThrowAsync<ChatReactionNotAllowedException>();
+    }
+
+    [Fact]
+    public async Task AddAsync_HappyPath_PersistsAndPublishes()
+    {
+        var (_, msg) = Seed();
+        _messages.AddReactionAsync(msg.Id, Arg.Any<Reaction>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        await BuildAdd().AddAsync(new AddReactionRequest(msg.Id, Author, "👍"), default);
+
+        await _messages.Received().AddReactionAsync(msg.Id, Arg.Any<Reaction>(), Arg.Any<CancellationToken>());
+        _outbox.Captured.OfType<ChatReactionAddedEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyReactionUpdatedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), msg.Id, Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<Guid>>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AddAsync_AlreadySameReaction_DoesNotPublishOrBroadcast()
+    {
+        var (_, msg) = Seed();
+        _messages.AddReactionAsync(msg.Id, Arg.Any<Reaction>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        await BuildAdd().AddAsync(new AddReactionRequest(msg.Id, Author, "👍"), default);
+
+        _outbox.Captured.OfType<ChatReactionAddedEvent>().Should().BeEmpty();
+        await _broadcaster.DidNotReceive().NotifyReactionUpdatedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<Guid>>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NonParticipant_Throws()
+    {
+        var (_, msg) = Seed();
+
+        var act = () => BuildRemove().RemoveAsync(new RemoveReactionRequest(msg.Id, Stranger, "👍"), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NotPresent_NoEventNoBroadcast()
+    {
+        var (_, msg) = Seed();
+        _messages.RemoveReactionAsync(msg.Id, Author, "👍", Arg.Any<CancellationToken>()).Returns(false);
+
+        await BuildRemove().RemoveAsync(new RemoveReactionRequest(msg.Id, Author, "👍"), default);
+
+        _outbox.Captured.OfType<ChatReactionRemovedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_ExistingReaction_PublishesAndBroadcasts()
+    {
+        var (_, msg) = Seed();
+        _messages.RemoveReactionAsync(msg.Id, Author, "👍", Arg.Any<CancellationToken>()).Returns(true);
+
+        await BuildRemove().RemoveAsync(new RemoveReactionRequest(msg.Id, Author, "👍"), default);
+
+        _outbox.Captured.OfType<ChatReactionRemovedEvent>().Should().ContainSingle();
+        await _broadcaster.Received().NotifyReactionUpdatedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), msg.Id,
+            Arg.Any<IReadOnlyDictionary<string, IReadOnlyList<Guid>>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
@@ -32,7 +32,8 @@ public class SendMessageServiceTests
         var dispatcher = new ChatEventDispatcher(
             _outbox,
             new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
-        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, TimeProvider.System);
+        var options = Microsoft.Extensions.Options.Options.Create(new Urfu.Link.Services.Chat.Infrastructure.ChatOptions());
+        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, TimeProvider.System, options);
     }
 
     private Conversation SeedConversation()

--- a/tests/unit/ChatService.UnitTests/Domain/ConversationPinningTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/ConversationPinningTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class ConversationPinningTests
+{
+    private static readonly Guid UserA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTimeOffset Now = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+
+    private static Conversation NewDirect() => Conversation.OpenDirect(UserA, UserB, Now);
+
+    [Fact]
+    public void NewConversation_HasNoPinnedMessages()
+    {
+        var conversation = NewDirect();
+
+        conversation.PinnedMessageIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PinMessage_FirstTime_AddsToPinnedList()
+    {
+        var conversation = NewDirect();
+        var messageId = Guid.NewGuid();
+
+        var pinned = conversation.PinMessage(messageId, maxPinned: 5);
+
+        pinned.Should().BeTrue();
+        conversation.PinnedMessageIds.Should().ContainSingle(id => id == messageId);
+        conversation.IsPinned(messageId).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PinMessage_AlreadyPinned_IsNoopReturnsFalse()
+    {
+        var conversation = NewDirect();
+        var messageId = Guid.NewGuid();
+        conversation.PinMessage(messageId, maxPinned: 5);
+
+        var second = conversation.PinMessage(messageId, maxPinned: 5);
+
+        second.Should().BeFalse();
+        conversation.PinnedMessageIds.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void PinMessage_AtCap_ReturnsFalse()
+    {
+        var conversation = NewDirect();
+        for (var i = 0; i < 5; i++)
+        {
+            conversation.PinMessage(Guid.NewGuid(), maxPinned: 5).Should().BeTrue();
+        }
+
+        var sixth = conversation.PinMessage(Guid.NewGuid(), maxPinned: 5);
+
+        sixth.Should().BeFalse();
+        conversation.PinnedMessageIds.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public void PinMessage_NonPositiveMaxPinned_Throws()
+    {
+        var conversation = NewDirect();
+
+        var act = () => conversation.PinMessage(Guid.NewGuid(), maxPinned: 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void UnpinMessage_PinnedMessage_RemovesAndReturnsTrue()
+    {
+        var conversation = NewDirect();
+        var messageId = Guid.NewGuid();
+        conversation.PinMessage(messageId, maxPinned: 5);
+
+        var unpinned = conversation.UnpinMessage(messageId);
+
+        unpinned.Should().BeTrue();
+        conversation.PinnedMessageIds.Should().BeEmpty();
+        conversation.IsPinned(messageId).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnpinMessage_NotPinned_ReturnsFalse()
+    {
+        var conversation = NewDirect();
+
+        var unpinned = conversation.UnpinMessage(Guid.NewGuid());
+
+        unpinned.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Hydrate_RestoresPinnedMessageIds()
+    {
+        var pinned = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        var conversation = Conversation.Hydrate(
+            id: "abc",
+            type: ConversationType.Direct,
+            participants: new[] { UserA, UserB },
+            createdAtUtc: Now,
+            lastMessageAtUtc: Now,
+            lastMessagePreview: null,
+            pinnedMessageIds: pinned);
+
+        conversation.PinnedMessageIds.Should().BeEquivalentTo(pinned);
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageDeleteTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageDeleteTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class MessageDeleteTests
+{
+    private const string ConversationId = "abc";
+    private static readonly Guid Sender = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Recipient = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTimeOffset Created = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(48);
+
+    private static Message NewMessage() => Message.Send(
+        id: Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Sender,
+        body: "hello",
+        attachments: new[] { new Attachment(Guid.NewGuid(), AttachmentType.Image, null, "f.png", 10, "image/png") },
+        clientMessageId: "client-1",
+        createdAtUtc: Created);
+
+    [Fact]
+    public void MarkDeletedForEveryone_WithinTtl_ClearsContent_AndSetsTombstone()
+    {
+        var message = NewMessage();
+        message.AddReaction(Recipient, "👍", Created.AddSeconds(1));
+        var deletedAt = Created.AddMinutes(1);
+
+        var deleted = message.MarkDeletedForEveryone(Sender, deletedAt, Ttl);
+
+        deleted.Should().BeTrue();
+        message.State.Should().Be(MessageState.Deleted);
+        message.DeletedAtUtc.Should().Be(deletedAt);
+        message.DeletedBy.Should().Be(Sender);
+        message.DeleteMode.Should().Be(DeleteMode.ForEveryone);
+        message.Body.Should().BeEmpty();
+        message.Attachments.Should().BeEmpty();
+        message.Reactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MarkDeletedForEveryone_PastTtl_ReturnsFalse_AndKeepsContent()
+    {
+        var message = NewMessage();
+        var deletedAt = Created.AddHours(49);
+
+        var deleted = message.MarkDeletedForEveryone(Sender, deletedAt, Ttl);
+
+        deleted.Should().BeFalse();
+        message.State.Should().Be(MessageState.Sent);
+        message.Body.Should().Be("hello");
+    }
+
+    [Fact]
+    public void MarkDeletedForEveryone_AlreadyDeleted_IsIdempotentNoop()
+    {
+        var message = NewMessage();
+        message.MarkDeletedForEveryone(Sender, Created.AddMinutes(1), Ttl);
+
+        var second = message.MarkDeletedForEveryone(Sender, Created.AddMinutes(2), Ttl);
+
+        second.Should().BeFalse();
+        message.DeletedAtUtc.Should().Be(Created.AddMinutes(1));
+    }
+
+    [Fact]
+    public void MarkDeletedForMe_AddsUserToHiddenFor_Idempotent()
+    {
+        var message = NewMessage();
+
+        message.MarkDeletedForMe(Recipient).Should().BeTrue();
+        message.HiddenFor.Should().BeEquivalentTo(new[] { Recipient });
+
+        message.MarkDeletedForMe(Recipient).Should().BeFalse();
+        message.HiddenFor.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void MarkDeletedForMe_DoesNotAffectVisibleStateForOthers()
+    {
+        var message = NewMessage();
+
+        message.MarkDeletedForMe(Recipient);
+
+        message.State.Should().Be(MessageState.Sent);
+        message.Body.Should().Be("hello");
+        message.Attachments.Should().HaveCount(1);
+        message.IsHiddenFor(Recipient).Should().BeTrue();
+        message.IsHiddenFor(Sender).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDeletableForEveryoneBy_NonAuthor_ReturnsFalse()
+    {
+        var message = NewMessage();
+
+        message.IsDeletableForEveryoneBy(Recipient, Created.AddMinutes(1), Ttl).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDeletableForEveryoneBy_AuthorWithinTtl_ReturnsTrue()
+    {
+        var message = NewMessage();
+
+        message.IsDeletableForEveryoneBy(Sender, Created.AddMinutes(1), Ttl).Should().BeTrue();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageEditTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageEditTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class MessageEditTests
+{
+    private const string ConversationId = "abc";
+    private static readonly Guid Sender = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Outsider = Guid.Parse("99999999-9999-9999-9999-999999999999");
+    private static readonly DateTimeOffset Created = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(48);
+
+    private static Message NewMessage() => Message.Send(
+        id: Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Sender,
+        body: "hello",
+        attachments: Array.Empty<Attachment>(),
+        clientMessageId: "client-1",
+        createdAtUtc: Created);
+
+    [Fact]
+    public void IsAuthor_ReturnsTrueForSender_FalseForOthers()
+    {
+        var message = NewMessage();
+
+        message.IsAuthor(Sender).Should().BeTrue();
+        message.IsAuthor(Outsider).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEditableBy_AuthorWithinTtl_ReturnsTrue()
+    {
+        var message = NewMessage();
+
+        message.IsEditableBy(Sender, Created.AddHours(1), Ttl).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEditableBy_NonAuthor_ReturnsFalse()
+    {
+        var message = NewMessage();
+
+        message.IsEditableBy(Outsider, Created.AddHours(1), Ttl).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEditableBy_PastTtl_ReturnsFalse()
+    {
+        var message = NewMessage();
+
+        message.IsEditableBy(Sender, Created.AddHours(49), Ttl).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEditableBy_DeletedMessage_ReturnsFalse()
+    {
+        var message = NewMessage();
+        message.MarkDeletedForEveryone(Sender, Created.AddMinutes(1), Ttl);
+
+        message.IsEditableBy(Sender, Created.AddMinutes(2), Ttl).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Edit_WithinTtl_UpdatesBody_AndRecordsHistory_AndSetsEditedAtUtc()
+    {
+        var message = NewMessage();
+        var editedAt = Created.AddMinutes(10);
+
+        var changed = message.Edit("updated", Array.Empty<Guid>(), editedAt, Ttl);
+
+        changed.Should().BeTrue();
+        message.Body.Should().Be("updated");
+        message.EditedAtUtc.Should().Be(editedAt);
+        message.EditHistory.Should().HaveCount(1);
+        message.EditHistory[0].Body.Should().Be("hello");
+        message.EditHistory[0].EditedAtUtc.Should().Be(Created);
+    }
+
+    [Fact]
+    public void Edit_PastTtl_ReturnsFalse_AndKeepsBody()
+    {
+        var message = NewMessage();
+
+        var changed = message.Edit("late", Array.Empty<Guid>(), Created.AddHours(49), Ttl);
+
+        changed.Should().BeFalse();
+        message.Body.Should().Be("hello");
+        message.EditedAtUtc.Should().BeNull();
+        message.EditHistory.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Edit_DeletedMessage_ReturnsFalse()
+    {
+        var message = NewMessage();
+        message.MarkDeletedForEveryone(Sender, Created.AddMinutes(1), Ttl);
+
+        var changed = message.Edit("after-delete", Array.Empty<Guid>(), Created.AddMinutes(2), Ttl);
+
+        changed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Edit_SameBodyAndMentions_IsNoop()
+    {
+        var message = NewMessage();
+
+        var changed = message.Edit("hello", Array.Empty<Guid>(), Created.AddMinutes(1), Ttl);
+
+        changed.Should().BeFalse();
+        message.EditHistory.Should().BeEmpty();
+        message.EditedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void Edit_ReplacesMentionsList()
+    {
+        var message = NewMessage();
+        var mentioned = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        var changed = message.Edit("hi @user", mentioned, Created.AddMinutes(1), Ttl);
+
+        changed.Should().BeTrue();
+        message.Mentions.Should().BeEquivalentTo(mentioned);
+    }
+
+    [Fact]
+    public void Edit_TwiceAppendsTwoEntriesToHistory_KeepingChronologicalOrder()
+    {
+        var message = NewMessage();
+        message.Edit("first", Array.Empty<Guid>(), Created.AddMinutes(1), Ttl);
+        message.Edit("second", Array.Empty<Guid>(), Created.AddMinutes(2), Ttl);
+
+        message.EditHistory.Should().HaveCount(2);
+        message.EditHistory[0].Body.Should().Be("hello");
+        message.EditHistory[0].EditedAtUtc.Should().Be(Created);
+        message.EditHistory[1].Body.Should().Be("first");
+        message.EditHistory[1].EditedAtUtc.Should().Be(Created.AddMinutes(1));
+        message.Body.Should().Be("second");
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageReactionsTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageReactionsTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class MessageReactionsTests
+{
+    private const string ConversationId = "abc";
+    private static readonly Guid Sender = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid UserA = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid UserB = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly DateTimeOffset Created = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(48);
+
+    private static Message NewMessage() => Message.Send(
+        id: Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Sender,
+        body: "hi",
+        attachments: Array.Empty<Attachment>(),
+        clientMessageId: "client-1",
+        createdAtUtc: Created);
+
+    [Fact]
+    public void AddReaction_NewReaction_IsAddedAndReturnsTrue()
+    {
+        var message = NewMessage();
+
+        var changed = message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+
+        changed.Should().BeTrue();
+        message.Reactions.Should().ContainSingle(r => r.UserId == UserA && r.Emoji == "👍");
+    }
+
+    [Fact]
+    public void AddReaction_SameUserSameEmoji_IsNoop()
+    {
+        var message = NewMessage();
+        message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+
+        var changed = message.AddReaction(UserA, "👍", Created.AddSeconds(2));
+
+        changed.Should().BeFalse();
+        message.Reactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddReaction_SameUserDifferentEmoji_ReplacesPriorReaction()
+    {
+        var message = NewMessage();
+        message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+
+        var changed = message.AddReaction(UserA, "❤", Created.AddSeconds(2));
+
+        changed.Should().BeTrue();
+        message.Reactions.Should().ContainSingle();
+        message.Reactions[0].Emoji.Should().Be("❤");
+        message.Reactions[0].CreatedAtUtc.Should().Be(Created.AddSeconds(2));
+    }
+
+    [Fact]
+    public void AddReaction_DifferentUsers_AccumulateIndependently()
+    {
+        var message = NewMessage();
+        message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+        message.AddReaction(UserB, "👍", Created.AddSeconds(2));
+        message.AddReaction(UserB, "❤", Created.AddSeconds(3));
+
+        message.Reactions.Should().HaveCount(2);
+        message.Reactions.Should().Contain(r => r.UserId == UserA && r.Emoji == "👍");
+        message.Reactions.Should().Contain(r => r.UserId == UserB && r.Emoji == "❤");
+    }
+
+    [Fact]
+    public void AddReaction_ToDeletedMessage_ReturnsFalse()
+    {
+        var message = NewMessage();
+        message.MarkDeletedForEveryone(Sender, Created.AddMinutes(1), Ttl);
+
+        var changed = message.AddReaction(UserA, "👍", Created.AddMinutes(2));
+
+        changed.Should().BeFalse();
+        message.Reactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveReaction_ExistingReaction_ReturnsTrueAndRemoves()
+    {
+        var message = NewMessage();
+        message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+
+        var removed = message.RemoveReaction(UserA, "👍");
+
+        removed.Should().BeTrue();
+        message.Reactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveReaction_DifferentEmoji_ReturnsFalse_AndKeepsExisting()
+    {
+        var message = NewMessage();
+        message.AddReaction(UserA, "👍", Created.AddSeconds(1));
+
+        var removed = message.RemoveReaction(UserA, "❤");
+
+        removed.Should().BeFalse();
+        message.Reactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void RemoveReaction_FromUserWithoutReaction_ReturnsFalse()
+    {
+        var message = NewMessage();
+
+        var removed = message.RemoveReaction(UserA, "👍");
+
+        removed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddReaction_WithEmptyEmoji_ThrowsArgumentException()
+    {
+        var message = NewMessage();
+
+        var act = () => message.AddReaction(UserA, "", Created.AddSeconds(1));
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageReadByTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageReadByTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class MessageReadByTests
+{
+    private const string ConversationId = "abc";
+    private static readonly Guid Sender = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Reader1 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Reader2 = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly DateTimeOffset Created = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(48);
+
+    private static Message NewMessage() => Message.Send(
+        id: Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Sender,
+        body: "hi",
+        attachments: Array.Empty<Attachment>(),
+        clientMessageId: "client-1",
+        createdAtUtc: Created);
+
+    [Fact]
+    public void MarkReadBy_FirstReader_PopulatesReadByAndScalarReadAt()
+    {
+        var message = NewMessage();
+        var readAt = Created.AddSeconds(10);
+
+        var changed = message.MarkReadBy(Reader1, readAt);
+
+        changed.Should().BeTrue();
+        message.ReadBy.Should().ContainSingle(r => r.UserId == Reader1 && r.ReadAtUtc == readAt);
+        message.ReadAtUtc.Should().Be(readAt);
+        message.State.Should().Be(MessageState.Read);
+        message.DeliveredAtUtc.Should().Be(readAt);
+    }
+
+    [Fact]
+    public void MarkReadBy_SecondReader_AddsToReadBy_AndKeepsScalarReadAtFromFirst()
+    {
+        var message = NewMessage();
+        message.MarkReadBy(Reader1, Created.AddSeconds(10));
+
+        var changed = message.MarkReadBy(Reader2, Created.AddSeconds(20));
+
+        changed.Should().BeTrue();
+        message.ReadBy.Should().HaveCount(2);
+        message.ReadAtUtc.Should().Be(Created.AddSeconds(10));
+    }
+
+    [Fact]
+    public void MarkReadBy_SameUserTwice_IsIdempotent()
+    {
+        var message = NewMessage();
+        message.MarkReadBy(Reader1, Created.AddSeconds(10));
+
+        var changed = message.MarkReadBy(Reader1, Created.AddSeconds(20));
+
+        changed.Should().BeFalse();
+        message.ReadBy.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void MarkReadBy_OnDeletedMessage_ReturnsFalse()
+    {
+        var message = NewMessage();
+        message.MarkDeletedForEveryone(Sender, Created.AddMinutes(1), Ttl);
+
+        var changed = message.MarkReadBy(Reader1, Created.AddMinutes(2));
+
+        changed.Should().BeFalse();
+        message.ReadBy.Should().BeEmpty();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/ValueObjects/ReplyToTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/ValueObjects/ReplyToTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain.ValueObjects;
+
+public class ReplyToTests
+{
+    private static readonly Guid MessageId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid SenderId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Create_ShortBody_KeepsBodyAsIs()
+    {
+        var replyTo = ReplyTo.Create(MessageId, SenderId, "hello");
+
+        replyTo.Preview.Should().Be("hello");
+        replyTo.MessageId.Should().Be(MessageId);
+        replyTo.SenderId.Should().Be(SenderId);
+    }
+
+    [Fact]
+    public void Create_LongBody_TruncatesToMaxPreviewLength()
+    {
+        var body = new string('a', ReplyTo.MaxPreviewLength + 50);
+
+        var replyTo = ReplyTo.Create(MessageId, SenderId, body);
+
+        replyTo.Preview.Length.Should().Be(ReplyTo.MaxPreviewLength);
+    }
+
+    [Fact]
+    public void Create_BodyWithSurrogatePairAtBoundary_DoesNotSplitPair()
+    {
+        // Build a body where index (MaxPreviewLength - 1) lands on a high surrogate.
+        var prefix = new string('a', ReplyTo.MaxPreviewLength - 1);
+        var rocket = "🚀"; // 🚀 is encoded as surrogate pair (high, low)
+        var body = prefix + rocket + new string('b', 50);
+
+        var replyTo = ReplyTo.Create(MessageId, SenderId, body);
+
+        replyTo.Preview.Length.Should().Be(ReplyTo.MaxPreviewLength - 1);
+        char.IsHighSurrogate(replyTo.Preview[^1]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Create_NullOrEmptyBody_ProducesEmptyPreview()
+    {
+        ReplyTo.Create(MessageId, SenderId, null!).Preview.Should().BeEmpty();
+        ReplyTo.Create(MessageId, SenderId, string.Empty).Preview.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #211

## Что сделано

Расширение ChatService полным набором фич мессенджера поверх MVP #210:

- **Edit / Delete** — TTL=48h, author-only, `EditHistory[]`, `DeleteMode.ForMe / ForEveryone` (`HiddenFor[]` для for-me, tombstone для for-everyone).
- **Reply** — `ReplyTo` в SendMessage с проверкой same-conversation, surrogate-safe truncation preview до 100 символов.
- **Forward** — до 50 сообщений за раз, `ForwardedFrom` value object, `MediaService.GrantConversationAccess` fan-out для attachment'ов.
- **Reactions** — emoji whitelist (по дефолту любые), pull-then-push pattern (одна реакция на user/message), summary `Dictionary<emoji, userIds[]>`.
- **Mentions** — парсер `@<guid>` / `@everyone` (плюс `@teachers` / `@students` как stub до #214). Публикует отдельный `chat.mention.created.v1` для NotificationService #209.
- **Pinned messages** — `Conversation.PinnedMessageIds[]` с cap=5 и атомарным `$expr` precondition в Mongo. Authz через `IDisciplineRoleResolver` (default stub: разрешает direct, блокирует group до #214).
- **Group read receipts** — `Message.ReadBy[]` populated на `MarkRead`, новый `MessageReadByUpdate` broadcast и `GET /messages/{id}/read-receipts` endpoint. В Direct поведение прежнее (scalar `ReadAtUtc`), для группы готов hook.
- **Typing** — обработан в PresenceService #208, ChatHub его не трогает (по согласованному решению).

## Architecture

- **Hub methods** (новые): `EditMessage`, `DeleteMessage`, `ForwardMessages`, `AddReaction`, `RemoveReaction`, `PinMessage`, `UnpinMessage`. `SendMessage` принимает опциональный `ReplyToMessageId`.
- **Broadcasts** (новые): `MessageEdited`, `MessageDeletedUpdate`, `ReactionUpdated`, `PinsUpdated`, `MessageReadByUpdate`.
- **REST endpoints**: `PATCH /messages/{id}`, `DELETE /messages/{id}?mode=...`, `POST/DELETE /messages/{id}/reactions[/emoji]`, `POST /conversations/{id}/forward`, `POST/DELETE /conversations/{id}/pinned[/messageId]`, `GET /messages/{id}/read-receipts`.
- **Kafka events** (новые): `chat.message.edited.v1`, `chat.message.deleted.v1`, `chat.reaction.added.v1`, `chat.reaction.removed.v1`, `chat.mention.created.v1`, `chat.message.pinned.v1`, `chat.message.unpinned.v1`. `chat.message.sent.v1` payload расширен `mentions[]`.
- **MongoDB**: новые поля во всех документах с `[BsonIgnoreIfNull]` (backward-compat), embedded docs для reactions / edit-history / replyTo / forwardedFrom / readBy. Sparse index `ix_messages_mentions`.
- **Configuration**: новый `Chat:` блок в `appsettings.json` (TTL, лимиты, allowed emojis).

## Тесты

- **Unit (xUnit + NSubstitute + FluentAssertions)**: 122 теста. Все домены, все application services, MentionsParser. Coverage по edge cases (TTL, author, race, idempotency).
- **Integration (TestContainers Mongo)**: 70 тестов. Repository extensions для edit/delete/reactions/readBy/pinning, индексы.

## Как проверить

\`\`\`bash
dotnet test tests/unit/ChatService.UnitTests/ChatService.UnitTests.csproj
dotnet test tests/integration/ChatService.IntegrationTests/ChatService.IntegrationTests.csproj
dotnet build Urfu.Link.slnx -c Release
\`\`\`

Локальный smoke (опционально):
1. \`make up\` (compose).
2. Открыть direct conversation между двумя пользователями.
3. \`SendMessage\` с \`replyToMessageId\` → MessageDto.ReplyTo populated.
4. \`EditMessage\` → broadcast \`MessageEdited\`.
5. \`AddReaction\` → broadcast \`ReactionUpdated\` с summary.
6. \`PinMessage\` → broadcast \`PinsUpdated\`.
7. \`ForwardMessages\` → recipient получает \`MessageReceived\` с \`forwardedFrom\`.

## Out of scope (для будущих issue)

- Discipline group chats (#214) — `ConversationType.Group` и `IDisciplineRoleResolver` готовы, но реальные роли подключатся в #214.
- `@teachers` / `@students` resolution — stub'ы (пустой список) до #214.
- NotificationService consumer для `chat.mention.created.v1` — событие публикуется, consumer добавит #209.