### PR TITLE
feat(#212): ChatService — threads (ветки сообщений)

### DIFF
--- a/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
+++ b/src/Services/Chat/ChatService.Api/Application/ChatExceptions.cs
@@ -221,3 +221,81 @@ public sealed class ChatReactionNotAllowedException : InvalidOperationException
 
     public string Emoji { get; private init; } = string.Empty;
 }
+
+public sealed class ChatThreadRootNotFoundException : InvalidOperationException
+{
+    public ChatThreadRootNotFoundException()
+    {
+    }
+
+    public ChatThreadRootNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatThreadRootNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatThreadRootNotFoundException For(Guid rootMessageId)
+        => new($"Thread root message '{rootMessageId:D}' was not found.")
+        {
+            RootMessageId = rootMessageId,
+        };
+
+    public Guid RootMessageId { get; private init; }
+}
+
+public sealed class ChatThreadCannotReplyToReplyException : InvalidOperationException
+{
+    public ChatThreadCannotReplyToReplyException()
+    {
+    }
+
+    public ChatThreadCannotReplyToReplyException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatThreadCannotReplyToReplyException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatThreadCannotReplyToReplyException For(Guid messageId)
+        => new($"Message '{messageId:D}' is itself a thread reply and cannot be used as a thread root.")
+        {
+            MessageId = messageId,
+        };
+
+    public Guid MessageId { get; private init; }
+}
+
+public sealed class ChatThreadReplyTargetNotInThreadException : InvalidOperationException
+{
+    public ChatThreadReplyTargetNotInThreadException()
+    {
+    }
+
+    public ChatThreadReplyTargetNotInThreadException(string message)
+        : base(message)
+    {
+    }
+
+    public ChatThreadReplyTargetNotInThreadException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static ChatThreadReplyTargetNotInThreadException For(Guid replyToMessageId, Guid rootMessageId)
+        => new($"Quote target '{replyToMessageId:D}' does not belong to thread '{rootMessageId:D}'.")
+        {
+            ReplyToMessageId = replyToMessageId,
+            RootMessageId = rootMessageId,
+        };
+
+    public Guid ReplyToMessageId { get; private init; }
+
+    public Guid RootMessageId { get; private init; }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ActiveThreadDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ActiveThreadDto.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+/// <summary>
+/// One entry in the user's "active threads" list. Surfaces the root message together with the
+/// caller's subscription metadata so clients can render the list without follow-up lookups.
+/// </summary>
+public sealed record ActiveThreadDto(
+    Guid RootMessageId,
+    string ConversationId,
+    MessageDto RootMessage,
+    int ReplyCount,
+    DateTimeOffset LastActivityAtUtc,
+    ThreadSubscriptionReason Reason);

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
@@ -21,7 +21,11 @@ public sealed record MessageDto(
     IReadOnlyList<Guid>? Mentions = null,
     ReplyToDto? ReplyTo = null,
     ForwardedFromDto? ForwardedFrom = null,
-    IReadOnlyDictionary<string, IReadOnlyList<Guid>>? ReactionsSummary = null)
+    IReadOnlyDictionary<string, IReadOnlyList<Guid>>? ReactionsSummary = null,
+    Guid? ThreadRootId = null,
+    int? ThreadReplyCount = null,
+    IReadOnlyList<Guid>? ThreadParticipants = null,
+    DateTimeOffset? ThreadLastReplyAtUtc = null)
 {
     public static MessageDto FromDomain(Message message)
     {
@@ -44,7 +48,14 @@ public sealed record MessageDto(
             Mentions: message.Mentions.Count == 0 ? Array.Empty<Guid>() : message.Mentions.ToList(),
             ReplyTo: message.ReplyTo is { } r ? ReplyToDto.FromDomain(r) : null,
             ForwardedFrom: message.ForwardedFrom is { } f ? ForwardedFromDto.FromDomain(f) : null,
-            ReactionsSummary: BuildReactionsSummary(message));
+            ReactionsSummary: BuildReactionsSummary(message),
+            // Thread fields are surfaced only when set so clients without thread support see a
+            // shape identical to the pre-#212 contract. Replies carry ThreadRootId; roots that
+            // accumulated replies carry the denorm trio.
+            ThreadRootId: message.ThreadRootId,
+            ThreadReplyCount: message.ThreadReplyCount > 0 ? message.ThreadReplyCount : null,
+            ThreadParticipants: message.ThreadParticipants.Count == 0 ? null : message.ThreadParticipants.ToList(),
+            ThreadLastReplyAtUtc: message.ThreadLastReplyAtUtc);
     }
 
     private static Dictionary<string, IReadOnlyList<Guid>> BuildReactionsSummary(Message message)

--- a/src/Services/Chat/ChatService.Api/Application/Cursors/CursorCodec.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Cursors/CursorCodec.cs
@@ -86,6 +86,32 @@ internal static class CursorCodec
         }
     }
 
+    public static string EncodeThreadActivity(ThreadActivityCursor cursor)
+    {
+        var payload = new ThreadActivityCursorPayload(cursor.LastActivityAtUtc.ToUnixTimeMilliseconds(), cursor.RootMessageId);
+        return EncodeBase64Url(JsonSerializer.SerializeToUtf8Bytes(payload, Options));
+    }
+
+    public static ThreadActivityCursor? DecodeThreadActivity(string? cursor)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+        {
+            return null;
+        }
+
+        try
+        {
+            var bytes = DecodeBase64Url(cursor);
+            var payload = JsonSerializer.Deserialize<ThreadActivityCursorPayload>(bytes, Options)
+                ?? throw new FormatException("Empty cursor payload.");
+            return new ThreadActivityCursor(DateTimeOffset.FromUnixTimeMilliseconds(payload.Ts), payload.Id);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            throw new InvalidChatCursorException("Invalid cursor.", nameof(cursor), ex);
+        }
+    }
+
     private static string EncodeBase64Url(byte[] bytes)
         => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
@@ -102,4 +128,5 @@ internal static class CursorCodec
 
     private sealed record ConversationCursorPayload(long Ts, string Id);
     private sealed record MessageCursorPayload(long Ts, Guid Id);
+    private sealed record ThreadActivityCursorPayload(long Ts, Guid Id);
 }

--- a/src/Services/Chat/ChatService.Api/Application/Threads/GetThreadMessagesQuery.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/GetThreadMessagesQuery.cs
@@ -1,0 +1,67 @@
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace Urfu.Link.Services.Chat.Application.Threads;
+
+/// <summary>
+/// Cursor-paginated reply list for a thread. Authorization mirrors the main flow: only
+/// participants of the parent conversation may read the thread, regardless of subscription
+/// state. The cursor type and limit clamps match
+/// <see cref="Messages.GetConversationMessagesQuery"/> so client cursor logic is uniform.
+/// </summary>
+public sealed class GetThreadMessagesQuery(
+    IConversationRepository conversations,
+    IMessageRepository messages)
+{
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 200;
+
+    public async Task<CursorPage<MessageDto>> ExecuteAsync(
+        Guid rootMessageId,
+        Guid callerUserId,
+        string? cursor,
+        int? limit,
+        CursorDirection direction,
+        CancellationToken cancellationToken)
+    {
+        var root = await messages.GetByIdAsync(rootMessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatThreadRootNotFoundException.For(rootMessageId);
+
+        if (root.IsThreadReply)
+        {
+            throw ChatThreadCannotReplyToReplyException.For(root.Id);
+        }
+
+        if (root.State == MessageState.Deleted)
+        {
+            throw ChatThreadRootNotFoundException.For(rootMessageId);
+        }
+
+        var conversation = await conversations.GetByIdAsync(root.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(root.ConversationId);
+
+        if (!conversation.IsParticipant(callerUserId))
+        {
+            throw new ChatAccessDeniedException(conversation.Id, callerUserId);
+        }
+
+        var effectiveLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var decodedCursor = CursorCodec.DecodeMessage(cursor);
+
+        // limit + 1 lets us know whether more pages exist without an extra round trip.
+        var fetched = await messages.ListThreadAsync(
+            rootMessageId, decodedCursor, effectiveLimit + 1, direction, cancellationToken).ConfigureAwait(false);
+
+        var items = fetched.Take(effectiveLimit).Select(MessageDto.FromDomain).ToList();
+        string? nextCursor = null;
+        if (fetched.Count > effectiveLimit)
+        {
+            var last = fetched[effectiveLimit - 1];
+            nextCursor = CursorCodec.EncodeMessage(new MessageCursor(last.CreatedAtUtc, last.Id));
+        }
+
+        return new CursorPage<MessageDto>(items, nextCursor);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Threads/GetUserActiveThreadsQuery.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/GetUserActiveThreadsQuery.cs
@@ -1,0 +1,77 @@
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace Urfu.Link.Services.Chat.Application.Threads;
+
+/// <summary>
+/// Returns the user's "active threads" — every thread they are subscribed to (manually,
+/// because they replied, or because they were mentioned), ordered by lastActivityAtUtc desc.
+/// Tombstoned roots are filtered out at projection time so a deleted root does not surface in
+/// the list even if the subscription document still exists.
+/// </summary>
+public sealed class GetUserActiveThreadsQuery(
+    IThreadSubscriptionRepository subscriptions,
+    IMessageRepository messages)
+{
+    private const int DefaultLimit = 30;
+    private const int MaxLimit = 100;
+
+    public async Task<CursorPage<ActiveThreadDto>> ExecuteAsync(
+        Guid callerUserId,
+        string? cursor,
+        int? limit,
+        CancellationToken cancellationToken)
+    {
+        var effectiveLimit = Math.Clamp(limit ?? DefaultLimit, 1, MaxLimit);
+        var decodedCursor = CursorCodec.DecodeThreadActivity(cursor);
+
+        var fetched = await subscriptions.ListUserActiveAsync(
+            callerUserId, decodedCursor, effectiveLimit + 1, cancellationToken).ConfigureAwait(false);
+
+        if (fetched.Count == 0)
+        {
+            return new CursorPage<ActiveThreadDto>(Array.Empty<ActiveThreadDto>(), null);
+        }
+
+        // Batch-load root messages in a single round trip and index by id for O(1) projection.
+        var rootIds = fetched.Select(s => s.RootMessageId).Distinct().ToList();
+        var roots = await messages.GetManyAsync(rootIds, cancellationToken).ConfigureAwait(false);
+        var rootById = roots.ToDictionary(r => r.Id);
+
+        var subsForPage = fetched.Take(effectiveLimit).ToList();
+        var items = new List<ActiveThreadDto>(subsForPage.Count);
+        foreach (var sub in subsForPage)
+        {
+            if (!rootById.TryGetValue(sub.RootMessageId, out var root))
+            {
+                // Subscription points at a missing message — possible if the root was hard-deleted
+                // out of band. Skip silently rather than fail the whole page.
+                continue;
+            }
+            if (root.State == MessageState.Deleted)
+            {
+                continue;
+            }
+
+            items.Add(new ActiveThreadDto(
+                RootMessageId: sub.RootMessageId,
+                ConversationId: root.ConversationId,
+                RootMessage: MessageDto.FromDomain(root),
+                ReplyCount: root.ThreadReplyCount,
+                LastActivityAtUtc: sub.LastActivityAtUtc,
+                Reason: sub.Reason));
+        }
+
+        string? nextCursor = null;
+        if (fetched.Count > effectiveLimit)
+        {
+            var last = fetched[effectiveLimit - 1];
+            nextCursor = CursorCodec.EncodeThreadActivity(
+                new ThreadActivityCursor(last.LastActivityAtUtc, last.RootMessageId));
+        }
+
+        return new CursorPage<ActiveThreadDto>(items, nextCursor);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Threads/JoinThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/JoinThreadService.cs
@@ -1,0 +1,76 @@
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Threads;
+
+public sealed record JoinThreadRequest(Guid CallerUserId, Guid RootMessageId);
+
+/// <summary>
+/// Manually subscribes a user to the thread rooted at <see cref="JoinThreadRequest.RootMessageId"/>.
+/// Only conversation participants may join; replies and tombstoned roots are rejected. Idempotent
+/// at the repository level — joining an existing subscription is a no-op event-wise but does not
+/// fail.
+/// </summary>
+public sealed class JoinThreadService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IThreadSubscriptionRepository subscriptions,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock)
+{
+    public async Task JoinAsync(JoinThreadRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var root = await messages.GetByIdAsync(request.RootMessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatThreadRootNotFoundException.For(request.RootMessageId);
+
+        if (root.IsThreadReply)
+        {
+            throw ChatThreadCannotReplyToReplyException.For(root.Id);
+        }
+
+        if (root.State == MessageState.Deleted)
+        {
+            throw ChatThreadRootNotFoundException.For(request.RootMessageId);
+        }
+
+        var conversation = await conversations.GetByIdAsync(root.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(root.ConversationId);
+
+        if (!conversation.IsParticipant(request.CallerUserId))
+        {
+            throw new ChatAccessDeniedException(conversation.Id, request.CallerUserId);
+        }
+
+        var now = clock.GetUtcNow();
+        // For a fresh subscriber, lastActivity defaults to the root's actual lastReplyAt so the
+        // newly-active thread shows up at the correct chronological position; if the root never
+        // had a reply, we fall back to "now" so the user's join still surfaces it.
+        var lastActivity = root.ThreadLastReplyAtUtc ?? now;
+
+        var subscription = ThreadSubscription.Subscribe(
+            root.Id, request.CallerUserId, ThreadSubscriptionReason.Manual, now, lastActivity);
+        var result = await subscriptions.UpsertAsync(subscription, cancellationToken).ConfigureAwait(false);
+
+        if (!result.RequiresEvent)
+        {
+            // Already subscribed at an equal-or-higher reason — nothing to publish or broadcast.
+            return;
+        }
+
+        await dispatcher.PublishAsync(
+            new ChatThreadSubscriptionChangedEvent(
+                root.Id, request.CallerUserId, Subscribed: true, ThreadSubscriptionReason.Manual, now),
+            cancellationToken).ConfigureAwait(false);
+
+        var subscribers = await subscriptions.GetSubscriberIdsAsync(root.Id, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyThreadParticipantJoinedAsync(
+            subscribers, root.Id, request.CallerUserId, ThreadSubscriptionReason.Manual, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Threads/LeaveThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/LeaveThreadService.cs
@@ -1,0 +1,35 @@
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace Urfu.Link.Services.Chat.Application.Threads;
+
+public sealed record LeaveThreadRequest(Guid CallerUserId, Guid RootMessageId);
+
+/// <summary>
+/// Removes the caller's subscription from a thread. Reply history is untouched — the user
+/// just stops receiving thread updates. Calling on a non-existent subscription is a no-op.
+/// </summary>
+public sealed class LeaveThreadService(
+    IThreadSubscriptionRepository subscriptions,
+    ChatEventDispatcher dispatcher,
+    TimeProvider clock)
+{
+    public async Task LeaveAsync(LeaveThreadRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var removed = await subscriptions.RemoveAsync(request.RootMessageId, request.CallerUserId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!removed)
+        {
+            return;
+        }
+
+        var now = clock.GetUtcNow();
+        await dispatcher.PublishAsync(
+            new ChatThreadSubscriptionChangedEvent(
+                request.RootMessageId, request.CallerUserId, Subscribed: false, ThreadSubscriptionReason.Manual, now),
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Threads/ReplyInThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/ReplyInThreadService.cs
@@ -1,0 +1,325 @@
+using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.Idempotency;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Mentions;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.Application.Threads;
+
+public sealed record ReplyInThreadRequest(
+    Guid SenderId,
+    Guid RootMessageId,
+    string Body,
+    IReadOnlyList<Guid> AttachmentAssetIds,
+    Guid? ReplyToMessageId,
+    string ClientMessageId);
+
+/// <summary>
+/// Posts a reply in the thread rooted at <see cref="ReplyInThreadRequest.RootMessageId"/>.
+/// The reply lives in the same <c>messages</c> collection as the main flow but carries a
+/// non-null <c>ThreadRootId</c>, so it is excluded from <c>ListByConversationAsync</c> and
+/// surfaces only via thread-specific queries.
+///
+/// Subscriptions are upserted in <c>(Replied | Mentioned)</c> reasons before the broadcast so
+/// the freshly-subscribed users immediately receive <c>ThreadReplyReceived</c>. The denorm
+/// update on the root is non-transactional w.r.t. the reply insert: the reply is written first
+/// and the counter follows, leaving at most a millisecond window in which the count lags. This
+/// is acceptable for a UI marker — clients re-render on <c>ThreadRootUpdated</c>.
+/// </summary>
+public sealed class ReplyInThreadService(
+    IConversationRepository conversations,
+    IMessageRepository messages,
+    IThreadSubscriptionRepository subscriptions,
+    IMediaServiceClient mediaServiceClient,
+    IIdempotencyStore idempotencyStore,
+    ChatEventDispatcher dispatcher,
+    IChatBroadcaster broadcaster,
+    TimeProvider clock,
+    IOptions<ChatOptions> options)
+{
+    public async Task<MessageDto> ReplyAsync(ReplyInThreadRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ValidatePayloadShape(request);
+
+        var root = await messages.GetByIdAsync(request.RootMessageId, cancellationToken).ConfigureAwait(false)
+            ?? throw ChatThreadRootNotFoundException.For(request.RootMessageId);
+
+        if (root.IsThreadReply)
+        {
+            throw ChatThreadCannotReplyToReplyException.For(root.Id);
+        }
+
+        // Tombstoned roots are surfaced as "not found" to callers — the application contract is
+        // that you cannot post into a thread whose origin has been deleted for everyone.
+        if (root.State == MessageState.Deleted)
+        {
+            throw ChatThreadRootNotFoundException.For(request.RootMessageId);
+        }
+
+        var conversation = await conversations.GetByIdAsync(root.ConversationId, cancellationToken).ConfigureAwait(false)
+            ?? throw ConversationNotFoundException.For(root.ConversationId);
+
+        if (!conversation.IsParticipant(request.SenderId))
+        {
+            throw new ChatAccessDeniedException(conversation.Id, request.SenderId);
+        }
+
+        // Idempotency on (senderId, clientMessageId) — same key shape as SendMessage but in a
+        // thread-scoped namespace so a main-flow client message id and a thread-reply client
+        // message id from the same sender don't collide.
+        var idempotencyKey = $"chat:thread:{request.SenderId:N}:{request.ClientMessageId}";
+        var firstAttempt = await idempotencyStore.TryRegisterAsync(idempotencyKey, cancellationToken).ConfigureAwait(false);
+        if (!firstAttempt)
+        {
+            var prior = await messages.FindByClientMessageIdAsync(request.SenderId, request.ClientMessageId, cancellationToken).ConfigureAwait(false);
+            if (prior is not null)
+            {
+                return MessageDto.FromDomain(prior);
+            }
+        }
+
+        var attachments = await ResolveAttachmentsAsync(request.AttachmentAssetIds, request.SenderId, cancellationToken).ConfigureAwait(false);
+        var replyTo = await ResolveReplyToInThreadAsync(root, request.ReplyToMessageId, cancellationToken).ConfigureAwait(false);
+
+        var opts = options.Value;
+        var mentions = MentionsParser.Parse(request.Body, conversation.Participants, opts.MaxMentionsPerMessage);
+
+        var now = clock.GetUtcNow();
+        var reply = Message.SendAsThreadReply(
+            id: Guid.NewGuid(),
+            conversationId: conversation.Id,
+            senderId: request.SenderId,
+            body: request.Body,
+            attachments: attachments,
+            clientMessageId: request.ClientMessageId,
+            createdAtUtc: now,
+            threadRootId: root.Id,
+            mentions: mentions,
+            replyTo: replyTo);
+
+        try
+        {
+            await messages.InsertAsync(reply, cancellationToken).ConfigureAwait(false);
+        }
+        catch (DuplicateClientMessageException)
+        {
+            var prior = await messages.FindByClientMessageIdAsync(request.SenderId, request.ClientMessageId, cancellationToken).ConfigureAwait(false);
+            if (prior is not null)
+            {
+                return MessageDto.FromDomain(prior);
+            }
+            throw;
+        }
+
+        // Bump root denorms after the reply is durably written. Mongo single-replica has no
+        // multi-document transactions; on rare crash between the two writes the reply exists
+        // but the count lags. Acceptable — the count is a UI hint, and ThreadRootUpdated will
+        // re-broadcast it on the next reply.
+        await messages.IncrementThreadDenormAsync(root.Id, request.SenderId, now, cancellationToken).ConfigureAwait(false);
+
+        await GrantAttachmentAccessAsync(attachments, conversation, request.SenderId, cancellationToken).ConfigureAwait(false);
+
+        // Auto-subscribe: the replier is always Replied; mentioned users are Mentioned (escalated
+        // if they were already Manual). Self-mention does not change the replier's reason.
+        var newSubscriberEvents = new List<(Guid UserId, ThreadSubscriptionReason Reason)>();
+
+        var replierUpsert = await subscriptions.UpsertAsync(
+            ThreadSubscription.Subscribe(root.Id, request.SenderId, ThreadSubscriptionReason.Replied, now, lastActivityAtUtc: now),
+            cancellationToken).ConfigureAwait(false);
+        if (replierUpsert.RequiresEvent)
+        {
+            newSubscriberEvents.Add((request.SenderId, ThreadSubscriptionReason.Replied));
+        }
+
+        foreach (var mentionedUserId in mentions)
+        {
+            if (mentionedUserId == request.SenderId)
+            {
+                continue;
+            }
+            var upsert = await subscriptions.UpsertAsync(
+                ThreadSubscription.Subscribe(root.Id, mentionedUserId, ThreadSubscriptionReason.Mentioned, now, lastActivityAtUtc: now),
+                cancellationToken).ConfigureAwait(false);
+            if (upsert.RequiresEvent)
+            {
+                newSubscriberEvents.Add((mentionedUserId, ThreadSubscriptionReason.Mentioned));
+            }
+        }
+
+        // Bump lastActivityAtUtc on every existing subscription (including the ones we just
+        // upserted — the upsert already set it, but this also covers any subscriber whose
+        // reason did not change yet whose active-threads ordering must advance).
+        await subscriptions.TouchActivityForRootAsync(root.Id, now, cancellationToken).ConfigureAwait(false);
+
+        var subscribers = await subscriptions.GetSubscriberIdsAsync(root.Id, cancellationToken).ConfigureAwait(false);
+
+        await dispatcher.PublishAsync(
+            new ChatThreadReplyPostedEvent(
+                conversation.Id,
+                root.Id,
+                reply.Id,
+                request.SenderId,
+                subscribers,
+                Mentions: mentions.Count == 0 ? null : mentions,
+                now),
+            cancellationToken).ConfigureAwait(false);
+
+        if (mentions.Count > 0)
+        {
+            await dispatcher.PublishAsync(
+                new ChatMentionCreatedEvent(
+                    conversation.Id,
+                    reply.Id,
+                    request.SenderId,
+                    mentions,
+                    now,
+                    ThreadRootId: root.Id),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var (userId, reason) in newSubscriberEvents)
+        {
+            await dispatcher.PublishAsync(
+                new ChatThreadSubscriptionChangedEvent(root.Id, userId, Subscribed: true, reason, now),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var replyDto = MessageDto.FromDomain(reply);
+        await broadcaster.NotifyThreadReplyReceivedAsync(subscribers, root.Id, replyDto, cancellationToken).ConfigureAwait(false);
+
+        // Compute the new root denorms in-memory for the broadcast — re-loading the root just to
+        // read what we already know is wasteful, and the IncrementThreadDenormAsync write above
+        // is the source of truth.
+        var newReplyCount = root.ThreadReplyCount + 1;
+        IReadOnlyList<Guid> newParticipants = root.ThreadParticipants.Contains(request.SenderId)
+            ? root.ThreadParticipants
+            : root.ThreadParticipants.Append(request.SenderId).ToList();
+
+        await broadcaster.NotifyThreadRootUpdatedAsync(
+            conversation.Participants,
+            conversation.Id,
+            root.Id,
+            newReplyCount,
+            newParticipants,
+            now,
+            cancellationToken).ConfigureAwait(false);
+
+        return replyDto;
+    }
+
+    private static void ValidatePayloadShape(ReplyInThreadRequest request)
+    {
+        if (request.Body is { Length: > ChatBodyConstraints.MaxBodyLength })
+        {
+            throw new ChatPayloadTooLargeException(
+                $"Reply body exceeds {ChatBodyConstraints.MaxBodyLength} characters.");
+        }
+
+        if (request.AttachmentAssetIds is { Count: > ChatBodyConstraints.MaxAttachmentsPerMessage })
+        {
+            throw new ChatPayloadTooLargeException(
+                $"Reply has more than {ChatBodyConstraints.MaxAttachmentsPerMessage} attachments.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ClientMessageId))
+        {
+            throw new ArgumentException("ClientMessageId is required.", nameof(request));
+        }
+    }
+
+    private async Task<ReplyTo?> ResolveReplyToInThreadAsync(
+        Message root,
+        Guid? replyToMessageId,
+        CancellationToken cancellationToken)
+    {
+        if (replyToMessageId is not { } id)
+        {
+            return null;
+        }
+
+        var target = await messages.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (target is null)
+        {
+            throw ChatThreadReplyTargetNotInThreadException.For(id, root.Id);
+        }
+
+        // The quote target must be either the thread root itself or another reply within the
+        // same thread. Quoting across threads or out of the main flow is rejected because the
+        // peer rendering would otherwise pull in a body the user is not viewing.
+        var isInThread = target.Id == root.Id || target.ThreadRootId == root.Id;
+        if (!isInThread)
+        {
+            throw ChatThreadReplyTargetNotInThreadException.For(id, root.Id);
+        }
+
+        return ReplyTo.Create(target.Id, target.SenderId, target.Body);
+    }
+
+    private async Task<IReadOnlyList<Attachment>> ResolveAttachmentsAsync(
+        IReadOnlyList<Guid> assetIds,
+        Guid senderId,
+        CancellationToken cancellationToken)
+    {
+        if (assetIds is null || assetIds.Count == 0)
+        {
+            return Array.Empty<Attachment>();
+        }
+
+        var metadata = await mediaServiceClient.BatchGetMetadataAsync(assetIds, cancellationToken).ConfigureAwait(false);
+        var byId = metadata.ToDictionary(m => m.AssetId);
+
+        var resolved = new List<Attachment>(assetIds.Count);
+        foreach (var assetId in assetIds)
+        {
+            if (!byId.TryGetValue(assetId, out var meta) || !meta.IsUploaded)
+            {
+                throw new ChatAttachmentNotOwnedException(assetId, senderId);
+            }
+            if (meta.OwnerId != senderId)
+            {
+                throw new ChatAttachmentNotOwnedException(assetId, senderId);
+            }
+            resolved.Add(new Attachment(
+                MediaAssetId: meta.AssetId,
+                Type: meta.Kind,
+                ThumbnailAssetId: null,
+                FileName: meta.OriginalFileName,
+                Size: meta.SizeBytes,
+                MimeType: meta.MimeType));
+        }
+        return resolved;
+    }
+
+    private async Task GrantAttachmentAccessAsync(
+        IReadOnlyList<Attachment> attachments,
+        Conversation conversation,
+        Guid senderId,
+        CancellationToken cancellationToken)
+    {
+        if (attachments.Count == 0)
+        {
+            return;
+        }
+
+        var grantees = conversation.Participants.Where(p => p != senderId).ToList();
+        if (grantees.Count == 0)
+        {
+            return;
+        }
+
+        var grantTasks = attachments
+            .Select(a => mediaServiceClient.GrantConversationAccessAsync(
+                a.MediaAssetId, grantees, conversation.Id, senderId, cancellationToken))
+            .ToArray();
+        await Task.WhenAll(grantTasks).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
@@ -11,6 +11,7 @@ public sealed class Message
     private readonly List<Reaction> _reactions;
     private readonly List<Guid> _mentions;
     private readonly List<ReadReceipt> _readBy;
+    private readonly List<Guid> _threadParticipants;
 
     private Message(
         Guid id,
@@ -33,7 +34,11 @@ public sealed class Message
         IEnumerable<Guid>? mentions,
         ReplyTo? replyTo,
         ForwardedFrom? forwardedFrom,
-        IEnumerable<ReadReceipt>? readBy)
+        IEnumerable<ReadReceipt>? readBy,
+        Guid? threadRootId,
+        int threadReplyCount,
+        IEnumerable<Guid>? threadParticipants,
+        DateTimeOffset? threadLastReplyAtUtc)
     {
         Id = id;
         ConversationId = conversationId;
@@ -56,6 +61,10 @@ public sealed class Message
         ReplyTo = replyTo;
         ForwardedFrom = forwardedFrom;
         _readBy = readBy?.ToList() ?? [];
+        ThreadRootId = threadRootId;
+        ThreadReplyCount = threadReplyCount;
+        _threadParticipants = threadParticipants?.ToList() ?? [];
+        ThreadLastReplyAtUtc = threadLastReplyAtUtc;
     }
 
     public Guid Id { get; }
@@ -102,6 +111,31 @@ public sealed class Message
 
     public bool HasAttachments => _attachments.Count > 0;
 
+    /// <summary>
+    /// When set, this message is a reply within the thread rooted at <see cref="ThreadRootId"/>.
+    /// On root and main-flow messages this is <c>null</c>.
+    /// </summary>
+    public Guid? ThreadRootId { get; }
+
+    /// <summary>
+    /// Denormalized count of replies in the thread rooted at this message. Always 0 on
+    /// thread replies (denorms live only on the root).
+    /// </summary>
+    public int ThreadReplyCount { get; private set; }
+
+    /// <summary>
+    /// Denormalized unique senders that have replied in this thread. Empty on thread replies.
+    /// </summary>
+    public IReadOnlyList<Guid> ThreadParticipants => _threadParticipants;
+
+    /// <summary>
+    /// Denormalized timestamp of the last reply in this thread. <c>null</c> if no replies yet,
+    /// or on thread replies themselves.
+    /// </summary>
+    public DateTimeOffset? ThreadLastReplyAtUtc { get; private set; }
+
+    public bool IsThreadReply => ThreadRootId.HasValue;
+
     public static Message Send(
         Guid id,
         string conversationId,
@@ -139,7 +173,71 @@ public sealed class Message
             mentions: mentions,
             replyTo: replyTo,
             forwardedFrom: forwardedFrom,
-            readBy: null);
+            readBy: null,
+            threadRootId: null,
+            threadReplyCount: 0,
+            threadParticipants: null,
+            threadLastReplyAtUtc: null);
+    }
+
+    /// <summary>
+    /// Creates a new reply in the thread rooted at <paramref name="threadRootId"/>. The reply
+    /// lives in the same <c>messages</c> collection but carries a non-null <see cref="ThreadRootId"/>;
+    /// the main-flow query filters these out. Denorm fields (count/participants/lastReplyAt)
+    /// remain at zero/empty on the reply itself — they are tracked on the root message only.
+    /// </summary>
+    public static Message SendAsThreadReply(
+        Guid id,
+        string conversationId,
+        Guid senderId,
+        string body,
+        IEnumerable<Attachment> attachments,
+        string clientMessageId,
+        DateTimeOffset createdAtUtc,
+        Guid threadRootId,
+        IEnumerable<Guid>? mentions = null,
+        ReplyTo? replyTo = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentNullException.ThrowIfNull(attachments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientMessageId);
+
+        if (threadRootId == Guid.Empty)
+        {
+            throw new ArgumentException("threadRootId must be a non-empty GUID.", nameof(threadRootId));
+        }
+
+        if (threadRootId == id)
+        {
+            throw new InvalidOperationException("A thread reply cannot reference itself as the thread root.");
+        }
+
+        return new Message(
+            id,
+            conversationId,
+            senderId,
+            body ?? string.Empty,
+            attachments,
+            clientMessageId,
+            MessageState.Sent,
+            createdAtUtc,
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            editedAtUtc: null,
+            editHistory: null,
+            deletedAtUtc: null,
+            deletedBy: null,
+            deleteMode: null,
+            hiddenFor: null,
+            reactions: null,
+            mentions: mentions,
+            replyTo: replyTo,
+            forwardedFrom: null,
+            readBy: null,
+            threadRootId: threadRootId,
+            threadReplyCount: 0,
+            threadParticipants: null,
+            threadLastReplyAtUtc: null);
     }
 
     public static Message Hydrate(
@@ -185,7 +283,11 @@ public sealed class Message
             mentions,
             replyTo,
             forwardedFrom,
-            readBy);
+            readBy,
+            threadRootId: null,
+            threadReplyCount: 0,
+            threadParticipants: null,
+            threadLastReplyAtUtc: null);
 
     public bool MarkDelivered(DateTimeOffset atUtc)
     {

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
@@ -456,4 +456,25 @@ public sealed class Message
 
         return true;
     }
+
+    /// <summary>
+    /// Records a new thread reply by updating the denormalized counters on this root message.
+    /// Increments <see cref="ThreadReplyCount"/>, adds the replier to <see cref="ThreadParticipants"/>
+    /// (deduplicated), and refreshes <see cref="ThreadLastReplyAtUtc"/>. Must be called only on
+    /// root messages — calling on a reply throws.
+    /// </summary>
+    public void IncrementThreadDenorm(Guid replierUserId, DateTimeOffset atUtc)
+    {
+        if (IsThreadReply)
+        {
+            throw new InvalidOperationException("Thread denorm can only be incremented on root messages.");
+        }
+
+        ThreadReplyCount++;
+        if (!_threadParticipants.Contains(replierUserId))
+        {
+            _threadParticipants.Add(replierUserId);
+        }
+        ThreadLastReplyAtUtc = atUtc;
+    }
 }

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
@@ -261,7 +261,11 @@ public sealed class Message
         IEnumerable<Guid>? mentions = null,
         ReplyTo? replyTo = null,
         ForwardedFrom? forwardedFrom = null,
-        IEnumerable<ReadReceipt>? readBy = null)
+        IEnumerable<ReadReceipt>? readBy = null,
+        Guid? threadRootId = null,
+        int threadReplyCount = 0,
+        IEnumerable<Guid>? threadParticipants = null,
+        DateTimeOffset? threadLastReplyAtUtc = null)
         => new(
             id,
             conversationId,
@@ -284,10 +288,10 @@ public sealed class Message
             replyTo,
             forwardedFrom,
             readBy,
-            threadRootId: null,
-            threadReplyCount: 0,
-            threadParticipants: null,
-            threadLastReplyAtUtc: null);
+            threadRootId,
+            threadReplyCount,
+            threadParticipants,
+            threadLastReplyAtUtc);
 
     public bool MarkDelivered(DateTimeOffset atUtc)
     {

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/ThreadSubscription.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/ThreadSubscription.cs
@@ -1,0 +1,94 @@
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Domain.Aggregates;
+
+/// <summary>
+/// Tracks that a user receives realtime updates and notifications for a thread rooted at
+/// <see cref="RootMessageId"/>. <see cref="LastActivityAtUtc"/> is the denormalized sort key
+/// for the user's "active threads" list, refreshed on every reply in the thread.
+/// </summary>
+public sealed class ThreadSubscription
+{
+    private ThreadSubscription(
+        Guid rootMessageId,
+        Guid userId,
+        ThreadSubscriptionReason reason,
+        DateTimeOffset subscribedAtUtc,
+        DateTimeOffset lastActivityAtUtc)
+    {
+        RootMessageId = rootMessageId;
+        UserId = userId;
+        Reason = reason;
+        SubscribedAtUtc = subscribedAtUtc;
+        LastActivityAtUtc = lastActivityAtUtc;
+    }
+
+    public Guid RootMessageId { get; }
+
+    public Guid UserId { get; }
+
+    public ThreadSubscriptionReason Reason { get; private set; }
+
+    public DateTimeOffset SubscribedAtUtc { get; }
+
+    public DateTimeOffset LastActivityAtUtc { get; private set; }
+
+    public static ThreadSubscription Subscribe(
+        Guid rootMessageId,
+        Guid userId,
+        ThreadSubscriptionReason reason,
+        DateTimeOffset subscribedAtUtc,
+        DateTimeOffset? lastActivityAtUtc = null)
+    {
+        if (rootMessageId == Guid.Empty)
+        {
+            throw new ArgumentException("rootMessageId must be a non-empty GUID.", nameof(rootMessageId));
+        }
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("userId must be a non-empty GUID.", nameof(userId));
+        }
+
+        return new ThreadSubscription(
+            rootMessageId,
+            userId,
+            reason,
+            subscribedAtUtc,
+            lastActivityAtUtc ?? subscribedAtUtc);
+    }
+
+    public static ThreadSubscription Hydrate(
+        Guid rootMessageId,
+        Guid userId,
+        ThreadSubscriptionReason reason,
+        DateTimeOffset subscribedAtUtc,
+        DateTimeOffset lastActivityAtUtc)
+        => new(rootMessageId, userId, reason, subscribedAtUtc, lastActivityAtUtc);
+
+    /// <summary>
+    /// Raises <see cref="Reason"/> to <paramref name="newReason"/> if it represents stronger
+    /// ownership; never downgrades. Returns <c>true</c> when the reason actually changed.
+    /// </summary>
+    public bool EscalateReason(ThreadSubscriptionReason newReason)
+    {
+        if (newReason <= Reason)
+        {
+            return false;
+        }
+
+        Reason = newReason;
+        return true;
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="LastActivityAtUtc"/> to <paramref name="atUtc"/> when newer.
+    /// Older or equal timestamps are ignored to avoid sort-key regressions under out-of-order writes.
+    /// </summary>
+    public void TouchActivity(DateTimeOffset atUtc)
+    {
+        if (atUtc > LastActivityAtUtc)
+        {
+            LastActivityAtUtc = atUtc;
+        }
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/ThreadSubscriptionReason.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/ThreadSubscriptionReason.cs
@@ -1,0 +1,13 @@
+namespace Urfu.Link.Services.Chat.Domain.Enums;
+
+/// <summary>
+/// Why a user is subscribed to a thread. Higher values represent stronger ownership and
+/// take precedence during escalation: a Manual subscription becomes Mentioned/Replied as
+/// the user's involvement deepens, and never downgrades.
+/// </summary>
+public enum ThreadSubscriptionReason
+{
+    Manual = 0,
+    Mentioned = 1,
+    Replied = 2,
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatMentionCreatedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatMentionCreatedEvent.cs
@@ -7,7 +7,8 @@ public sealed record ChatMentionCreatedEvent(
     Guid MessageId,
     Guid SenderId,
     IReadOnlyList<Guid> MentionedUserIds,
-    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+    DateTimeOffset OccurredAtUtc,
+    Guid? ThreadRootId = null) : IIntegrationEvent
 {
     public Guid EventId { get; } = Guid.NewGuid();
 

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatThreadReplyPostedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatThreadReplyPostedEvent.cs
@@ -1,0 +1,22 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+/// <summary>
+/// A new reply was posted in a thread. NotificationService consumes this event to deliver
+/// "new thread reply" notifications to the supplied <paramref name="Subscribers"/>; mentions
+/// are surfaced separately via <see cref="ChatMentionCreatedEvent"/> for priority routing.
+/// </summary>
+public sealed record ChatThreadReplyPostedEvent(
+    string ConversationId,
+    Guid RootMessageId,
+    Guid MessageId,
+    Guid SenderId,
+    IReadOnlyList<Guid> Subscribers,
+    IReadOnlyList<Guid>? Mentions,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.thread.reply_posted.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Events/ChatThreadSubscriptionChangedEvent.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Events/ChatThreadSubscriptionChangedEvent.cs
@@ -1,0 +1,21 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Domain.Events;
+
+/// <summary>
+/// A user's thread subscription was added, escalated, or removed. <c>Subscribed=true</c> covers
+/// both the initial subscribe and reason escalation; <c>Subscribed=false</c> is emitted on
+/// explicit unsubscribe.
+/// </summary>
+public sealed record ChatThreadSubscriptionChangedEvent(
+    Guid RootMessageId,
+    Guid UserId,
+    bool Subscribed,
+    ThreadSubscriptionReason Reason,
+    DateTimeOffset OccurredAtUtc) : IIntegrationEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+
+    public string EventType => "chat.thread.subscription_changed.v1";
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
@@ -115,6 +115,31 @@ public interface IMessageRepository
     Task<bool> AddReadByAsync(Guid messageId, ReadReceipt receipt, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<ReadReceipt>> GetReadReceiptsAsync(Guid messageId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atomically updates the denormalized thread counters on the root message in a single
+    /// pipeline op: increments <c>threadReplyCount</c>, unions the replier into
+    /// <c>threadParticipants</c>, and bumps <c>threadLastReplyAtUtc</c>. The filter requires the
+    /// target to be a non-deleted root message (<c>threadRootId</c> null) so a thread reply
+    /// cannot be promoted into a root by mistake. Returns false if no document matched.
+    /// </summary>
+    Task<bool> IncrementThreadDenormAsync(
+        Guid rootMessageId,
+        Guid replierUserId,
+        DateTimeOffset atUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cursor-paginated list of replies in the thread rooted at <paramref name="rootMessageId"/>,
+    /// ordered chronologically (Older direction returns newest-first; Newer returns oldest-first
+    /// past the cursor — same semantics as <see cref="ListByConversationAsync"/>).
+    /// </summary>
+    Task<IReadOnlyList<Message>> ListThreadAsync(
+        Guid rootMessageId,
+        MessageCursor? cursor,
+        int limit,
+        CursorDirection direction,
+        CancellationToken cancellationToken);
 }
 
 public sealed class DuplicateClientMessageException : InvalidOperationException

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IThreadSubscriptionRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IThreadSubscriptionRepository.cs
@@ -1,0 +1,54 @@
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+
+namespace Urfu.Link.Services.Chat.Domain.Interfaces;
+
+/// <summary>
+/// Outcome of an upsert: was the subscription created, was the existing one's reason escalated,
+/// or was it a no-op (already at or above the requested reason).
+/// </summary>
+public readonly record struct ThreadSubscriptionUpsertResult(bool WasCreated, bool ReasonEscalated)
+{
+    public bool RequiresEvent => WasCreated || ReasonEscalated;
+}
+
+public interface IThreadSubscriptionRepository
+{
+    /// <summary>
+    /// Creates the subscription if missing, or escalates <see cref="ThreadSubscription.Reason"/>
+    /// when the new reason is higher priority. Always advances <c>LastActivityAtUtc</c> via the
+    /// aggregate's <see cref="ThreadSubscription.TouchActivity"/> rules.
+    /// </summary>
+    Task<ThreadSubscriptionUpsertResult> UpsertAsync(
+        ThreadSubscription subscription,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes the explicit subscription. Returns <see langword="false"/> if no subscription
+    /// existed for the (root, user) pair.
+    /// </summary>
+    Task<bool> RemoveAsync(Guid rootMessageId, Guid userId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Guid>> GetSubscriberIdsAsync(Guid rootMessageId, CancellationToken cancellationToken);
+
+    Task<bool> IsSubscribedAsync(Guid rootMessageId, Guid userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Bulk-refreshes <c>LastActivityAtUtc</c> on every subscription for the given root, so the
+    /// thread floats to the top of every subscriber's "active threads" list. The mongo update is
+    /// monotonic — older timestamps cannot overwrite newer ones.
+    /// </summary>
+    Task<long> TouchActivityForRootAsync(
+        Guid rootMessageId,
+        DateTimeOffset atUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cursor-paginated list of the user's subscriptions, sorted by LastActivityAtUtc desc then
+    /// RootMessageId desc as a deterministic tie-breaker.
+    /// </summary>
+    Task<IReadOnlyList<ThreadSubscription>> ListUserActiveAsync(
+        Guid userId,
+        ThreadActivityCursor? cursor,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/Pagination.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/Pagination.cs
@@ -9,3 +9,5 @@ public enum CursorDirection
 public readonly record struct ConversationCursor(DateTimeOffset LastMessageAtUtc, string ConversationId);
 
 public readonly record struct MessageCursor(DateTimeOffset CreatedAtUtc, Guid MessageId);
+
+public readonly record struct ThreadActivityCursor(DateTimeOffset LastActivityAtUtc, Guid RootMessageId);

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetThreadMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetThreadMessagesEndpoint.cs
@@ -1,0 +1,50 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class GetThreadMessagesRequest
+{
+    public Guid Id { get; set; }
+
+    [QueryParam] public string? Cursor { get; set; }
+
+    [QueryParam] public int? Limit { get; set; }
+
+    [QueryParam] public string? Direction { get; set; }
+}
+
+public sealed class GetThreadMessagesEndpoint(GetThreadMessagesQuery query)
+    : Endpoint<GetThreadMessagesRequest, CursorPage<MessageDto>>
+{
+    public override void Configure()
+    {
+        Get("messages/{id}/thread");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Cursor-paginated list of replies in a thread.");
+    }
+
+    public override async Task HandleAsync(GetThreadMessagesRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var direction = string.Equals(req.Direction, "newer", StringComparison.OrdinalIgnoreCase)
+            ? CursorDirection.Newer
+            : CursorDirection.Older;
+
+        try
+        {
+            var page = await query.ExecuteAsync(req.Id, caller, req.Cursor, req.Limit, direction, ct).ConfigureAwait(false);
+            await Send.OkAsync(page, ct).ConfigureAwait(false);
+        }
+        catch (InvalidChatCursorException)
+        {
+            AddError(r => r.Cursor!, "Invalid cursor.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/ReplyInThreadEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/ReplyInThreadEndpoint.cs
@@ -1,0 +1,46 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class ReplyInThreadRouteRequest
+{
+    public Guid Id { get; set; }
+
+    public string Body { get; set; } = string.Empty;
+
+    public IReadOnlyList<Guid> AttachmentAssetIds { get; set; } = Array.Empty<Guid>();
+
+    public Guid? ReplyToMessageId { get; set; }
+
+    public string ClientMessageId { get; set; } = string.Empty;
+}
+
+public sealed class ReplyInThreadEndpoint(ReplyInThreadService service)
+    : Endpoint<ReplyInThreadRouteRequest, MessageDto>
+{
+    public override void Configure()
+    {
+        Post("messages/{id}/thread");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Post a reply in the thread rooted at the given message.");
+    }
+
+    public override async Task HandleAsync(ReplyInThreadRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        var dto = await service.ReplyAsync(
+            new ReplyInThreadRequest(
+                caller,
+                req.Id,
+                req.Body ?? string.Empty,
+                req.AttachmentAssetIds ?? Array.Empty<Guid>(),
+                req.ReplyToMessageId,
+                req.ClientMessageId ?? string.Empty),
+            ct).ConfigureAwait(false);
+        await Send.OkAsync(dto, ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/SubscribeToThreadEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/SubscribeToThreadEndpoint.cs
@@ -1,0 +1,29 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class SubscribeToThreadRouteRequest
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class SubscribeToThreadEndpoint(JoinThreadService service)
+    : Endpoint<SubscribeToThreadRouteRequest>
+{
+    public override void Configure()
+    {
+        Post("messages/{id}/thread/subscribe");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Manually subscribe to thread updates rooted at the given message.");
+    }
+
+    public override async Task HandleAsync(SubscribeToThreadRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        await service.JoinAsync(new JoinThreadRequest(caller, req.Id), ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/UnsubscribeFromThreadEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/UnsubscribeFromThreadEndpoint.cs
@@ -1,0 +1,29 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+public sealed class UnsubscribeFromThreadRouteRequest
+{
+    public Guid Id { get; set; }
+}
+
+public sealed class UnsubscribeFromThreadEndpoint(LeaveThreadService service)
+    : Endpoint<UnsubscribeFromThreadRouteRequest>
+{
+    public override void Configure()
+    {
+        Delete("messages/{id}/thread/subscribe");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Remove the caller's subscription from a thread. Reply history is untouched.");
+    }
+
+    public override async Task HandleAsync(UnsubscribeFromThreadRouteRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        await service.LeaveAsync(new LeaveThreadRequest(caller, req.Id), ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Threads/GetActiveThreadsEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Threads/GetActiveThreadsEndpoint.cs
@@ -1,0 +1,41 @@
+using FastEndpoints;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Threads;
+
+public sealed class GetActiveThreadsRequest
+{
+    [QueryParam] public string? Cursor { get; set; }
+
+    [QueryParam] public int? Limit { get; set; }
+}
+
+public sealed class GetActiveThreadsEndpoint(GetUserActiveThreadsQuery query)
+    : Endpoint<GetActiveThreadsRequest, CursorPage<ActiveThreadDto>>
+{
+    public override void Configure()
+    {
+        Get("threads/active");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Caller's active threads, ordered by last activity desc.");
+    }
+
+    public override async Task HandleAsync(GetActiveThreadsRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+        try
+        {
+            var page = await query.ExecuteAsync(caller, req.Cursor, req.Limit, ct).ConfigureAwait(false);
+            await Send.OkAsync(page, ct).ConfigureAwait(false);
+        }
+        catch (InvalidChatCursorException)
+        {
+            AddError(r => r.Cursor!, "Invalid cursor.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -13,6 +13,7 @@ using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Application.Threads;
 using Urfu.Link.Services.Chat.Domain;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Infrastructure.Authorization;
@@ -47,6 +48,7 @@ public static class ModuleRegistration
         services.AddSingleton<ChatMongoContext>();
         services.AddScoped<IConversationRepository, ConversationRepository>();
         services.AddScoped<IMessageRepository, MessageRepository>();
+        services.AddScoped<IThreadSubscriptionRepository, ThreadSubscriptionRepository>();
         services.AddHostedService<MongoIndexInitializer>();
 
         services.AddOptions<ChatOptions>()
@@ -105,6 +107,11 @@ public static class ModuleRegistration
         services.AddScoped<GetConversationQuery>();
         services.AddScoped<GetConversationMessagesQuery>();
         services.AddScoped<GetReadReceiptsQuery>();
+        services.AddScoped<ReplyInThreadService>();
+        services.AddScoped<JoinThreadService>();
+        services.AddScoped<LeaveThreadService>();
+        services.AddScoped<GetThreadMessagesQuery>();
+        services.AddScoped<GetUserActiveThreadsQuery>();
 
         services.AddSingleton<IChatBroadcaster, ChatBroadcaster>();
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ChatMongoContext.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ChatMongoContext.cs
@@ -13,6 +13,7 @@ public sealed class ChatMongoContext : IDisposable
 {
     public const string ConversationsCollectionName = "conversations";
     public const string MessagesCollectionName = "messages";
+    public const string ThreadSubscriptionsCollectionName = "thread_subscriptions";
 
     private readonly MongoClient _client;
     private readonly IMongoDatabase _database;
@@ -47,4 +48,7 @@ public sealed class ChatMongoContext : IDisposable
 
     internal IMongoCollection<MessageDocument> Messages
         => _database.GetCollection<MessageDocument>(MessagesCollectionName);
+
+    internal IMongoCollection<ThreadSubscriptionDocument> ThreadSubscriptions
+        => _database.GetCollection<ThreadSubscriptionDocument>(ThreadSubscriptionsCollectionName);
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
@@ -79,6 +79,20 @@ internal sealed class MessageDocument
     [BsonElement("readBy")]
     public List<ReadReceiptDocument> ReadBy { get; set; } = new();
 
+    [BsonElement("threadRootId")]
+    [BsonIgnoreIfNull]
+    public Guid? ThreadRootId { get; set; }
+
+    [BsonElement("threadReplyCount")]
+    public int ThreadReplyCount { get; set; }
+
+    [BsonElement("threadParticipants")]
+    public List<Guid> ThreadParticipants { get; set; } = new();
+
+    [BsonElement("threadLastReplyAtUtc")]
+    [BsonIgnoreIfNull]
+    public DateTime? ThreadLastReplyAtUtc { get; set; }
+
     public Message ToDomain() => Message.Hydrate(
         Id,
         ConversationId,
@@ -100,7 +114,11 @@ internal sealed class MessageDocument
         Mentions,
         ReplyTo?.ToDomain(),
         ForwardedFrom?.ToDomain(),
-        ReadBy.Select(r => r.ToDomain()));
+        ReadBy.Select(r => r.ToDomain()),
+        ThreadRootId,
+        ThreadReplyCount,
+        ThreadParticipants,
+        ThreadLastReplyAtUtc.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(ThreadLastReplyAtUtc.Value, DateTimeKind.Utc)) : null);
 
     public static MessageDocument FromDomain(Message message) => new()
     {
@@ -125,5 +143,9 @@ internal sealed class MessageDocument
         ReplyTo = message.ReplyTo is { } r ? ReplyToDocument.FromDomain(r) : null,
         ForwardedFrom = message.ForwardedFrom is { } f ? ForwardedFromDocument.FromDomain(f) : null,
         ReadBy = message.ReadBy.Select(ReadReceiptDocument.FromDomain).ToList(),
+        ThreadRootId = message.ThreadRootId,
+        ThreadReplyCount = message.ThreadReplyCount,
+        ThreadParticipants = message.ThreadParticipants.ToList(),
+        ThreadLastReplyAtUtc = message.ThreadLastReplyAtUtc?.UtcDateTime,
     };
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ThreadSubscriptionDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ThreadSubscriptionDocument.cs
@@ -1,0 +1,45 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+internal sealed class ThreadSubscriptionDocument
+{
+    [BsonId]
+    public ObjectId Id { get; set; }
+
+    [BsonElement("rootMessageId")]
+    public Guid RootMessageId { get; set; }
+
+    [BsonElement("userId")]
+    public Guid UserId { get; set; }
+
+    [BsonElement("reason")]
+    [BsonRepresentation(BsonType.String)]
+    public ThreadSubscriptionReason Reason { get; set; }
+
+    [BsonElement("subscribedAtUtc")]
+    public DateTime SubscribedAtUtc { get; set; }
+
+    [BsonElement("lastActivityAtUtc")]
+    public DateTime LastActivityAtUtc { get; set; }
+
+    public ThreadSubscription ToDomain() => ThreadSubscription.Hydrate(
+        RootMessageId,
+        UserId,
+        Reason,
+        new DateTimeOffset(DateTime.SpecifyKind(SubscribedAtUtc, DateTimeKind.Utc)),
+        new DateTimeOffset(DateTime.SpecifyKind(LastActivityAtUtc, DateTimeKind.Utc)));
+
+    public static ThreadSubscriptionDocument FromDomain(ThreadSubscription subscription) => new()
+    {
+        Id = ObjectId.GenerateNewId(),
+        RootMessageId = subscription.RootMessageId,
+        UserId = subscription.UserId,
+        Reason = subscription.Reason,
+        SubscribedAtUtc = subscription.SubscribedAtUtc.UtcDateTime,
+        LastActivityAtUtc = subscription.LastActivityAtUtc.UtcDateTime,
+    };
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -424,4 +424,97 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         }
         return doc.ReadBy.Select(r => r.ToDomain()).ToList();
     }
+
+    public async Task<bool> IncrementThreadDenormAsync(
+        Guid rootMessageId,
+        Guid replierUserId,
+        DateTimeOffset atUtc,
+        CancellationToken cancellationToken)
+    {
+        var fb = Builders<MessageDocument>.Filter;
+        // Filter ensures we only ever bump denorms on a non-deleted root: a thread reply has
+        // threadRootId set, so excluding it prevents a reply from accidentally accumulating its
+        // own children. Tombstoned roots are likewise excluded — the application layer rejects
+        // replies on deleted roots and this is a defensive backstop.
+        var filter = fb.And(
+            fb.Eq(m => m.Id, rootMessageId),
+            fb.Eq(m => m.ThreadRootId, (Guid?)null),
+            fb.Ne(m => m.State, MessageState.Deleted));
+
+        // Single atomic pipeline: $add for the counter, $setUnion for participants (dedupes the
+        // replier across multiple replies), unconditional $set for the timestamp because the
+        // caller always passes the new reply's timestamp.
+        var pipeline = new BsonDocument[]
+        {
+            new("$set", new BsonDocument
+            {
+                {
+                    "threadReplyCount",
+                    new BsonDocument("$add", new BsonArray
+                    {
+                        new BsonDocument("$ifNull", new BsonArray { "$threadReplyCount", 0 }),
+                        1,
+                    })
+                },
+                {
+                    "threadParticipants",
+                    new BsonDocument("$setUnion", new BsonArray
+                    {
+                        new BsonDocument("$ifNull", new BsonArray { "$threadParticipants", new BsonArray() }),
+                        new BsonArray { new BsonBinaryData(replierUserId, GuidRepresentation.Standard) },
+                    })
+                },
+                { "threadLastReplyAtUtc", atUtc.UtcDateTime },
+            })
+        };
+
+        PipelineDefinition<MessageDocument, MessageDocument> definition = pipeline;
+        var update = Builders<MessageDocument>.Update.Pipeline(definition);
+
+        var result = await context.Messages
+            .UpdateOneAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount > 0;
+    }
+
+    public async Task<IReadOnlyList<Message>> ListThreadAsync(
+        Guid rootMessageId,
+        MessageCursor? cursor,
+        int limit,
+        CursorDirection direction,
+        CancellationToken cancellationToken)
+    {
+        if (limit <= 0)
+        {
+            return Array.Empty<Message>();
+        }
+
+        var fb = Builders<MessageDocument>.Filter;
+        var filter = fb.Eq(m => m.ThreadRootId, (Guid?)rootMessageId);
+
+        if (cursor is { } c)
+        {
+            var ts = c.CreatedAtUtc.UtcDateTime;
+            filter = direction == CursorDirection.Older
+                ? fb.And(filter, fb.Or(
+                    fb.Lt(m => m.CreatedAtUtc, ts),
+                    fb.And(fb.Eq(m => m.CreatedAtUtc, ts), fb.Lt(m => m.Id, c.MessageId))))
+                : fb.And(filter, fb.Or(
+                    fb.Gt(m => m.CreatedAtUtc, ts),
+                    fb.And(fb.Eq(m => m.CreatedAtUtc, ts), fb.Gt(m => m.Id, c.MessageId))));
+        }
+
+        var sort = direction == CursorDirection.Older
+            ? Builders<MessageDocument>.Sort.Descending(m => m.CreatedAtUtc).Descending(m => m.Id)
+            : Builders<MessageDocument>.Sort.Ascending(m => m.CreatedAtUtc).Ascending(m => m.Id);
+
+        var docs = await context.Messages
+            .Find(filter)
+            .Sort(sort)
+            .Limit(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return docs.Select(d => d.ToDomain()).ToList();
+    }
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -102,7 +102,12 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         }
 
         var fb = Builders<MessageDocument>.Filter;
-        var filter = fb.Eq(m => m.ConversationId, conversationId);
+        // Main-flow only: thread replies have threadRootId set and are surfaced exclusively via
+        // ListThreadAsync. Mongo treats missing == null, so legacy documents without the field
+        // continue to appear here without backfill.
+        var filter = fb.And(
+            fb.Eq(m => m.ConversationId, conversationId),
+            fb.Eq(m => m.ThreadRootId, (Guid?)null));
 
         if (cursor is { } c)
         {
@@ -180,8 +185,13 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         DateTimeOffset readAtUtc,
         CancellationToken cancellationToken)
     {
+        // Reading the main flow does not affect thread replies: they have their own surfacing
+        // via GetThreadMessages and read transitions there are out of scope for this call. We
+        // therefore reject thread reply anchors and exclude thread replies from the bulk update.
         var anchor = await context.Messages
-            .Find(m => m.Id == upToMessageId && m.ConversationId == conversationId)
+            .Find(m => m.Id == upToMessageId
+                && m.ConversationId == conversationId
+                && m.ThreadRootId == null)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
         if (anchor is null)
@@ -193,6 +203,7 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
         var anchorTs = anchor.CreatedAtUtc;
         var filter = fb.And(
             fb.Eq(m => m.ConversationId, conversationId),
+            fb.Eq(m => m.ThreadRootId, (Guid?)null),
             fb.Ne(m => m.State, MessageState.Read),
             fb.Ne(m => m.State, MessageState.Deleted),
             fb.Or(

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
@@ -58,6 +58,50 @@ internal sealed class MongoIndexInitializer(ChatMongoContext context) : IHostedS
                         Background = true,
                         Sparse = true,
                     }),
+                // Thread-reply chronological lookups: GetThreadMessages walks replies for a given
+                // root in createdAt order, so the keys are (threadRootId, createdAtUtc) ascending.
+                // Sparse since main-flow messages have no threadRootId.
+                new CreateIndexModel<MessageDocument>(
+                    Builders<MessageDocument>.IndexKeys
+                        .Ascending(m => m.ThreadRootId)
+                        .Ascending(m => m.CreatedAtUtc),
+                    new CreateIndexOptions
+                    {
+                        Name = "ix_messages_threadRoot_createdAt",
+                        Background = true,
+                        Sparse = true,
+                    }),
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        var threadSubscriptions = context.ThreadSubscriptions;
+        await threadSubscriptions.Indexes.CreateManyAsync(
+            new[]
+            {
+                // Uniqueness on (rootMessageId, userId) prevents duplicate subscriptions and lets
+                // UpsertAsync rely on it as an atomicity backstop.
+                new CreateIndexModel<ThreadSubscriptionDocument>(
+                    Builders<ThreadSubscriptionDocument>.IndexKeys
+                        .Ascending(d => d.RootMessageId)
+                        .Ascending(d => d.UserId),
+                    new CreateIndexOptions
+                    {
+                        Name = "ux_thread_subscriptions_root_user",
+                        Background = true,
+                        Unique = true,
+                    }),
+                // Active-threads keyset pagination: filter by userId, sort by lastActivityAtUtc desc
+                // then rootMessageId desc as a deterministic tie-breaker.
+                new CreateIndexModel<ThreadSubscriptionDocument>(
+                    Builders<ThreadSubscriptionDocument>.IndexKeys
+                        .Ascending(d => d.UserId)
+                        .Descending(d => d.LastActivityAtUtc)
+                        .Descending(d => d.RootMessageId),
+                    new CreateIndexOptions
+                    {
+                        Name = "ix_thread_subscriptions_user_lastActivity_desc",
+                        Background = true,
+                    }),
             },
             cancellationToken).ConfigureAwait(false);
     }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ThreadSubscriptionRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ThreadSubscriptionRepository.cs
@@ -1,0 +1,150 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+internal sealed class ThreadSubscriptionRepository(ChatMongoContext context) : IThreadSubscriptionRepository
+{
+    public async Task<ThreadSubscriptionUpsertResult> UpsertAsync(
+        ThreadSubscription subscription,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var filter = Builders<ThreadSubscriptionDocument>.Filter.And(
+            Builders<ThreadSubscriptionDocument>.Filter.Eq(d => d.RootMessageId, subscription.RootMessageId),
+            Builders<ThreadSubscriptionDocument>.Filter.Eq(d => d.UserId, subscription.UserId));
+
+        // Pipeline upsert: $max on reason and lastActivityAtUtc enforces escalation-only
+        // semantics atomically. Reason is stored as its enum string ("Manual"/"Mentioned"/"Replied")
+        // — by design these names sort lexicographically in the same order as the enum's priority,
+        // so $max on the string yields the higher-priority value.
+        var pipeline = new BsonDocument[]
+        {
+            new("$set", new BsonDocument
+            {
+                { "rootMessageId", new BsonBinaryData(subscription.RootMessageId, GuidRepresentation.Standard) },
+                { "userId", new BsonBinaryData(subscription.UserId, GuidRepresentation.Standard) },
+                {
+                    "subscribedAtUtc",
+                    new BsonDocument("$ifNull", new BsonArray { "$subscribedAtUtc", subscription.SubscribedAtUtc.UtcDateTime })
+                },
+                {
+                    "reason",
+                    new BsonDocument("$max", new BsonArray { "$reason", subscription.Reason.ToString() })
+                },
+                {
+                    "lastActivityAtUtc",
+                    new BsonDocument("$max", new BsonArray { "$lastActivityAtUtc", subscription.LastActivityAtUtc.UtcDateTime })
+                },
+            })
+        };
+
+        var update = new BsonDocumentStagePipelineDefinition<ThreadSubscriptionDocument, ThreadSubscriptionDocument>(pipeline);
+        var options = new FindOneAndUpdateOptions<ThreadSubscriptionDocument, ThreadSubscriptionDocument>
+        {
+            IsUpsert = true,
+            ReturnDocument = ReturnDocument.Before,
+        };
+
+        var before = await context.ThreadSubscriptions
+            .FindOneAndUpdateAsync(filter, update, options, cancellationToken)
+            .ConfigureAwait(false);
+
+        var wasCreated = before is null;
+        var reasonEscalated = before is not null && (int)before.Reason < (int)subscription.Reason;
+        return new ThreadSubscriptionUpsertResult(wasCreated, reasonEscalated);
+    }
+
+    public async Task<bool> RemoveAsync(Guid rootMessageId, Guid userId, CancellationToken cancellationToken)
+    {
+        var result = await context.ThreadSubscriptions
+            .DeleteOneAsync(
+                d => d.RootMessageId == rootMessageId && d.UserId == userId,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return result.DeletedCount > 0;
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetSubscriberIdsAsync(Guid rootMessageId, CancellationToken cancellationToken)
+    {
+        var ids = await context.ThreadSubscriptions
+            .Find(d => d.RootMessageId == rootMessageId)
+            .Project(d => d.UserId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return ids;
+    }
+
+    public async Task<bool> IsSubscribedAsync(Guid rootMessageId, Guid userId, CancellationToken cancellationToken)
+    {
+        var count = await context.ThreadSubscriptions
+            .CountDocumentsAsync(
+                d => d.RootMessageId == rootMessageId && d.UserId == userId,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return count > 0;
+    }
+
+    public async Task<long> TouchActivityForRootAsync(
+        Guid rootMessageId,
+        DateTimeOffset atUtc,
+        CancellationToken cancellationToken)
+    {
+        var pipeline = new BsonDocument[]
+        {
+            new("$set", new BsonDocument(
+                "lastActivityAtUtc",
+                new BsonDocument("$max", new BsonArray { "$lastActivityAtUtc", atUtc.UtcDateTime })))
+        };
+        var update = new BsonDocumentStagePipelineDefinition<ThreadSubscriptionDocument, ThreadSubscriptionDocument>(pipeline);
+
+        var filter = Builders<ThreadSubscriptionDocument>.Filter.Eq(d => d.RootMessageId, rootMessageId);
+        var result = await context.ThreadSubscriptions
+            .UpdateManyAsync(filter, update, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return result.ModifiedCount;
+    }
+
+    public async Task<IReadOnlyList<ThreadSubscription>> ListUserActiveAsync(
+        Guid userId,
+        ThreadActivityCursor? cursor,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        if (limit <= 0)
+        {
+            return Array.Empty<ThreadSubscription>();
+        }
+
+        var fb = Builders<ThreadSubscriptionDocument>.Filter;
+        var filter = fb.Eq(d => d.UserId, userId);
+
+        if (cursor is { } c)
+        {
+            var ts = c.LastActivityAtUtc.UtcDateTime;
+            // Strict descending paging keyed on (lastActivityAtUtc, rootMessageId): take rows
+            // older than the cursor, breaking ties by RootMessageId desc.
+            var cursorFilter = fb.Or(
+                fb.Lt(d => d.LastActivityAtUtc, ts),
+                fb.And(
+                    fb.Eq(d => d.LastActivityAtUtc, ts),
+                    fb.Lt(d => d.RootMessageId, c.RootMessageId)));
+            filter = fb.And(filter, cursorFilter);
+        }
+
+        var docs = await context.ThreadSubscriptions
+            .Find(filter)
+            .Sort(Builders<ThreadSubscriptionDocument>.Sort
+                .Descending(d => d.LastActivityAtUtc)
+                .Descending(d => d.RootMessageId))
+            .Limit(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return docs.Select(d => d.ToDomain()).ToList();
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -114,6 +114,40 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
         return hub.Clients.Users(ToUserIds(recipientUserIds)).PinsUpdated(conversationId, pinnedMessages);
     }
 
+    public Task NotifyThreadReplyReceivedAsync(
+        IReadOnlyList<Guid> subscriberUserIds,
+        Guid rootMessageId,
+        MessageDto reply,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscriberUserIds);
+        ArgumentNullException.ThrowIfNull(reply);
+        if (subscriberUserIds.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+        return hub.Clients.Users(ToUserIds(subscriberUserIds)).ThreadReplyReceived(rootMessageId, reply);
+    }
+
+    public Task NotifyThreadRootUpdatedAsync(
+        IReadOnlyList<Guid> participantUserIds,
+        string conversationId,
+        Guid rootMessageId,
+        int replyCount,
+        IReadOnlyList<Guid> participants,
+        DateTimeOffset lastReplyAtUtc,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(participantUserIds);
+        ArgumentNullException.ThrowIfNull(participants);
+        if (participantUserIds.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+        return hub.Clients.Users(ToUserIds(participantUserIds))
+            .ThreadRootUpdated(conversationId, rootMessageId, replyCount, participants, lastReplyAtUtc);
+    }
+
     private static List<string> ToUserIds(IReadOnlyList<Guid> userIds)
         => userIds.Select(u => u.ToString("D", CultureInfo.InvariantCulture)).ToList();
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -148,6 +148,22 @@ internal sealed class ChatBroadcaster(IHubContext<ChatHub, IChatClient> hub) : I
             .ThreadRootUpdated(conversationId, rootMessageId, replyCount, participants, lastReplyAtUtc);
     }
 
+    public Task NotifyThreadParticipantJoinedAsync(
+        IReadOnlyList<Guid> subscriberUserIds,
+        Guid rootMessageId,
+        Guid joinedUserId,
+        ThreadSubscriptionReason reason,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscriberUserIds);
+        if (subscriberUserIds.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+        return hub.Clients.Users(ToUserIds(subscriberUserIds))
+            .ThreadParticipantJoined(rootMessageId, joinedUserId, reason.ToString());
+    }
+
     private static List<string> ToUserIds(IReadOnlyList<Guid> userIds)
         => userIds.Select(u => u.ToString("D", CultureInfo.InvariantCulture)).ToList();
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.SignalR;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Application.Threads;
 using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
 // PinMessageService and UnpinMessageService live in Application.Conversations.
 
@@ -18,6 +20,13 @@ public sealed record SendMessageHubInput(
 
 public sealed record EditMessageHubInput(Guid MessageId, string NewBody);
 
+public sealed record ReplyInThreadHubInput(
+    Guid RootMessageId,
+    string Body,
+    IReadOnlyList<Guid> AttachmentAssetIds,
+    string ClientMessageId,
+    Guid? ReplyToMessageId = null);
+
 [Authorize]
 public sealed class ChatHub(
     OpenDirectConversationService openDirect,
@@ -30,7 +39,11 @@ public sealed class ChatHub(
     AddReactionService addReaction,
     RemoveReactionService removeReaction,
     PinMessageService pinMessage,
-    UnpinMessageService unpinMessage) : Hub<IChatClient>
+    UnpinMessageService unpinMessage,
+    ReplyInThreadService replyInThread,
+    JoinThreadService joinThread,
+    LeaveThreadService leaveThread,
+    GetThreadMessagesQuery getThreadMessages) : Hub<IChatClient>
 {
     public async Task<ConversationDto> OpenDirectConversation(Guid peerUserId)
     {
@@ -129,4 +142,41 @@ public sealed class ChatHub(
             Context.ConnectionAborted);
     }
 
+    public Task<MessageDto> ReplyInThread(ReplyInThreadHubInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        var caller = Context.User!.GetUserId();
+        return replyInThread.ReplyAsync(
+            new ReplyInThreadRequest(
+                caller,
+                input.RootMessageId,
+                input.Body ?? string.Empty,
+                input.AttachmentAssetIds ?? Array.Empty<Guid>(),
+                input.ReplyToMessageId,
+                input.ClientMessageId),
+            Context.ConnectionAborted);
+    }
+
+    public Task JoinThread(Guid rootMessageId)
+    {
+        var caller = Context.User!.GetUserId();
+        return joinThread.JoinAsync(new JoinThreadRequest(caller, rootMessageId), Context.ConnectionAborted);
+    }
+
+    public Task LeaveThread(Guid rootMessageId)
+    {
+        var caller = Context.User!.GetUserId();
+        return leaveThread.LeaveAsync(new LeaveThreadRequest(caller, rootMessageId), Context.ConnectionAborted);
+    }
+
+    /// <summary>
+    /// Walks the thread reply list. Defaults to <see cref="CursorDirection.Older"/> so an empty
+    /// cursor returns the most recent replies first — matching the main-flow REST contract.
+    /// </summary>
+    public Task<CursorPage<MessageDto>> GetThreadMessages(Guid rootMessageId, string? cursor, int? limit)
+    {
+        var caller = Context.User!.GetUserId();
+        return getThreadMessages.ExecuteAsync(
+            rootMessageId, caller, cursor, limit, CursorDirection.Older, Context.ConnectionAborted);
+    }
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -80,4 +80,11 @@ public interface IChatBroadcaster
         IReadOnlyList<Guid> participants,
         DateTimeOffset lastReplyAtUtc,
         CancellationToken cancellationToken);
+
+    Task NotifyThreadParticipantJoinedAsync(
+        IReadOnlyList<Guid> subscriberUserIds,
+        Guid rootMessageId,
+        Guid joinedUserId,
+        ThreadSubscriptionReason reason,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -65,4 +65,19 @@ public interface IChatBroadcaster
         string conversationId,
         IReadOnlyList<MessageDto> pinnedMessages,
         CancellationToken cancellationToken);
+
+    Task NotifyThreadReplyReceivedAsync(
+        IReadOnlyList<Guid> subscriberUserIds,
+        Guid rootMessageId,
+        MessageDto reply,
+        CancellationToken cancellationToken);
+
+    Task NotifyThreadRootUpdatedAsync(
+        IReadOnlyList<Guid> participantUserIds,
+        string conversationId,
+        Guid rootMessageId,
+        int replyCount,
+        IReadOnlyList<Guid> participants,
+        DateTimeOffset lastReplyAtUtc,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -38,4 +38,10 @@ public interface IChatClient
         int replyCount,
         IReadOnlyList<Guid> participants,
         DateTimeOffset lastReplyAtUtc);
+
+    /// <summary>
+    /// Delivered to current thread subscribers when a new user joins (manually or by reply).
+    /// Reason indicates why the user was added so clients can render different UI cues.
+    /// </summary>
+    Task ThreadParticipantJoined(Guid rootMessageId, Guid userId, string reason);
 }

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatClient.cs
@@ -24,4 +24,18 @@ public interface IChatClient
     Task ReactionUpdated(Guid messageId, IReadOnlyDictionary<string, IReadOnlyList<Guid>> summary);
 
     Task PinsUpdated(string conversationId, IReadOnlyList<MessageDto> pinnedMessages);
+
+    /// <summary>Delivered only to thread subscribers — the new reply does not surface in the main flow.</summary>
+    Task ThreadReplyReceived(Guid rootMessageId, MessageDto reply);
+
+    /// <summary>
+    /// Delivered to every participant of the parent conversation so the main-flow UI can refresh
+    /// the "N replies" marker on the root message without re-fetching it.
+    /// </summary>
+    Task ThreadRootUpdated(
+        string conversationId,
+        Guid rootMessageId,
+        int replyCount,
+        IReadOnlyList<Guid> participants,
+        DateTimeOffset lastReplyAtUtc);
 }

--- a/src/Services/Chat/README.md
+++ b/src/Services/Chat/README.md
@@ -2,11 +2,12 @@
 
 ## Responsibility
 
-Direct (1-on-1) messaging plus the messenger feature surface from #211: edit/delete with TTL,
-reply, forward, reactions, mentions, pinned messages, and group-aware read receipts. The
-service stores conversations and messages in MongoDB, broadcasts state changes over SignalR,
-and emits Kafka integration events on `urfu.chat.events.v1` for downstream services
-(NotificationService, analytics).
+Direct (1-on-1) messaging plus the messenger feature surface from #211 (edit/delete with TTL,
+reply, forward, reactions, mentions, pinned messages, group-aware read receipts) and the
+threads feature from #212 (branched discussions rooted at any main-flow message). The service
+stores conversations, messages, and thread subscriptions in MongoDB, broadcasts state changes
+over SignalR, and emits Kafka integration events on `urfu.chat.events.v1` for downstream
+services (NotificationService, analytics).
 
 Discipline / group chats are scaffolded but disabled at the policy layer until #214 wires up
 real teacher/student role resolution; until then `IDisciplineRoleResolver` allows direct
@@ -19,19 +20,29 @@ participants to pin and rejects all group-chat pin attempts.
     `PinnedMessageIds` with cap-aware `PinMessage`/`UnpinMessage`.
   - `Message` — state machine `Sent → Delivered → Read [→ Deleted]` with feature methods:
     `Edit`, `MarkDeletedForEveryone`, `MarkDeletedForMe`, `AddReaction`, `RemoveReaction`,
-    `MarkReadBy`. TTL/author guards live in `IsEditableBy` / `IsDeletableForEveryoneBy`.
+    `MarkReadBy`, plus thread support: `SendAsThreadReply` factory and the root-only
+    `IncrementThreadDenorm` for `ThreadReplyCount` / `ThreadParticipants` /
+    `ThreadLastReplyAtUtc`. TTL/author guards live in `IsEditableBy` /
+    `IsDeletableForEveryoneBy`.
+  - `ThreadSubscription` — who receives realtime updates for a thread. Reason has strict
+    priority ordering `Manual < Mentioned < Replied`; `EscalateReason` raises but never
+    downgrades, and `LastActivityAtUtc` is the denorm sort key for the active-threads list.
   - Value objects: `Attachment`, `MessagePreview`, `Reaction`, `EditHistoryEntry`, `ReplyTo`,
     `ForwardedFrom`, `ReadReceipt`.
   - Enums: `MessageState`, `ConversationType` (`Direct`, `Group`), `DeleteMode`
-    (`ForMe`, `ForEveryone`).
+    (`ForMe`, `ForEveryone`), `ThreadSubscriptionReason` (`Manual`, `Mentioned`, `Replied`).
   - Integration events — see the table below.
 - `Application/`
   - Use cases: `OpenDirectConversation`, `SendMessage` (handles reply, mentions, attachment
     grants), `MarkDelivered`, `MarkRead` (also populates `ReadBy[]`), `EditMessage`,
     `DeleteMessage`, `ForwardMessages`, `AddReaction`, `RemoveReaction`, `PinMessage`,
-    `UnpinMessage`.
+    `UnpinMessage`. Thread services in `Application/Threads/`: `ReplyInThread` (auto-subscribes
+    replier with `Replied`, mentions with `Mentioned`, escalating but never downgrading existing
+    subscriptions, then bumps every subscriber's `LastActivityAtUtc`), `JoinThread` (manual
+    `Manual` subscription), `LeaveThread`.
   - Queries: `GetUserConversations`, `GetConversation`, `GetConversationMessages`,
-    `GetReadReceipts`.
+    `GetReadReceipts`, `GetThreadMessages`, `GetUserActiveThreads` (joins
+    `thread_subscriptions` with their roots and filters out tombstoned roots at projection).
   - `Mentions/MentionsParser` — extracts `@<guid>`, `@everyone`, and the discipline-only
     `@teachers`/`@students` tokens (stubbed empty until #214). Drops non-participants and
     caps at `Chat:MaxMentionsPerMessage`.
@@ -69,10 +80,14 @@ participants to pin and rejects all group-chat pin attempts.
     (descending).
   - Collection `messages` — composite indexes `(conversationId, createdAtUtc desc)` and
     `(senderId, createdAtUtc desc)`, a unique sparse index on
-    `(senderId, clientMessageId)` for `SendMessage` idempotency, and a sparse index on
-    `mentions` for future mention search.
+    `(senderId, clientMessageId)` for `SendMessage` idempotency, a sparse index on
+    `mentions` for future mention search, and a sparse `(threadRootId, createdAtUtc asc)`
+    index that backs `ListThreadAsync`.
+  - Collection `thread_subscriptions` — unique `(rootMessageId, userId)` (atomicity backstop
+    for the upsert pipeline) and `(userId, lastActivityAtUtc desc, rootMessageId desc)` for
+    the active-threads keyset pagination.
 - Redis: shared `IIdempotencyStore` (BuildingBlocks) for hot-path duplicate detection of
-  SendMessage by `(senderId, clientMessageId)`.
+  SendMessage and ReplyInThread by `(senderId, clientMessageId)`.
 
 ## Realtime
 
@@ -85,13 +100,23 @@ HTTP upgrade or, for transports that can't set headers, from `?access_token=` on
 
 `OpenDirectConversation`, `SendMessage` (with optional `ReplyToMessageId`), `MarkDelivered`,
 `MarkRead`, `EditMessage`, `DeleteMessage`, `ForwardMessages`, `AddReaction`,
-`RemoveReaction`, `PinMessage`, `UnpinMessage`.
+`RemoveReaction`, `PinMessage`, `UnpinMessage`, `ReplyInThread`, `JoinThread`, `LeaveThread`,
+`GetThreadMessages`.
 
 ### Broadcasts (`IChatClient`, server → client)
 
 `ConversationUpdated`, `MessageReceived`, `MessageDeliveredUpdate`, `MessageReadUpdate`,
 `MessageReadByUpdate` (group-aware), `MessageEdited`, `MessageDeletedUpdate`,
-`ReactionUpdated`, `PinsUpdated`.
+`ReactionUpdated`, `PinsUpdated`, `ThreadReplyReceived` (subscribers only),
+`ThreadRootUpdated` (every conversation participant — refreshes the main-flow "N replies"
+marker), `ThreadParticipantJoined` (existing subscribers).
+
+### Thread broadcasts use the same `Clients.Users(...)` addressing as the main flow
+
+Subscribers are the single source of truth in `thread_subscriptions`; SignalR groups are
+intentionally **not** used. This avoids a second piece of state to keep in sync, gives free
+multi-device delivery via `IUserIdProvider`, and makes reconnect a no-op (the broadcaster
+just queries subscribers on each call).
 
 ### Typing indicators
 
@@ -115,6 +140,11 @@ responsibility for now.
 | `POST` | `/messages/{id}/reactions` | Add or replace caller's reaction. |
 | `DELETE` | `/messages/{id}/reactions/{emoji}` | Remove caller's reaction. |
 | `GET` | `/messages/{id}/read-receipts` | List of `ReadReceipt`s on the message. |
+| `POST` | `/messages/{id}/thread` | Post a reply in the thread rooted at this message. |
+| `GET` | `/messages/{id}/thread` | Cursor-paginated reply list. |
+| `POST` | `/messages/{id}/thread/subscribe` | Manually subscribe (`Manual` reason). |
+| `DELETE` | `/messages/{id}/thread/subscribe` | Unsubscribe. Reply history is untouched. |
+| `GET` | `/threads/active` | Caller's active threads, ordered by last activity desc. |
 
 ## Integration events (Kafka topic `urfu.chat.events.v1`)
 
@@ -128,14 +158,41 @@ responsibility for now.
 | `chat.message.deleted.v1` | conversationId, messageId, deleteMode, deletedBy | analytics |
 | `chat.reaction.added.v1` | conversationId, messageId, userId, emoji | analytics |
 | `chat.reaction.removed.v1` | conversationId, messageId, userId, emoji | analytics |
-| `chat.mention.created.v1` | conversationId, messageId, senderId, mentionedUserIds | NotificationService (#209) |
+| `chat.mention.created.v1` | conversationId, messageId, senderId, mentionedUserIds, threadRootId? | NotificationService (#209) |
 | `chat.message.pinned.v1` | conversationId, messageId, pinnedByUserId | analytics |
 | `chat.message.unpinned.v1` | conversationId, messageId, unpinnedByUserId | analytics |
+| `chat.thread.reply_posted.v1` | conversationId, rootMessageId, messageId, senderId, subscribers, mentions? | NotificationService (future) |
+| `chat.thread.subscription_changed.v1` | rootMessageId, userId, subscribed, reason | NotificationService (future) |
 
-## Out of scope (#211)
+## Out of scope (#211 / #212)
 
 - Discipline group chats themselves (#214). `ConversationType.Group` and the role-resolver
   contract are in place but no service opens group conversations yet.
 - Real `@teachers` / `@students` resolution — currently expanded to an empty set.
-- NotificationService consumer for `chat.mention.created.v1` (#209). The event ships, the
-  consumer arrives later.
+- NotificationService consumer for `chat.mention.created.v1` (#209) and the thread events
+  added by #212. The events ship through the outbox, the consumer arrives later.
+
+## Threads — design notes (#212)
+
+- **Storage:** thread replies live in the same `messages` collection as main-flow messages
+  but carry a non-null `threadRootId`. `ListByConversationAsync` and `MarkReadUpToAsync`
+  filter on `threadRootId: null` so the main flow stays clean and read transitions there
+  do not reach into threads. Mongo treats missing fields as null, so pre-#212 documents
+  hydrate as main-flow without a backfill.
+- **Denormalization:** the root message owns `ThreadReplyCount`, `ThreadParticipants`, and
+  `ThreadLastReplyAtUtc`. Each subscription document additionally stores
+  `LastActivityAtUtc` so the active-threads list can paginate from a single index without
+  joining the messages collection.
+- **Atomicity:** `IncrementThreadDenormAsync` and `ThreadSubscriptionRepository.UpsertAsync`
+  use Mongo aggregation-pipeline updates with `$max` / `$setUnion` so escalation and
+  bookkeeping happen in a single op. The reply insert and the root denorm bump are two
+  writes — Mongo single-replica has no multi-doc transactions, so a crash between the two
+  leaves the reply but lags the counter; the next reply re-broadcasts the corrected count
+  through `ThreadRootUpdated`.
+- **Auto-subscribe:** posting a reply subscribes the replier as `Replied`; mentioning a user
+  subscribes them as `Mentioned`. Both escalate, never downgrade — so a manual subscriber
+  who later replies becomes `Replied`, and a `Replied` subscriber who is mentioned again
+  stays `Replied`. Edits to a reply do **not** mutate subscriptions.
+- **Authorization:** join, reply, and read all require participation in the parent
+  conversation. Tombstoned roots reject new replies. A reply cannot point at itself or at
+  another reply.

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/ThreadEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/ThreadEndpointsTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http.Json;
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+
+namespace ChatService.IntegrationTests.Endpoints;
+
+[Collection(IntegrationCollection.Name)]
+public class ThreadEndpointsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ThreadEndpointsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private async Task<(Guid alice, Guid bob, string convId, Guid rootId)> SeedThreadRootAsync()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        Guid rootId;
+        string convId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var open = scope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            var conv = await open.OpenAsync(alice, bob, default);
+            convId = conv.Id;
+
+            var send = scope.ServiceProvider.GetRequiredService<SendMessageService>();
+            var sent = await send.SendAsync(
+                new SendMessageRequest(convId, alice, "root", Array.Empty<Guid>(), $"c-root-{Guid.NewGuid():N}", null),
+                default);
+            rootId = sent.Id;
+        }
+        return (alice, bob, convId, rootId);
+    }
+
+    [Fact]
+    public async Task Post_Reply_PostsReplyAndReturnsThreadRootId()
+    {
+        var (_, bob, _, rootId) = await SeedThreadRootAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(bob);
+
+        using var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/chat/messages/{rootId}/thread",
+            new
+            {
+                body = "in thread",
+                attachmentAssetIds = Array.Empty<Guid>(),
+                clientMessageId = $"c-{Guid.NewGuid():N}",
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<MessageDto>();
+        dto!.ThreadRootId.Should().Be(rootId);
+        dto.Body.Should().Be("in thread");
+    }
+
+    [Fact]
+    public async Task Get_ThreadMessages_ReturnsRepliesPage()
+    {
+        var (_, bob, _, rootId) = await SeedThreadRootAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(bob);
+
+        using var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/v1/chat/messages/{rootId}/thread",
+            new
+            {
+                body = "first",
+                attachmentAssetIds = Array.Empty<Guid>(),
+                clientMessageId = $"c-{Guid.NewGuid():N}",
+            });
+
+        var page = await client.GetFromJsonAsync<CursorPage<MessageDto>>(
+            $"/api/v1/chat/messages/{rootId}/thread?limit=10");
+
+        page!.Items.Should().ContainSingle().Which.Body.Should().Be("first");
+    }
+
+    [Fact]
+    public async Task SubscribeAndUnsubscribe_RoundTrip_ReturnsNoContent()
+    {
+        var (_, bob, _, rootId) = await SeedThreadRootAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(bob);
+
+        using var client = _factory.CreateClient();
+        var subscribe = await client.PostAsJsonAsync(
+            $"/api/v1/chat/messages/{rootId}/thread/subscribe",
+            new { });
+        subscribe.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var unsubscribe = await client.DeleteAsync(
+            $"/api/v1/chat/messages/{rootId}/thread/subscribe");
+        unsubscribe.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Get_ActiveThreads_ListsRepliedSubscriptions()
+    {
+        var (_, bob, _, rootId) = await SeedThreadRootAsync();
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(bob);
+
+        using var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/v1/chat/messages/{rootId}/thread",
+            new
+            {
+                body = "first",
+                attachmentAssetIds = Array.Empty<Guid>(),
+                clientMessageId = $"c-{Guid.NewGuid():N}",
+            });
+
+        var page = await client.GetFromJsonAsync<CursorPage<ActiveThreadDto>>(
+            "/api/v1/chat/threads/active?limit=10");
+
+        page!.Items.Should().ContainSingle().Which.RootMessageId.Should().Be(rootId);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubThreadsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubThreadsTests.cs
@@ -1,0 +1,143 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace ChatService.IntegrationTests.Hub;
+
+[Collection(IntegrationCollection.Name)]
+public class ChatHubThreadsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public ChatHubThreadsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ReplyInThread_BroadcastsThreadReplyToReplier_AndThreadRootUpdatedToConvParticipants()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var aliceThreadRoot = new TaskCompletionSource<(Guid RootId, int ReplyCount)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        aliceConn.On<string, Guid, int, IReadOnlyList<Guid>, DateTimeOffset>("ThreadRootUpdated",
+            (_, rootId, replyCount, _, _) => aliceThreadRoot.TrySetResult((rootId, replyCount)));
+
+        var bobThreadReply = new TaskCompletionSource<(Guid RootId, MessageDto Reply)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        bobConn.On<Guid, MessageDto>("ThreadReplyReceived", (rootId, reply) => bobThreadReply.TrySetResult((rootId, reply)));
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+        var root = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "root",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        var reply = await bobConn.InvokeAsync<MessageDto>("ReplyInThread", new
+        {
+            RootMessageId = root.Id,
+            Body = "in thread",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        var rootUpdate = await aliceThreadRoot.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        rootUpdate.RootId.Should().Be(root.Id);
+        rootUpdate.ReplyCount.Should().Be(1);
+
+        var replyEvent = await bobThreadReply.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        replyEvent.RootId.Should().Be(root.Id);
+        replyEvent.Reply.Id.Should().Be(reply.Id);
+        replyEvent.Reply.ThreadRootId.Should().Be(root.Id);
+    }
+
+    [Fact]
+    public async Task NonSubscriber_DoesNotReceiveThreadReplyReceived_UntilJoinThread()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var charlie = Guid.NewGuid();
+
+        // Seed a 3-participant conversation directly so charlie is part of the chat without
+        // having replied or been mentioned. Direct conversations only support 2 participants,
+        // so we hydrate a Group conversation through the repository.
+        await using var seedScope = _factory.Services.CreateAsyncScope();
+        var convs = seedScope.ServiceProvider.GetRequiredService<IConversationRepository>();
+        var conv = Conversation.Hydrate(
+            id: $"group-{Guid.NewGuid():N}",
+            type: ConversationType.Group,
+            participants: new[] { alice, bob, charlie },
+            createdAtUtc: DateTimeOffset.UtcNow,
+            lastMessageAtUtc: DateTimeOffset.UtcNow,
+            lastMessagePreview: null);
+        await convs.TryCreateAsync(conv, default);
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+        await using var charlieConn = await TestChatHubClient.ConnectAsync(_factory, charlie);
+
+        // Charlie tracks ThreadReplyReceived; should not fire before JoinThread.
+        var charlieReplyEvents = 0;
+        charlieConn.On<Guid, MessageDto>("ThreadReplyReceived", (_, _) =>
+        {
+            Interlocked.Increment(ref charlieReplyEvents);
+        });
+
+        // Alice posts root.
+        var root = await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "root",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        // Bob replies in thread → he becomes Replied subscriber.
+        await bobConn.InvokeAsync<MessageDto>("ReplyInThread", new
+        {
+            RootMessageId = root.Id,
+            Body = "first reply",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        // Give the broadcast a moment to fan out (it will reach Bob's connection but not Charlie's).
+        await Task.Delay(500);
+        charlieReplyEvents.Should().Be(0, "Charlie has not subscribed yet");
+
+        // Charlie joins.
+        await charlieConn.InvokeAsync("JoinThread", root.Id);
+
+        // Set up Charlie's expectation for the next reply.
+        var charlieReplyTcs = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+        charlieConn.Remove("ThreadReplyReceived");
+        charlieConn.On<Guid, MessageDto>("ThreadReplyReceived", (rootId, _) => charlieReplyTcs.TrySetResult(rootId));
+
+        // Bob replies again — Charlie should now receive.
+        await bobConn.InvokeAsync<MessageDto>("ReplyInThread", new
+        {
+            RootMessageId = root.Id,
+            Body = "second reply",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        var receivedRootId = await charlieReplyTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        receivedRootId.Should().Be(root.Id);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -75,6 +75,8 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
             .DeleteManyAsync(MongoDB.Driver.FilterDefinition<dynamic>.Empty);
         await ctx.Database.GetCollection<dynamic>(ChatMongoContext.MessagesCollectionName)
             .DeleteManyAsync(MongoDB.Driver.FilterDefinition<dynamic>.Empty);
+        await ctx.Database.GetCollection<dynamic>(ChatMongoContext.ThreadSubscriptionsCollectionName)
+            .DeleteManyAsync(MongoDB.Driver.FilterDefinition<dynamic>.Empty);
 
         var multiplexer = Services.GetRequiredService<IConnectionMultiplexer>();
         var endpoints = multiplexer.GetEndPoints();

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryThreadsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryThreadsTests.cs
@@ -1,0 +1,180 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class MessageRepositoryThreadsTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private MessageRepository _repo = null!;
+
+    private const string ConvId = "conv-thread-tests";
+
+    public MessageRepositoryThreadsTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new MessageRepository(_context);
+        var indexes = new MongoIndexInitializer(_context);
+        await indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task InsertAsync_ThreadReply_RoundTripsThreadRootId()
+    {
+        var sender = Guid.NewGuid();
+        var rootId = Guid.NewGuid();
+        var reply = Message.SendAsThreadReply(
+            id: Guid.NewGuid(),
+            conversationId: ConvId,
+            senderId: sender,
+            body: "reply",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: $"c-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow,
+            threadRootId: rootId);
+
+        await _repo.InsertAsync(reply, default);
+
+        var loaded = await _repo.GetByIdAsync(reply.Id, default);
+        loaded.Should().NotBeNull();
+        loaded!.ThreadRootId.Should().Be(rootId);
+        loaded.IsThreadReply.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IncrementThreadDenormAsync_OnRoot_UpdatesAllThreeFields()
+    {
+        var sender = Guid.NewGuid();
+        var replier = Guid.NewGuid();
+        var root = Message.Send(Guid.NewGuid(), ConvId, sender, "root", Array.Empty<Attachment>(),
+            $"c-{Guid.NewGuid():N}", DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(root, default);
+
+        var atUtc = DateTimeOffset.UtcNow.AddSeconds(10);
+        var ok = await _repo.IncrementThreadDenormAsync(root.Id, replier, atUtc, default);
+
+        ok.Should().BeTrue();
+        var reloaded = await _repo.GetByIdAsync(root.Id, default);
+        reloaded!.ThreadReplyCount.Should().Be(1);
+        reloaded.ThreadParticipants.Should().ContainSingle().Which.Should().Be(replier);
+        reloaded.ThreadLastReplyAtUtc.Should().NotBeNull();
+        reloaded.ThreadLastReplyAtUtc!.Value.Should().BeCloseTo(atUtc, TimeSpan.FromMilliseconds(10));
+    }
+
+    [Fact]
+    public async Task IncrementThreadDenormAsync_DedupesParticipants_AcrossMultipleReplies()
+    {
+        var sender = Guid.NewGuid();
+        var replier = Guid.NewGuid();
+        var root = Message.Send(Guid.NewGuid(), ConvId, sender, "root", Array.Empty<Attachment>(),
+            $"c-{Guid.NewGuid():N}", DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(root, default);
+
+        await _repo.IncrementThreadDenormAsync(root.Id, replier, DateTimeOffset.UtcNow.AddSeconds(10), default);
+        await _repo.IncrementThreadDenormAsync(root.Id, replier, DateTimeOffset.UtcNow.AddSeconds(20), default);
+        await _repo.IncrementThreadDenormAsync(root.Id, replier, DateTimeOffset.UtcNow.AddSeconds(30), default);
+
+        var reloaded = await _repo.GetByIdAsync(root.Id, default);
+        reloaded!.ThreadReplyCount.Should().Be(3);
+        reloaded.ThreadParticipants.Should().ContainSingle().Which.Should().Be(replier);
+    }
+
+    [Fact]
+    public async Task IncrementThreadDenormAsync_OnReply_ReturnsFalse()
+    {
+        var sender = Guid.NewGuid();
+        var rootId = Guid.NewGuid();
+        var reply = Message.SendAsThreadReply(
+            id: Guid.NewGuid(), conversationId: ConvId, senderId: sender, body: "r",
+            attachments: Array.Empty<Attachment>(), clientMessageId: $"c-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow, threadRootId: rootId);
+        await _repo.InsertAsync(reply, default);
+
+        var ok = await _repo.IncrementThreadDenormAsync(reply.Id, sender, DateTimeOffset.UtcNow, default);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListThreadAsync_ReturnsRepliesInChronologicalOrder()
+    {
+        var sender = Guid.NewGuid();
+        var rootId = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var ids = new List<Guid>();
+        for (var i = 0; i < 5; i++)
+        {
+            var reply = Message.SendAsThreadReply(
+                id: Guid.NewGuid(), conversationId: ConvId, senderId: sender, body: $"r{i}",
+                attachments: Array.Empty<Attachment>(), clientMessageId: $"c-{i}-{Guid.NewGuid():N}",
+                createdAtUtc: baseTime.AddSeconds(i), threadRootId: rootId);
+            await _repo.InsertAsync(reply, default);
+            ids.Add(reply.Id);
+        }
+
+        var page = await _repo.ListThreadAsync(rootId, cursor: null, limit: 10, CursorDirection.Older, default);
+
+        page.Should().HaveCount(5);
+        page.Select(m => m.Id).Should().Equal(ids[4], ids[3], ids[2], ids[1], ids[0]);
+    }
+
+    [Fact]
+    public async Task ListByConversationAsync_ExcludesThreadReplies()
+    {
+        var sender = Guid.NewGuid();
+        var conv = $"conv-mainflow-{Guid.NewGuid():N}";
+        var root = Message.Send(Guid.NewGuid(), conv, sender, "root",
+            Array.Empty<Attachment>(), $"c-r-{Guid.NewGuid():N}", DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(root, default);
+
+        // Add a thread reply
+        var reply = Message.SendAsThreadReply(
+            id: Guid.NewGuid(), conversationId: conv, senderId: sender, body: "in thread",
+            attachments: Array.Empty<Attachment>(), clientMessageId: $"c-rep-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow.AddSeconds(10), threadRootId: root.Id);
+        await _repo.InsertAsync(reply, default);
+
+        var page = await _repo.ListByConversationAsync(conv, null, 100, CursorDirection.Older, default);
+
+        page.Should().ContainSingle().Which.Id.Should().Be(root.Id);
+    }
+
+    [Fact]
+    public async Task MarkReadUpToAsync_DoesNotReachIntoThreadReplies()
+    {
+        var sender = Guid.NewGuid();
+        var conv = $"conv-read-thread-{Guid.NewGuid():N}";
+        var root = Message.Send(Guid.NewGuid(), conv, sender, "root",
+            Array.Empty<Attachment>(), $"c-r-{Guid.NewGuid():N}", DateTimeOffset.UtcNow.AddMinutes(-1));
+        await _repo.InsertAsync(root, default);
+
+        var reply = Message.SendAsThreadReply(
+            id: Guid.NewGuid(), conversationId: conv, senderId: sender, body: "reply",
+            attachments: Array.Empty<Attachment>(), clientMessageId: $"c-rep-{Guid.NewGuid():N}",
+            createdAtUtc: DateTimeOffset.UtcNow.AddSeconds(-30), threadRootId: root.Id);
+        await _repo.InsertAsync(reply, default);
+
+        await _repo.MarkReadUpToAsync(conv, root.Id, DateTimeOffset.UtcNow, default);
+
+        var loadedReply = await _repo.GetByIdAsync(reply.Id, default);
+        // Reply must remain in Sent state — main-flow read does not touch thread replies.
+        loadedReply!.State.Should().Be(MessageState.Sent);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/ThreadSubscriptionRepositoryTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/ThreadSubscriptionRepositoryTests.cs
@@ -1,0 +1,165 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class ThreadSubscriptionRepositoryTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private ThreadSubscriptionRepository _repo = null!;
+
+    public ThreadSubscriptionRepositoryTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new ThreadSubscriptionRepository(_context);
+        var indexes = new MongoIndexInitializer(_context);
+        await indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task UpsertAsync_NewSubscription_ReturnsWasCreated()
+    {
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var sub = ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow);
+
+        var result = await _repo.UpsertAsync(sub, default);
+
+        result.WasCreated.Should().BeTrue();
+        result.ReasonEscalated.Should().BeFalse();
+        var subscribers = await _repo.GetSubscriberIdsAsync(rootId, default);
+        subscribers.Should().ContainSingle().Which.Should().Be(userId);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_AlreadyAtSameReason_ReturnsNeitherFlag()
+    {
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow), default);
+
+        var second = await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow.AddSeconds(1)), default);
+
+        second.WasCreated.Should().BeFalse();
+        second.ReasonEscalated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_EscalatesReason_FromManualToReplied()
+    {
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow), default);
+
+        var escalation = await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Replied, DateTimeOffset.UtcNow.AddSeconds(1)), default);
+
+        escalation.WasCreated.Should().BeFalse();
+        escalation.ReasonEscalated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_DoesNotDowngradeReason()
+    {
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Replied, DateTimeOffset.UtcNow), default);
+
+        var attemptDowngrade = await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow.AddSeconds(1)), default);
+
+        attemptDowngrade.WasCreated.Should().BeFalse();
+        attemptDowngrade.ReasonEscalated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DeletesAndReturnsTrue()
+    {
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow), default);
+
+        var removed = await _repo.RemoveAsync(rootId, userId, default);
+
+        removed.Should().BeTrue();
+        var subs = await _repo.GetSubscriberIdsAsync(rootId, default);
+        subs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveAsync_MissingSubscription_ReturnsFalse()
+    {
+        var removed = await _repo.RemoveAsync(Guid.NewGuid(), Guid.NewGuid(), default);
+
+        removed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TouchActivityForRootAsync_BumpsAllSubscriptions()
+    {
+        var rootId = Guid.NewGuid();
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var early = DateTimeOffset.UtcNow.AddMinutes(-10);
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, alice, ThreadSubscriptionReason.Replied, early), default);
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, bob, ThreadSubscriptionReason.Mentioned, early), default);
+
+        var late = DateTimeOffset.UtcNow;
+        var modified = await _repo.TouchActivityForRootAsync(rootId, late, default);
+
+        modified.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ListUserActiveAsync_PaginatesByLastActivityDesc()
+    {
+        var user = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow.AddMinutes(-30);
+        for (var i = 0; i < 5; i++)
+        {
+            var sub = ThreadSubscription.Subscribe(
+                Guid.NewGuid(), user, ThreadSubscriptionReason.Replied,
+                subscribedAtUtc: baseTime.AddMinutes(i),
+                lastActivityAtUtc: baseTime.AddMinutes(i));
+            await _repo.UpsertAsync(sub, default);
+        }
+
+        var page = await _repo.ListUserActiveAsync(user, cursor: null, limit: 3, default);
+
+        page.Should().HaveCount(3);
+        // Newest first
+        for (var i = 0; i < page.Count - 1; i++)
+        {
+            page[i].LastActivityAtUtc.Should().BeAfter(page[i + 1].LastActivityAtUtc);
+        }
+    }
+
+    [Fact]
+    public async Task UniqueIndex_PreventsDuplicateUpsertViaConcurrentAccess()
+    {
+        // The UpsertAsync pipeline already collapses duplicates atomically; this test exists to
+        // ensure the unique index is in place so a hand-written InsertOne would also fail. We use
+        // the public Upsert API twice and verify exactly one document persists.
+        var rootId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Manual, DateTimeOffset.UtcNow), default);
+        await _repo.UpsertAsync(ThreadSubscription.Subscribe(rootId, userId, ThreadSubscriptionReason.Mentioned, DateTimeOffset.UtcNow.AddSeconds(1)), default);
+
+        var subs = await _repo.GetSubscriberIdsAsync(rootId, default);
+        subs.Should().ContainSingle();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/CursorCodecTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/CursorCodecTests.cs
@@ -32,6 +32,19 @@ public class CursorCodecTests
         decoded.Should().Be(original);
     }
 
+    [Fact]
+    public void EncodeDecode_ThreadActivity_RoundTrips()
+    {
+        var original = new ThreadActivityCursor(
+            new DateTimeOffset(2026, 04, 25, 10, 00, 00, TimeSpan.Zero),
+            Guid.NewGuid());
+
+        var encoded = CursorCodec.EncodeThreadActivity(original);
+        var decoded = CursorCodec.DecodeThreadActivity(encoded);
+
+        decoded.Should().Be(original);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -40,12 +53,20 @@ public class CursorCodecTests
     {
         CursorCodec.DecodeConversation(input).Should().BeNull();
         CursorCodec.DecodeMessage(input).Should().BeNull();
+        CursorCodec.DecodeThreadActivity(input).Should().BeNull();
     }
 
     [Fact]
     public void Decode_Garbage_ThrowsInvalidChatCursorException()
     {
         var act = () => CursorCodec.DecodeConversation("not-base64!!");
+        act.Should().Throw<InvalidChatCursorException>();
+    }
+
+    [Fact]
+    public void DecodeThreadActivity_Garbage_ThrowsInvalidChatCursorException()
+    {
+        var act = () => CursorCodec.DecodeThreadActivity("not-base64!!");
         act.Should().Throw<InvalidChatCursorException>();
     }
 }

--- a/tests/unit/ChatService.UnitTests/Application/GetThreadMessagesQueryTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/GetThreadMessagesQueryTests.cs
@@ -1,0 +1,89 @@
+using System.Globalization;
+using FluentAssertions;
+using NSubstitute;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class GetThreadMessagesQueryTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture);
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+
+    private GetThreadMessagesQuery Build() => new(_conversations, _messages);
+
+    private (Conversation conv, Message root) SeedRoot()
+    {
+        var conv = Conversation.OpenDirect(Author, Peer, Now);
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+        var root = Message.Send(Guid.NewGuid(), conv.Id, Author, "root",
+            Array.Empty<Attachment>(), "c-root", Now);
+        _messages.GetByIdAsync(root.Id, Arg.Any<CancellationToken>()).Returns(root);
+        return (conv, root);
+    }
+
+    [Fact]
+    public async Task Execute_RootMissing_Throws()
+    {
+        _messages.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Message?)null);
+
+        var act = () => Build().ExecuteAsync(Guid.NewGuid(), Author, null, null, CursorDirection.Older, default);
+
+        await act.Should().ThrowAsync<ChatThreadRootNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Execute_NonParticipant_ThrowsAccessDenied()
+    {
+        var (_, root) = SeedRoot();
+
+        var act = () => Build().ExecuteAsync(root.Id, Stranger, null, null, CursorDirection.Older, default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task Execute_ReturnsMessages_AndEncodesCursorWhenMore()
+    {
+        var (_, root) = SeedRoot();
+        var replies = Enumerable.Range(0, 51).Select(i => Message.SendAsThreadReply(
+                id: Guid.NewGuid(),
+                conversationId: root.ConversationId,
+                senderId: Peer,
+                body: $"r{i}",
+                attachments: Array.Empty<Attachment>(),
+                clientMessageId: $"c-{i}",
+                createdAtUtc: Now.AddSeconds(i),
+                threadRootId: root.Id))
+            .ToList();
+        _messages.ListThreadAsync(root.Id, null, 51, CursorDirection.Older, Arg.Any<CancellationToken>())
+            .Returns(replies);
+
+        var page = await Build().ExecuteAsync(root.Id, Author, null, 50, CursorDirection.Older, default);
+
+        page.Items.Should().HaveCount(50);
+        page.NextCursor.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Execute_NoMore_NextCursorIsNull()
+    {
+        var (_, root) = SeedRoot();
+        _messages.ListThreadAsync(root.Id, null, Arg.Any<int>(), CursorDirection.Older, Arg.Any<CancellationToken>())
+            .Returns(new List<Message>());
+
+        var page = await Build().ExecuteAsync(root.Id, Author, null, 50, CursorDirection.Older, default);
+
+        page.NextCursor.Should().BeNull();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/GetUserActiveThreadsQueryTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/GetUserActiveThreadsQueryTests.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using FluentAssertions;
+using NSubstitute;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class GetUserActiveThreadsQueryTests
+{
+    private static readonly Guid User = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture);
+    private const string ConvId = "conv-1";
+
+    private readonly IThreadSubscriptionRepository _subscriptions = Substitute.For<IThreadSubscriptionRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+
+    private GetUserActiveThreadsQuery Build() => new(_subscriptions, _messages);
+
+    private static Message MakeRoot(Guid id, int replyCount = 0)
+    {
+        return Message.Hydrate(
+            id, ConvId, Other, "root", Array.Empty<Attachment>(), $"c-{id}",
+            MessageState.Sent, Now, null, null,
+            threadReplyCount: replyCount);
+    }
+
+    [Fact]
+    public async Task Execute_NoSubscriptions_ReturnsEmptyPage()
+    {
+        _subscriptions.ListUserActiveAsync(User, null, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ThreadSubscription>());
+
+        var page = await Build().ExecuteAsync(User, null, null, default);
+
+        page.Items.Should().BeEmpty();
+        page.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Execute_ProjectsSubscriptions_WithRoots()
+    {
+        var rootA = MakeRoot(Guid.NewGuid(), replyCount: 3);
+        var rootB = MakeRoot(Guid.NewGuid(), replyCount: 7);
+        var subA = ThreadSubscription.Subscribe(rootA.Id, User, ThreadSubscriptionReason.Replied, Now, Now.AddMinutes(10));
+        var subB = ThreadSubscription.Subscribe(rootB.Id, User, ThreadSubscriptionReason.Mentioned, Now, Now.AddMinutes(5));
+
+        _subscriptions.ListUserActiveAsync(User, null, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { subA, subB });
+        _messages.GetManyAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { rootA, rootB });
+
+        var page = await Build().ExecuteAsync(User, null, null, default);
+
+        page.Items.Should().HaveCount(2);
+        page.Items[0].RootMessageId.Should().Be(rootA.Id);
+        page.Items[0].ReplyCount.Should().Be(3);
+        page.Items[0].Reason.Should().Be(ThreadSubscriptionReason.Replied);
+        page.Items[1].Reason.Should().Be(ThreadSubscriptionReason.Mentioned);
+    }
+
+    [Fact]
+    public async Task Execute_FiltersOutDeletedRoots()
+    {
+        var deletedRoot = Message.Hydrate(
+            Guid.NewGuid(), ConvId, Other, "", Array.Empty<Attachment>(), "c-deleted",
+            MessageState.Deleted, Now, null, null,
+            deletedAtUtc: Now, deletedBy: Other, deleteMode: DeleteMode.ForEveryone);
+        var sub = ThreadSubscription.Subscribe(deletedRoot.Id, User, ThreadSubscriptionReason.Replied, Now, Now);
+
+        _subscriptions.ListUserActiveAsync(User, null, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { sub });
+        _messages.GetManyAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { deletedRoot });
+
+        var page = await Build().ExecuteAsync(User, null, null, default);
+
+        page.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Execute_EncodesNextCursor_WhenMore()
+    {
+        var roots = new List<Message>();
+        var subs = new List<ThreadSubscription>();
+        for (int i = 0; i < 31; i++)
+        {
+            var root = MakeRoot(Guid.NewGuid(), replyCount: 1);
+            roots.Add(root);
+            subs.Add(ThreadSubscription.Subscribe(
+                root.Id, User, ThreadSubscriptionReason.Replied, Now, Now.AddSeconds(i)));
+        }
+
+        _subscriptions.ListUserActiveAsync(User, null, 31, Arg.Any<CancellationToken>())
+            .Returns(subs);
+        _messages.GetManyAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(roots);
+
+        var page = await Build().ExecuteAsync(User, null, 30, default);
+
+        page.Items.Should().HaveCount(30);
+        page.NextCursor.Should().NotBeNull();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/JoinLeaveThreadServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/JoinLeaveThreadServiceTests.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using FluentAssertions;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class JoinLeaveThreadServiceTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IThreadSubscriptionRepository _subscriptions = Substitute.For<IThreadSubscriptionRepository>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    private ChatEventDispatcher Dispatcher() => new(
+        _outbox,
+        new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+
+    private JoinThreadService BuildJoin() =>
+        new(_conversations, _messages, _subscriptions, Dispatcher(), _broadcaster, _clock);
+
+    private LeaveThreadService BuildLeave() => new(_subscriptions, Dispatcher(), _clock);
+
+    private (Conversation conv, Message root) SeedRoot()
+    {
+        var conv = Conversation.OpenDirect(Author, Peer, _clock.GetUtcNow());
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+        var root = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: conv.Id,
+            senderId: Author,
+            body: "root",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c-root",
+            createdAtUtc: _clock.GetUtcNow());
+        _messages.GetByIdAsync(root.Id, Arg.Any<CancellationToken>()).Returns(root);
+        return (conv, root);
+    }
+
+    // ---- Join ----
+
+    [Fact]
+    public async Task Join_RootMissing_Throws()
+    {
+        _messages.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Message?)null);
+
+        var act = () => BuildJoin().JoinAsync(new JoinThreadRequest(Peer, Guid.NewGuid()), default);
+
+        await act.Should().ThrowAsync<ChatThreadRootNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Join_NonParticipant_ThrowsAccessDenied()
+    {
+        var (_, root) = SeedRoot();
+
+        var act = () => BuildJoin().JoinAsync(new JoinThreadRequest(Stranger, root.Id), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task Join_NewSubscription_PublishesEventAndBroadcasts()
+    {
+        var (_, root) = SeedRoot();
+        _subscriptions.UpsertAsync(Arg.Any<ThreadSubscription>(), Arg.Any<CancellationToken>())
+            .Returns(new ThreadSubscriptionUpsertResult(WasCreated: true, ReasonEscalated: false));
+        _subscriptions.GetSubscriberIdsAsync(root.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Guid>>(new List<Guid> { Peer }));
+
+        await BuildJoin().JoinAsync(new JoinThreadRequest(Peer, root.Id), default);
+
+        var changed = _outbox.Captured.OfType<ChatThreadSubscriptionChangedEvent>().Should().ContainSingle().Subject;
+        changed.UserId.Should().Be(Peer);
+        changed.Subscribed.Should().BeTrue();
+        changed.Reason.Should().Be(ThreadSubscriptionReason.Manual);
+
+        await _broadcaster.Received().NotifyThreadParticipantJoinedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), root.Id, Peer, ThreadSubscriptionReason.Manual, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Join_AlreadyAtSameOrHigherReason_DoesNotPublish()
+    {
+        var (_, root) = SeedRoot();
+        _subscriptions.UpsertAsync(Arg.Any<ThreadSubscription>(), Arg.Any<CancellationToken>())
+            .Returns(new ThreadSubscriptionUpsertResult(WasCreated: false, ReasonEscalated: false));
+
+        await BuildJoin().JoinAsync(new JoinThreadRequest(Peer, root.Id), default);
+
+        _outbox.Captured.OfType<ChatThreadSubscriptionChangedEvent>().Should().BeEmpty();
+        await _broadcaster.DidNotReceive().NotifyThreadParticipantJoinedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<ThreadSubscriptionReason>(), Arg.Any<CancellationToken>());
+    }
+
+    // ---- Leave ----
+
+    [Fact]
+    public async Task Leave_NoExistingSubscription_NoOp()
+    {
+        _subscriptions.RemoveAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        await BuildLeave().LeaveAsync(new LeaveThreadRequest(Peer, Guid.NewGuid()), default);
+
+        _outbox.Captured.OfType<ChatThreadSubscriptionChangedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Leave_RemovesAndPublishesUnsubscribedEvent()
+    {
+        var rootId = Guid.NewGuid();
+        _subscriptions.RemoveAsync(rootId, Peer, Arg.Any<CancellationToken>()).Returns(true);
+
+        await BuildLeave().LeaveAsync(new LeaveThreadRequest(Peer, rootId), default);
+
+        var changed = _outbox.Captured.OfType<ChatThreadSubscriptionChangedEvent>().Should().ContainSingle().Subject;
+        changed.RootMessageId.Should().Be(rootId);
+        changed.UserId.Should().Be(Peer);
+        changed.Subscribed.Should().BeFalse();
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/ReplyInThreadServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ReplyInThreadServiceTests.cs
@@ -1,0 +1,275 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Idempotency;
+using Urfu.Link.BuildingBlocks.Outbox;
+using Urfu.Link.Services.Chat.Application;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Application.Threads;
+using Urfu.Link.Services.Chat.Domain;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure;
+using Urfu.Link.Services.Chat.Realtime;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class ReplyInThreadServiceTests
+{
+    private static readonly Guid Author = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+    private readonly IThreadSubscriptionRepository _subscriptions = Substitute.For<IThreadSubscriptionRepository>();
+    private readonly IMediaServiceClient _media = Substitute.For<IMediaServiceClient>();
+    private readonly IIdempotencyStore _idempotency = Substitute.For<IIdempotencyStore>();
+    private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly RecordingOutboxWriter _outbox = new();
+    private readonly FakeTimeProvider _clock = new(DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture));
+
+    public ReplyInThreadServiceTests()
+    {
+        _idempotency.TryRegisterAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _subscriptions.UpsertAsync(Arg.Any<ThreadSubscription>(), Arg.Any<CancellationToken>())
+            .Returns(new ThreadSubscriptionUpsertResult(WasCreated: true, ReasonEscalated: false));
+        _subscriptions.GetSubscriberIdsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult<IReadOnlyList<Guid>>(new List<Guid> { Author }));
+        _messages.IncrementThreadDenormAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+    }
+
+    private ReplyInThreadService Build()
+    {
+        var dispatcher = new ChatEventDispatcher(
+            _outbox,
+            new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
+        var options = Options.Create(new ChatOptions { MaxMentionsPerMessage = 50 });
+        return new ReplyInThreadService(
+            _conversations, _messages, _subscriptions, _media, _idempotency,
+            dispatcher, _broadcaster, _clock, options);
+    }
+
+    private (Conversation conv, Message root) SeedRoot(DateTimeOffset rootCreatedAt)
+    {
+        var conv = Conversation.OpenDirect(Author, Peer, rootCreatedAt);
+        _conversations.GetByIdAsync(conv.Id, Arg.Any<CancellationToken>()).Returns(conv);
+
+        var root = Message.Send(
+            id: Guid.NewGuid(),
+            conversationId: conv.Id,
+            senderId: Author,
+            body: "root",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c-root",
+            createdAtUtc: rootCreatedAt);
+        _messages.GetByIdAsync(root.Id, Arg.Any<CancellationToken>()).Returns(root);
+        return (conv, root);
+    }
+
+    private static ReplyInThreadRequest NewRequest(Guid sender, Guid rootId, string body = "hello", string clientId = "c-1")
+        => new(sender, rootId, body, Array.Empty<Guid>(), ReplyToMessageId: null, ClientMessageId: clientId);
+
+    [Fact]
+    public async Task ReplyAsync_RootMissing_ThrowsThreadRootNotFound()
+    {
+        _messages.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Message?)null);
+
+        var act = () => Build().ReplyAsync(NewRequest(Author, Guid.NewGuid()), default);
+
+        await act.Should().ThrowAsync<ChatThreadRootNotFoundException>();
+    }
+
+    [Fact]
+    public async Task ReplyAsync_RootIsThreadReply_ThrowsCannotReplyToReply()
+    {
+        var (conv, _) = SeedRoot(_clock.GetUtcNow());
+        var existingRoot = Message.Send(Guid.NewGuid(), conv.Id, Peer, "r", Array.Empty<Attachment>(), "c-x", _clock.GetUtcNow());
+        var nestedRoot = Message.SendAsThreadReply(
+            id: Guid.NewGuid(),
+            conversationId: conv.Id,
+            senderId: Peer,
+            body: "reply",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c-y",
+            createdAtUtc: _clock.GetUtcNow(),
+            threadRootId: existingRoot.Id);
+        _messages.GetByIdAsync(nestedRoot.Id, Arg.Any<CancellationToken>()).Returns(nestedRoot);
+
+        var act = () => Build().ReplyAsync(NewRequest(Author, nestedRoot.Id), default);
+
+        await act.Should().ThrowAsync<ChatThreadCannotReplyToReplyException>();
+    }
+
+    [Fact]
+    public async Task ReplyAsync_NonParticipant_ThrowsAccessDenied()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        var act = () => Build().ReplyAsync(NewRequest(Stranger, root.Id), default);
+
+        await act.Should().ThrowAsync<ChatAccessDeniedException>();
+    }
+
+    [Fact]
+    public async Task ReplyAsync_HappyPath_InsertsReplyWithThreadRootId()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        await _messages.Received().InsertAsync(
+            Arg.Is<Message>(m => m.ThreadRootId == root.Id && m.IsThreadReply),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_HappyPath_IncrementsRootDenorm()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        await _messages.Received().IncrementThreadDenormAsync(
+            root.Id, Author, _clock.GetUtcNow(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_HappyPath_AutoSubscribesReplierAsReplied()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        await _subscriptions.Received().UpsertAsync(
+            Arg.Is<ThreadSubscription>(s =>
+                s.RootMessageId == root.Id
+                && s.UserId == Author
+                && s.Reason == ThreadSubscriptionReason.Replied),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_WithMentions_AutoSubscribesMentioned()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+        var body = $"hi @{Peer:D}";
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id, body), default);
+
+        await _subscriptions.Received().UpsertAsync(
+            Arg.Is<ThreadSubscription>(s =>
+                s.UserId == Peer
+                && s.Reason == ThreadSubscriptionReason.Mentioned),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_HappyPath_PublishesThreadReplyPostedEvent()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        var posted = _outbox.Captured.OfType<ChatThreadReplyPostedEvent>().Should().ContainSingle().Subject;
+        posted.RootMessageId.Should().Be(root.Id);
+        posted.SenderId.Should().Be(Author);
+        posted.Subscribers.Should().Contain(Author);
+    }
+
+    [Fact]
+    public async Task ReplyAsync_WithMentions_PublishesMentionEventWithThreadRootId()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+        var body = $"hi @{Peer:D}";
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id, body), default);
+
+        var mention = _outbox.Captured.OfType<ChatMentionCreatedEvent>().Should().ContainSingle().Subject;
+        mention.ThreadRootId.Should().Be(root.Id);
+        mention.MentionedUserIds.Should().Contain(Peer);
+    }
+
+    [Fact]
+    public async Task ReplyAsync_NewSubscriber_PublishesSubscriptionChangedEvent()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        var changed = _outbox.Captured.OfType<ChatThreadSubscriptionChangedEvent>().Should().ContainSingle().Subject;
+        changed.UserId.Should().Be(Author);
+        changed.Subscribed.Should().BeTrue();
+        changed.Reason.Should().Be(ThreadSubscriptionReason.Replied);
+    }
+
+    [Fact]
+    public async Task ReplyAsync_BroadcastsThreadReplyReceived_AndThreadRootUpdated()
+    {
+        var (conv, root) = SeedRoot(_clock.GetUtcNow());
+
+        await Build().ReplyAsync(NewRequest(Author, root.Id), default);
+
+        await _broadcaster.Received().NotifyThreadReplyReceivedAsync(
+            Arg.Any<IReadOnlyList<Guid>>(),
+            root.Id,
+            Arg.Any<MessageDto>(),
+            Arg.Any<CancellationToken>());
+        await _broadcaster.Received().NotifyThreadRootUpdatedAsync(
+            Arg.Is<IReadOnlyList<Guid>>(p => p.SequenceEqual(conv.Participants)),
+            conv.Id,
+            root.Id,
+            1,
+            Arg.Any<IReadOnlyList<Guid>>(),
+            _clock.GetUtcNow(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplyAsync_DuplicateClientMessageId_ReturnsPriorMessage()
+    {
+        var (_, root) = SeedRoot(_clock.GetUtcNow());
+
+        var existing = Message.SendAsThreadReply(
+            id: Guid.NewGuid(),
+            conversationId: root.ConversationId,
+            senderId: Author,
+            body: "first",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "c-1",
+            createdAtUtc: _clock.GetUtcNow().AddSeconds(-1),
+            threadRootId: root.Id);
+
+        _idempotency.TryRegisterAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _messages.FindByClientMessageIdAsync(Author, "c-1", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var dto = await Build().ReplyAsync(NewRequest(Author, root.Id, body: "second", clientId: "c-1"), default);
+
+        dto.Id.Should().Be(existing.Id);
+        await _messages.DidNotReceive().InsertAsync(Arg.Any<Message>(), Arg.Any<CancellationToken>());
+    }
+
+    private sealed class RecordingOutboxWriter : IOutboxWriter
+    {
+        public List<IIntegrationEvent> Captured { get; } = new();
+
+        public ValueTask EnqueueAsync<TEvent>(string topic, IntegrationEnvelope<TEvent> envelope, CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            Captured.Add(envelope.Payload);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class MessageThreadTests
+{
+    private const string ConversationId = "abc";
+    private static readonly Guid Sender = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Replier = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTimeOffset Created = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+
+    private static Message NewRootMessage() => Message.Send(
+        id: Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Sender,
+        body: "root",
+        attachments: Array.Empty<Attachment>(),
+        clientMessageId: "client-root",
+        createdAtUtc: Created);
+
+    private static Message NewReply(Guid rootId, Guid? replyId = null) => Message.SendAsThreadReply(
+        id: replyId ?? Guid.NewGuid(),
+        conversationId: ConversationId,
+        senderId: Replier,
+        body: "reply",
+        attachments: Array.Empty<Attachment>(),
+        clientMessageId: "client-reply",
+        createdAtUtc: Created.AddSeconds(10),
+        threadRootId: rootId);
+
+    [Fact]
+    public void Send_DefaultMessage_HasNoThreadFields()
+    {
+        var message = NewRootMessage();
+
+        message.ThreadRootId.Should().BeNull();
+        message.ThreadReplyCount.Should().Be(0);
+        message.ThreadParticipants.Should().BeEmpty();
+        message.ThreadLastReplyAtUtc.Should().BeNull();
+        message.IsThreadReply.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SendAsThreadReply_CreatesReply_WithThreadRootIdSet()
+    {
+        var root = NewRootMessage();
+
+        var reply = NewReply(root.Id);
+
+        reply.ThreadRootId.Should().Be(root.Id);
+        reply.IsThreadReply.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SendAsThreadReply_RejectsEmptyRootMessageId()
+    {
+        var act = () => Message.SendAsThreadReply(
+            id: Guid.NewGuid(),
+            conversationId: ConversationId,
+            senderId: Replier,
+            body: "reply",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "client-reply",
+            createdAtUtc: Created.AddSeconds(10),
+            threadRootId: Guid.Empty);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*threadRootId*");
+    }
+
+    [Fact]
+    public void SendAsThreadReply_RejectsSelfReference()
+    {
+        var sameId = Guid.NewGuid();
+
+        var act = () => Message.SendAsThreadReply(
+            id: sameId,
+            conversationId: ConversationId,
+            senderId: Replier,
+            body: "reply",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "client-reply",
+            createdAtUtc: Created.AddSeconds(10),
+            threadRootId: sameId);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*self*");
+    }
+
+    [Fact]
+    public void SendAsThreadReply_NewReply_HasNoOwnThreadDenorms()
+    {
+        var root = NewRootMessage();
+
+        var reply = NewReply(root.Id);
+
+        reply.ThreadReplyCount.Should().Be(0);
+        reply.ThreadParticipants.Should().BeEmpty();
+        reply.ThreadLastReplyAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void SendAsThreadReply_StartsInSentState()
+    {
+        var root = NewRootMessage();
+
+        var reply = NewReply(root.Id);
+
+        reply.State.Should().Be(MessageState.Sent);
+        reply.DeliveredAtUtc.Should().BeNull();
+        reply.ReadAtUtc.Should().BeNull();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
@@ -111,4 +111,74 @@ public class MessageThreadTests
         reply.DeliveredAtUtc.Should().BeNull();
         reply.ReadAtUtc.Should().BeNull();
     }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnRoot_IncrementsReplyCount()
+    {
+        var root = NewRootMessage();
+        var replyAt = Created.AddSeconds(10);
+
+        root.IncrementThreadDenorm(Replier, replyAt);
+
+        root.ThreadReplyCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnRoot_AddsParticipantOnFirstReplyFromUser()
+    {
+        var root = NewRootMessage();
+        var replyAt = Created.AddSeconds(10);
+
+        root.IncrementThreadDenorm(Replier, replyAt);
+
+        root.ThreadParticipants.Should().ContainSingle().Which.Should().Be(Replier);
+    }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnRoot_DoesNotDuplicateParticipantOnRepeatReply()
+    {
+        var root = NewRootMessage();
+
+        root.IncrementThreadDenorm(Replier, Created.AddSeconds(10));
+        root.IncrementThreadDenorm(Replier, Created.AddSeconds(20));
+
+        root.ThreadParticipants.Should().ContainSingle().Which.Should().Be(Replier);
+        root.ThreadReplyCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnRoot_AccumulatesDistinctParticipants()
+    {
+        var root = NewRootMessage();
+        var otherReplier = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+        root.IncrementThreadDenorm(Replier, Created.AddSeconds(10));
+        root.IncrementThreadDenorm(otherReplier, Created.AddSeconds(20));
+
+        root.ThreadParticipants.Should().BeEquivalentTo(new[] { Replier, otherReplier });
+    }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnRoot_UpdatesLastReplyAt()
+    {
+        var root = NewRootMessage();
+        var firstReply = Created.AddSeconds(10);
+        var secondReply = Created.AddSeconds(20);
+
+        root.IncrementThreadDenorm(Replier, firstReply);
+        root.IncrementThreadDenorm(Replier, secondReply);
+
+        root.ThreadLastReplyAtUtc.Should().Be(secondReply);
+    }
+
+    [Fact]
+    public void IncrementThreadDenorm_OnReply_Throws()
+    {
+        var root = NewRootMessage();
+        var reply = NewReply(root.Id);
+
+        var act = () => reply.IncrementThreadDenorm(Replier, Created.AddSeconds(10));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*root*");
+    }
 }

--- a/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageThreadTests.cs
@@ -181,4 +181,74 @@ public class MessageThreadTests
 
         act.Should().Throw<InvalidOperationException>().WithMessage("*root*");
     }
+
+    [Fact]
+    public void Hydrate_WithoutThreadArgs_PreservesMainFlowDefaults()
+    {
+        var hydrated = Message.Hydrate(
+            id: Guid.NewGuid(),
+            conversationId: ConversationId,
+            senderId: Sender,
+            body: "hello",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "client-1",
+            state: MessageState.Sent,
+            createdAtUtc: Created,
+            deliveredAtUtc: null,
+            readAtUtc: null);
+
+        hydrated.ThreadRootId.Should().BeNull();
+        hydrated.IsThreadReply.Should().BeFalse();
+        hydrated.ThreadReplyCount.Should().Be(0);
+        hydrated.ThreadParticipants.Should().BeEmpty();
+        hydrated.ThreadLastReplyAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void Hydrate_WithThreadRootId_RestoresAsReply()
+    {
+        var rootId = Guid.NewGuid();
+
+        var hydrated = Message.Hydrate(
+            id: Guid.NewGuid(),
+            conversationId: ConversationId,
+            senderId: Replier,
+            body: "reply",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "client-reply",
+            state: MessageState.Sent,
+            createdAtUtc: Created.AddSeconds(10),
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            threadRootId: rootId);
+
+        hydrated.ThreadRootId.Should().Be(rootId);
+        hydrated.IsThreadReply.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Hydrate_WithThreadDenorms_RestoresCountParticipantsLastReplyAt()
+    {
+        var participants = new[] { Replier, Guid.Parse("33333333-3333-3333-3333-333333333333") };
+        var lastReply = Created.AddSeconds(120);
+
+        var hydrated = Message.Hydrate(
+            id: Guid.NewGuid(),
+            conversationId: ConversationId,
+            senderId: Sender,
+            body: "root",
+            attachments: Array.Empty<Attachment>(),
+            clientMessageId: "client-root",
+            state: MessageState.Sent,
+            createdAtUtc: Created,
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            threadReplyCount: 2,
+            threadParticipants: participants,
+            threadLastReplyAtUtc: lastReply);
+
+        hydrated.ThreadReplyCount.Should().Be(2);
+        hydrated.ThreadParticipants.Should().BeEquivalentTo(participants);
+        hydrated.ThreadLastReplyAtUtc.Should().Be(lastReply);
+    }
 }

--- a/tests/unit/ChatService.UnitTests/Domain/ThreadSubscriptionTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/ThreadSubscriptionTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Domain;
+
+public class ThreadSubscriptionTests
+{
+    private static readonly Guid Root = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid User = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly DateTimeOffset SubscribedAt = new(2026, 04, 25, 12, 00, 00, TimeSpan.Zero);
+
+    [Fact]
+    public void Subscribe_StoresRootUserAndReason()
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Manual, SubscribedAt);
+
+        sub.RootMessageId.Should().Be(Root);
+        sub.UserId.Should().Be(User);
+        sub.Reason.Should().Be(ThreadSubscriptionReason.Manual);
+        sub.SubscribedAtUtc.Should().Be(SubscribedAt);
+    }
+
+    [Fact]
+    public void Subscribe_DefaultsLastActivityToSubscribedAt_WhenNotProvided()
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Manual, SubscribedAt);
+
+        sub.LastActivityAtUtc.Should().Be(SubscribedAt);
+    }
+
+    [Fact]
+    public void Subscribe_UsesProvidedLastActivity_WhenGiven()
+    {
+        var lastActivity = SubscribedAt.AddMinutes(-5);
+
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Manual, SubscribedAt, lastActivity);
+
+        sub.LastActivityAtUtc.Should().Be(lastActivity);
+    }
+
+    [Fact]
+    public void Subscribe_RejectsEmptyRootMessageId()
+    {
+        var act = () => ThreadSubscription.Subscribe(Guid.Empty, User, ThreadSubscriptionReason.Manual, SubscribedAt);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*rootMessageId*");
+    }
+
+    [Fact]
+    public void Subscribe_RejectsEmptyUserId()
+    {
+        var act = () => ThreadSubscription.Subscribe(Root, Guid.Empty, ThreadSubscriptionReason.Manual, SubscribedAt);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*userId*");
+    }
+
+    [Theory]
+    [InlineData(ThreadSubscriptionReason.Manual, ThreadSubscriptionReason.Mentioned, true)]
+    [InlineData(ThreadSubscriptionReason.Manual, ThreadSubscriptionReason.Replied, true)]
+    [InlineData(ThreadSubscriptionReason.Mentioned, ThreadSubscriptionReason.Replied, true)]
+    public void EscalateReason_ToHigherPriority_SucceedsAndUpdates(
+        ThreadSubscriptionReason initial, ThreadSubscriptionReason next, bool expectedChanged)
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, initial, SubscribedAt);
+
+        var changed = sub.EscalateReason(next);
+
+        changed.Should().Be(expectedChanged);
+        sub.Reason.Should().Be(next);
+    }
+
+    [Theory]
+    [InlineData(ThreadSubscriptionReason.Replied, ThreadSubscriptionReason.Mentioned)]
+    [InlineData(ThreadSubscriptionReason.Replied, ThreadSubscriptionReason.Manual)]
+    [InlineData(ThreadSubscriptionReason.Mentioned, ThreadSubscriptionReason.Manual)]
+    public void EscalateReason_ToLowerOrEqualPriority_DoesNotDowngrade(
+        ThreadSubscriptionReason initial, ThreadSubscriptionReason attempt)
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, initial, SubscribedAt);
+
+        var changed = sub.EscalateReason(attempt);
+
+        changed.Should().BeFalse();
+        sub.Reason.Should().Be(initial);
+    }
+
+    [Fact]
+    public void EscalateReason_SameLevel_NoChange()
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Mentioned, SubscribedAt);
+
+        var changed = sub.EscalateReason(ThreadSubscriptionReason.Mentioned);
+
+        changed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TouchActivity_WithNewerTimestamp_Updates()
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Manual, SubscribedAt);
+        var newer = SubscribedAt.AddMinutes(5);
+
+        sub.TouchActivity(newer);
+
+        sub.LastActivityAtUtc.Should().Be(newer);
+    }
+
+    [Fact]
+    public void TouchActivity_WithOlderTimestamp_KeepsExisting()
+    {
+        var sub = ThreadSubscription.Subscribe(Root, User, ThreadSubscriptionReason.Manual, SubscribedAt);
+        var older = SubscribedAt.AddMinutes(-5);
+
+        sub.TouchActivity(older);
+
+        sub.LastActivityAtUtc.Should().Be(SubscribedAt);
+    }
+
+    [Fact]
+    public void Hydrate_RestoresAllFields()
+    {
+        var lastActivity = SubscribedAt.AddMinutes(30);
+
+        var sub = ThreadSubscription.Hydrate(Root, User, ThreadSubscriptionReason.Replied, SubscribedAt, lastActivity);
+
+        sub.RootMessageId.Should().Be(Root);
+        sub.UserId.Should().Be(User);
+        sub.Reason.Should().Be(ThreadSubscriptionReason.Replied);
+        sub.SubscribedAtUtc.Should().Be(SubscribedAt);
+        sub.LastActivityAtUtc.Should().Be(lastActivity);
+    }
+}


### PR DESCRIPTION
Closes #212

## Что сделано

Реализованы треды (ветвления обсуждений от конкретного сообщения) для direct и group чатов.

### Domain
- `Message`: новые поля `ThreadRootId`, `ThreadReplyCount`, `ThreadParticipants`, `ThreadLastReplyAtUtc`; фабрика `SendAsThreadReply` с инвариантом «нельзя ответить на самого себя»; root-only `IncrementThreadDenorm`.
- `ThreadSubscription` aggregate с приоритетной эскалацией Reason (`Manual < Mentioned < Replied`) — никогда не downgrade.
- 2 новых integration event'а (`chat.thread.reply_posted.v1`, `chat.thread.subscription_changed.v1`); `ChatMentionCreatedEvent` теперь несёт optional `ThreadRootId`.

### Infrastructure
- `ThreadSubscriptionRepository` с atomic pipeline upsert (`$max` на reason для escalation-without-downgrade) поверх unique-индекса `(rootMessageId, userId)`.
- `MessageRepository.IncrementThreadDenormAsync` — единая Mongo операция `$add` + `$setUnion` + `$set`.
- `MessageRepository.ListThreadAsync` — keyset pagination на `(threadRootId, createdAtUtc)`.
- Main-flow filter: `ListByConversationAsync` и `MarkReadUpToAsync` теперь исключают thread replies через `threadRootId: null`. Mongo treats missing == null — backward compat без backfill.
- 3 новых индекса (sparse `(threadRootId, createdAtUtc)`, unique `(rootMessageId, userId)`, `(userId, lastActivityAtUtc desc)`).

### Application
- `ReplyInThreadService` — посылает reply, инкрементит denorm на root, auto-subscribe replier (Replied) и mentions (Mentioned), bulk touch-activity на subscribers, публикует события через outbox, broadcast'ит `ThreadReplyReceived` (subscribers) и `ThreadRootUpdated` (все участники chat).
- `JoinThreadService` / `LeaveThreadService` — manual subscription.
- `GetThreadMessagesQuery` + `GetUserActiveThreadsQuery` (cursor-paginated, отсортированы по `LastActivityAtUtc desc`).

### Realtime
- 4 новых hub метода: `ReplyInThread`, `JoinThread`, `LeaveThread`, `GetThreadMessages`.
- 3 новых broadcast метода: `ThreadReplyReceived`, `ThreadRootUpdated`, `ThreadParticipantJoined`.
- **Без SignalR groups** — subscribers в Mongo единственный source of truth, адресация через `Clients.Users(...)` (`IUserIdProvider`). Reconnect и multi-device работают сами по себе.

### REST (`/api/v1/chat/`)
- `POST messages/{id}/thread` — reply
- `GET messages/{id}/thread` — список replies
- `POST/DELETE messages/{id}/thread/subscribe` — manual subscribe/unsubscribe
- `GET threads/active` — активные треды юзера

## Как проверить

Минимальный сценарий:
- [ ] `dotnet test tests/unit/ChatService.UnitTests/` → 180/180 ✅
- [ ] `dotnet test tests/integration/ChatService.IntegrationTests/` → 139/139 ✅
- [ ] Smoke в SignalR-клиенте: A пишет root → B вызывает `ReplyInThread` → A получает `ThreadRootUpdated` (count=1), B получает `ThreadReplyReceived`.
- [ ] Multi-client проверка с group conversation (3+ участника): C, не subscribed, не получает `ThreadReplyReceived`; после `JoinThread` начинает получать.
- [ ] `GET /chat/threads/active` возвращает треды юзера в порядке последней активности.
- [ ] Главный поток (`GET conversations/{id}/messages`) не содержит thread replies.

## Не в скоупе (отдельные issue)
- NotificationService handler для `chat.thread.reply_posted.v1` — текущий KafkaConsumerWorker в NotificationService пока без chat-handler'ов вообще; будет отдельной задачей вместе с `chat.message.sent.v1` / `chat.mention.created.v1`.
- Edit-time auto-subscribe newly mentioned users — намеренно упрощено: subscriptions меняются только при создании reply.