### PR TITLE
feat(#213): ChatService — search по истории сообщений (MongoDB text index)

### DIFF
--- a/src/BuildingBlocks/Idempotency/RateLimitEndpointFilter.cs
+++ b/src/BuildingBlocks/Idempotency/RateLimitEndpointFilter.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+
+namespace Urfu.Link.BuildingBlocks.Idempotency;
+
+/// <summary>
+/// FastEndpoints / minimal-API filter that consults an <see cref="IRateLimiter"/> before the
+/// endpoint runs. On rejection it sets <c>Retry-After</c> and returns 429 directly, skipping
+/// the handler. Concrete services derive a one-class-per-policy subclass that supplies the
+/// key (e.g. authenticated user id) and the limiter resolved from keyed DI.
+/// </summary>
+public abstract class RateLimitEndpointFilter(IRateLimiter rateLimiter) : IEndpointFilter
+{
+    /// <summary>
+    /// Returns the rate-limit bucket key for the current request, or <see langword="null"/> /
+    /// empty to bypass rate limiting (e.g. for unauthenticated callers when the policy is per
+    /// user).
+    /// </summary>
+    protected abstract string? BuildKey(HttpContext context);
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var key = BuildKey(context.HttpContext);
+        if (string.IsNullOrEmpty(key))
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        var decision = await rateLimiter
+            .TryAcquireAsync(key, context.HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+        if (decision.Allowed)
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        var retryAfter = (int)Math.Ceiling((decision.RetryAfter ?? TimeSpan.FromMinutes(1)).TotalSeconds);
+        context.HttpContext.Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
+        return Results.StatusCode(StatusCodes.Status429TooManyRequests);
+    }
+}

--- a/src/BuildingBlocks/Idempotency/RateLimiter.cs
+++ b/src/BuildingBlocks/Idempotency/RateLimiter.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+
+namespace Urfu.Link.BuildingBlocks.Idempotency;
+
+/// <summary>
+/// Per-key fixed-window rate limiter. Each successful <see cref="TryAcquireAsync"/> consumes
+/// one token; once <see cref="RateLimiterOptions.MaxRequests"/> is exceeded inside the window,
+/// further calls return <see cref="RateLimitDecision.Allowed"/> = false until the window
+/// elapses.
+/// </summary>
+public interface IRateLimiter
+{
+    ValueTask<RateLimitDecision> TryAcquireAsync(string key, CancellationToken cancellationToken = default);
+}
+
+public sealed record RateLimitDecision(bool Allowed, TimeSpan? RetryAfter);
+
+public sealed class RateLimiterOptions
+{
+    public string Name { get; set; } = string.Empty;
+
+    public TimeSpan Window { get; set; }
+
+    public int MaxRequests { get; set; }
+
+    public string KeyPrefix { get; set; } = "urfu:rate-limit";
+}
+
+/// <summary>
+/// Redis-backed fixed-window limiter. The Lua script is atomic — INCR is paired with PEXPIRE
+/// only on the first request of a window, so process death between ops cannot leave a key
+/// without a TTL.
+/// </summary>
+public sealed class RedisFixedWindowRateLimiter(
+    IConnectionMultiplexer multiplexer,
+    RateLimiterOptions options) : IRateLimiter
+{
+    private const string IncrementWithExpireScript =
+        "local count = redis.call('INCR', KEYS[1]) " +
+        "if count == 1 then redis.call('PEXPIRE', KEYS[1], ARGV[1]) end " +
+        "return count";
+
+    public async ValueTask<RateLimitDecision> TryAcquireAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var database = multiplexer.GetDatabase();
+        var redisKey = (RedisKey)$"{options.KeyPrefix}:{options.Name}:{key}";
+        var ttlMs = (long)options.Window.TotalMilliseconds;
+
+        var raw = await database.ScriptEvaluateAsync(
+            IncrementWithExpireScript,
+            new[] { redisKey },
+            new RedisValue[] { ttlMs }).WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        var count = (long)raw;
+
+        if (count <= options.MaxRequests)
+        {
+            return new RateLimitDecision(Allowed: true, RetryAfter: null);
+        }
+
+        var pttl = await database.KeyTimeToLiveAsync(redisKey).WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new RateLimitDecision(Allowed: false, RetryAfter: pttl ?? options.Window);
+    }
+}
+
+public static class RateLimiterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a Redis-backed fixed-window rate limiter as a keyed singleton. Resolve with
+    /// <c>[FromKeyedServices(name)] IRateLimiter</c>. Multiple policies coexist; each gets its
+    /// own Redis namespace via <see cref="RateLimiterOptions.Name"/>.
+    /// </summary>
+    public static IServiceCollection AddRedisRateLimiter(
+        this IServiceCollection services,
+        string name,
+        TimeSpan window,
+        int maxRequests,
+        string keyPrefix = "urfu:rate-limit")
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (window <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(window), "Window must be positive.");
+        }
+        if (maxRequests <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxRequests), "MaxRequests must be positive.");
+        }
+
+        services.AddKeyedSingleton<IRateLimiter>(name, (sp, _) =>
+        {
+            var multiplexer = sp.GetRequiredService<IConnectionMultiplexer>();
+            return new RedisFixedWindowRateLimiter(multiplexer, new RateLimiterOptions
+            {
+                Name = name,
+                Window = window,
+                MaxRequests = maxRequests,
+                KeyPrefix = keyPrefix,
+            });
+        });
+        return services;
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/MessageSearchResultDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/MessageSearchResultDto.cs
@@ -1,0 +1,25 @@
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Application.Contracts;
+
+/// <summary>
+/// One hit returned by full-text search: a thin projection of the message plus the search-time
+/// relevance score and an optional substring snippet around the matched term.
+/// </summary>
+public sealed record MessageSearchResultDto(
+    Guid MessageId,
+    string ConversationId,
+    ConversationPreviewDto ConversationPreview,
+    Guid SenderId,
+    string Body,
+    double Score,
+    DateTimeOffset CreatedAtUtc,
+    string? HighlightedSnippet);
+
+/// <summary>
+/// Minimum identifying info about the conversation a hit lives in. For direct chats the
+/// caller's counterparty is surfaced as <see cref="PeerUserId"/>; group chats use
+/// <see cref="Title"/> once a title field is added to the aggregate. <see cref="Type"/> lets
+/// the client decide which one to render.
+/// </summary>
+public sealed record ConversationPreviewDto(ConversationType Type, string? Title, Guid? PeerUserId);

--- a/src/Services/Chat/ChatService.Api/Application/Cursors/CursorCodec.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Cursors/CursorCodec.cs
@@ -112,6 +112,38 @@ internal static class CursorCodec
         }
     }
 
+    public static string EncodeMessageSearch(MessageSearchCursor cursor)
+    {
+        var payload = new MessageSearchCursorPayload(
+            cursor.Score,
+            cursor.CreatedAtUtc.ToUnixTimeMilliseconds(),
+            cursor.MessageId);
+        return EncodeBase64Url(JsonSerializer.SerializeToUtf8Bytes(payload, Options));
+    }
+
+    public static MessageSearchCursor? DecodeMessageSearch(string? cursor)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+        {
+            return null;
+        }
+
+        try
+        {
+            var bytes = DecodeBase64Url(cursor);
+            var payload = JsonSerializer.Deserialize<MessageSearchCursorPayload>(bytes, Options)
+                ?? throw new FormatException("Empty cursor payload.");
+            return new MessageSearchCursor(
+                payload.Score,
+                DateTimeOffset.FromUnixTimeMilliseconds(payload.Ts),
+                payload.Id);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            throw new InvalidChatCursorException("Invalid cursor.", nameof(cursor), ex);
+        }
+    }
+
     private static string EncodeBase64Url(byte[] bytes)
         => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
@@ -129,4 +161,5 @@ internal static class CursorCodec
     private sealed record ConversationCursorPayload(long Ts, string Id);
     private sealed record MessageCursorPayload(long Ts, Guid Id);
     private sealed record ThreadActivityCursorPayload(long Ts, Guid Id);
+    private sealed record MessageSearchCursorPayload(double Score, long Ts, Guid Id);
 }

--- a/src/Services/Chat/ChatService.Api/Application/Messages/MessageSnippetBuilder.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/MessageSnippetBuilder.cs
@@ -1,0 +1,65 @@
+using System.Text;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+/// <summary>
+/// Builds a short highlighted snippet around the first occurrence of the search term in a
+/// message body. Best-effort — returns null when the term cannot be located literally (e.g.
+/// the stemmer matched a different morphological form).
+/// </summary>
+internal static class MessageSnippetBuilder
+{
+    private const int ContextChars = 30;
+
+    public static string? Build(string body, string query)
+    {
+        if (string.IsNullOrWhiteSpace(body) || string.IsNullOrWhiteSpace(query))
+        {
+            return null;
+        }
+
+        var firstTerm = ExtractFirstTerm(query);
+        if (firstTerm is null)
+        {
+            return null;
+        }
+
+        var matchIndex = body.IndexOf(firstTerm, StringComparison.OrdinalIgnoreCase);
+        if (matchIndex < 0)
+        {
+            return null;
+        }
+
+        var start = Math.Max(0, matchIndex - ContextChars);
+        var end = Math.Min(body.Length, matchIndex + firstTerm.Length + ContextChars);
+
+        var sb = new StringBuilder();
+        if (start > 0)
+        {
+            sb.Append("...");
+        }
+        sb.Append(body, start, end - start);
+        if (end < body.Length)
+        {
+            sb.Append("...");
+        }
+        return sb.ToString();
+    }
+
+    private static string? ExtractFirstTerm(string query)
+    {
+        var sb = new StringBuilder();
+        foreach (var ch in query)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(ch);
+            }
+            else if (sb.Length > 0)
+            {
+                break;
+            }
+        }
+        return sb.Length > 0 ? sb.ToString() : null;
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/MessageSnippetBuilder.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/MessageSnippetBuilder.cs
@@ -33,6 +33,18 @@ internal static class MessageSnippetBuilder
         var start = Math.Max(0, matchIndex - ContextChars);
         var end = Math.Min(body.Length, matchIndex + firstTerm.Length + ContextChars);
 
+        // Don't split a surrogate pair at either boundary: a low surrogate at start means we'd
+        // orphan its high half (and vice-versa at end-1). Without these adjustments emoji like
+        // "🎉" near the slice edge end up as U+FFFD when re-decoded.
+        if (start > 0 && char.IsLowSurrogate(body[start]))
+        {
+            start++;
+        }
+        if (end < body.Length && end > 0 && char.IsHighSurrogate(body[end - 1]))
+        {
+            end--;
+        }
+
         var sb = new StringBuilder();
         if (start > 0)
         {

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SearchMessagesQuery.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SearchMessagesQuery.cs
@@ -1,0 +1,137 @@
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+
+namespace Urfu.Link.Services.Chat.Application.Messages;
+
+/// <summary>
+/// Endpoint-facing parameters for <see cref="SearchMessagesQuery"/>. Keeps cursor/limit
+/// concerns separate from <see cref="MessageSearchCriteria"/> (which is the repository-level
+/// filter).
+/// </summary>
+public sealed record SearchMessagesParameters(
+    string Query,
+    string? ConversationId,
+    Guid? SenderId,
+    DateTimeOffset? DateFrom,
+    DateTimeOffset? DateTo,
+    bool? HasAttachments,
+    AttachmentType? AttachmentType,
+    string? Cursor,
+    int? Limit);
+
+public sealed class SearchMessagesQuery(
+    IConversationRepository conversations,
+    IMessageRepository messages)
+{
+    private const int DefaultLimit = 20;
+    private const int MaxLimit = 100;
+
+    public async Task<CursorPage<MessageSearchResultDto>> ExecuteAsync(
+        SearchMessagesParameters parameters,
+        Guid callerUserId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var limit = Math.Clamp(parameters.Limit ?? DefaultLimit, 1, MaxLimit);
+
+        // Access control is a single boundary: pull the caller's conversation set, optionally
+        // restrict to the requested conversationId, and silently return empty for anything
+        // outside that scope. Search MUST NOT 403 on outside-conversation queries — that would
+        // leak which conversations exist.
+        var allowedIds = await conversations.GetUserConversationIdsAsync(callerUserId, cancellationToken).ConfigureAwait(false);
+        if (allowedIds.Count == 0)
+        {
+            return new CursorPage<MessageSearchResultDto>(Array.Empty<MessageSearchResultDto>(), null);
+        }
+
+        IReadOnlyList<string> scope = parameters.ConversationId is { Length: > 0 } cid
+            ? (allowedIds.Contains(cid) ? new[] { cid } : Array.Empty<string>())
+            : allowedIds;
+
+        if (scope.Count == 0)
+        {
+            return new CursorPage<MessageSearchResultDto>(Array.Empty<MessageSearchResultDto>(), null);
+        }
+
+        var cursor = CursorCodec.DecodeMessageSearch(parameters.Cursor);
+
+        var criteria = new MessageSearchCriteria(
+            parameters.Query,
+            parameters.SenderId,
+            parameters.DateFrom,
+            parameters.DateTo,
+            parameters.HasAttachments,
+            parameters.AttachmentType);
+
+        // Fetch one extra row so we can decide whether a next page exists without re-issuing the
+        // query — same pattern as ListByConversationAsync.
+        var hits = await messages.SearchAsync(
+            criteria,
+            scope,
+            cursor,
+            limit + 1,
+            cancellationToken).ConfigureAwait(false);
+
+        var hasMore = hits.Count > limit;
+        var pageHits = hasMore ? hits.Take(limit).ToList() : hits.ToList();
+
+        // Single batch lookup for conversation previews — no N+1.
+        List<string> distinctConvIds = pageHits.Select(h => h.Message.ConversationId).Distinct().ToList();
+        var conversationLookup = await BuildPreviewLookupAsync(distinctConvIds, callerUserId, cancellationToken).ConfigureAwait(false);
+
+        var items = pageHits.Select(h => new MessageSearchResultDto(
+            MessageId: h.Message.Id,
+            ConversationId: h.Message.ConversationId,
+            ConversationPreview: conversationLookup.TryGetValue(h.Message.ConversationId, out var preview)
+                ? preview
+                : new ConversationPreviewDto(ConversationType.Direct, null, null),
+            SenderId: h.Message.SenderId,
+            Body: h.Message.Body,
+            Score: h.Score,
+            CreatedAtUtc: h.Message.CreatedAtUtc,
+            HighlightedSnippet: MessageSnippetBuilder.Build(h.Message.Body, parameters.Query))).ToList();
+
+        string? nextCursor = null;
+        if (hasMore)
+        {
+            var last = pageHits[^1];
+            nextCursor = CursorCodec.EncodeMessageSearch(
+                new MessageSearchCursor(last.Score, last.Message.CreatedAtUtc, last.Message.Id));
+        }
+
+        return new CursorPage<MessageSearchResultDto>(items, nextCursor);
+    }
+
+    private async Task<Dictionary<string, ConversationPreviewDto>> BuildPreviewLookupAsync(
+        List<string> conversationIds,
+        Guid callerUserId,
+        CancellationToken cancellationToken)
+    {
+        if (conversationIds.Count == 0)
+        {
+            return new Dictionary<string, ConversationPreviewDto>(StringComparer.Ordinal);
+        }
+
+        var docs = await conversations.GetByIdsAsync(conversationIds, cancellationToken).ConfigureAwait(false);
+        return docs.ToDictionary(c => c.Id, c => BuildPreview(c, callerUserId), StringComparer.Ordinal);
+    }
+
+    private static ConversationPreviewDto BuildPreview(Conversation conversation, Guid callerUserId)
+    {
+        if (conversation.Type == ConversationType.Direct)
+        {
+            // Direct: surface the counterparty so the client can render a name/avatar.
+            var peer = conversation.Participants.FirstOrDefault(p => p != callerUserId);
+            return new ConversationPreviewDto(ConversationType.Direct, null, peer == Guid.Empty ? null : peer);
+        }
+
+        // Group/discipline conversations don't have a Title field on the aggregate yet — null
+        // is the correct value until that work lands. Type alone tells the client this is a
+        // group hit, which is enough to render a placeholder.
+        return new ConversationPreviewDto(conversation.Type, null, null);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IConversationRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IConversationRepository.cs
@@ -43,4 +43,22 @@ public interface IConversationRepository
         string conversationId,
         Guid messageId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the ids of every conversation in which <paramref name="userId"/> is a participant.
+    /// No pagination — the full list is required by callers (e.g. global message search) that
+    /// then use it as an <c>$in</c> filter against the messages collection.
+    /// </summary>
+    Task<IReadOnlyList<string>> GetUserConversationIdsAsync(
+        Guid userId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Bulk-loads conversations by id. Returns only conversations that exist; missing ids are
+    /// silently skipped. Used by search to hydrate <c>conversationPreview</c> per result without
+    /// an N+1.
+    /// </summary>
+    Task<IReadOnlyList<Conversation>> GetByIdsAsync(
+        IReadOnlyList<string> conversationIds,
+        CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/IMessageRepository.cs
@@ -4,6 +4,25 @@ using Urfu.Link.Services.Chat.Domain.ValueObjects;
 
 namespace Urfu.Link.Services.Chat.Domain.Interfaces;
 
+/// <summary>
+/// Filter inputs for full-text message search. The conversation scope (which chats are
+/// visible to the caller) is provided separately to the repository so access control stays a
+/// single concern in the application layer.
+/// </summary>
+public sealed record MessageSearchCriteria(
+    string Query,
+    Guid? SenderId,
+    DateTimeOffset? DateFrom,
+    DateTimeOffset? DateTo,
+    bool? HasAttachments,
+    AttachmentType? AttachmentType);
+
+/// <summary>
+/// A single search result: the message plus its MongoDB <c>$meta:"textScore"</c> relevance
+/// score.
+/// </summary>
+public sealed record MessageSearchHit(Message Message, double Score);
+
 public interface IMessageRepository
 {
     Task<Message?> GetByIdAsync(Guid messageId, CancellationToken cancellationToken);
@@ -139,6 +158,18 @@ public interface IMessageRepository
         MessageCursor? cursor,
         int limit,
         CursorDirection direction,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Full-text search over message bodies, restricted to <paramref name="allowedConversationIds"/>
+    /// and the main flow (thread replies are excluded). Results are ordered by descending
+    /// MongoDB textScore, then descending createdAt and id as deterministic tie-breakers.
+    /// </summary>
+    Task<IReadOnlyList<MessageSearchHit>> SearchAsync(
+        MessageSearchCriteria criteria,
+        IReadOnlyList<string> allowedConversationIds,
+        MessageSearchCursor? cursor,
+        int limit,
         CancellationToken cancellationToken);
 }
 

--- a/src/Services/Chat/ChatService.Api/Domain/Interfaces/Pagination.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Interfaces/Pagination.cs
@@ -11,3 +11,5 @@ public readonly record struct ConversationCursor(DateTimeOffset LastMessageAtUtc
 public readonly record struct MessageCursor(DateTimeOffset CreatedAtUtc, Guid MessageId);
 
 public readonly record struct ThreadActivityCursor(DateTimeOffset LastActivityAtUtc, Guid RootMessageId);
+
+public readonly record struct MessageSearchCursor(double Score, DateTimeOffset CreatedAtUtc, Guid MessageId);

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/ChatSearchRateLimit.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/ChatSearchRateLimit.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Idempotency;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+/// <summary>
+/// DI key under which the <c>/chat/search</c> per-user rate limiter is registered.
+/// </summary>
+public static class ChatSearchRateLimiterPolicy
+{
+    public const string Name = "chat-search";
+}
+
+/// <summary>
+/// Per-authenticated-user rate-limit filter for <see cref="SearchMessagesEndpoint"/>. Resolves
+/// the policy-specific limiter from keyed DI and keys the bucket by the caller's user id.
+/// Unauthenticated requests bypass the filter (the endpoint group already requires auth, this
+/// is a defensive fallback).
+/// </summary>
+public sealed class ChatSearchRateLimitFilter(
+    [FromKeyedServices(ChatSearchRateLimiterPolicy.Name)] IRateLimiter rateLimiter)
+    : RateLimitEndpointFilter(rateLimiter)
+{
+    protected override string? BuildKey(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.User.Identity?.IsAuthenticated == true
+            ? context.User.GetUserId().ToString("N")
+            : null;
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
@@ -1,0 +1,108 @@
+using FastEndpoints;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Idempotency;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Chat.Endpoints.Messages;
+
+/// <summary>
+/// DI key under which the chat-search rate limiter is registered. Endpoints resolve it via
+/// <c>[FromKeyedServices]</c> so multiple policies can coexist.
+/// </summary>
+public static class ChatSearchRateLimiterPolicy
+{
+    public const string Name = "chat-search";
+}
+
+public sealed class SearchMessagesRequest
+{
+    [QueryParam] public string? Q { get; set; }
+
+    [QueryParam] public string? ConversationId { get; set; }
+
+    [QueryParam] public Guid? SenderId { get; set; }
+
+    [QueryParam] public DateTimeOffset? From { get; set; }
+
+    [QueryParam] public DateTimeOffset? To { get; set; }
+
+    [QueryParam] public bool? HasAttachments { get; set; }
+
+    [QueryParam] public AttachmentType? AttachmentType { get; set; }
+
+    [QueryParam] public string? Cursor { get; set; }
+
+    [QueryParam] public int? Limit { get; set; }
+}
+
+public sealed class SearchMessagesValidator : Validator<SearchMessagesRequest>
+{
+    public SearchMessagesValidator()
+    {
+        RuleFor(x => x.Q)
+            .NotEmpty().WithMessage("Query is required.")
+            .MinimumLength(2).WithMessage("Query must be at least 2 characters.");
+        RuleFor(x => x.Limit!.Value)
+            .InclusiveBetween(1, 100).WithMessage("Limit must be between 1 and 100.")
+            .When(x => x.Limit.HasValue);
+    }
+}
+
+public sealed class SearchMessagesEndpoint(
+    SearchMessagesQuery query,
+    [FromKeyedServices(ChatSearchRateLimiterPolicy.Name)] IRateLimiter rateLimiter)
+    : Endpoint<SearchMessagesRequest, CursorPage<MessageSearchResultDto>>
+{
+    public override void Configure()
+    {
+        Get("search");
+        Group<Endpoints.ChatGroup>();
+        Summary(s => s.Summary = "Full-text search across the caller's chat history.");
+    }
+
+    public override async Task HandleAsync(SearchMessagesRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var caller = User.GetUserId();
+
+        var decision = await rateLimiter
+            .TryAcquireAsync($"{caller:N}", ct)
+            .ConfigureAwait(false);
+        if (!decision.Allowed)
+        {
+            var retry = decision.RetryAfter ?? TimeSpan.FromSeconds(60);
+            HttpContext.Response.Headers["Retry-After"] =
+                ((int)Math.Ceiling(retry.TotalSeconds)).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            await Send.ResponseAsync(default!, StatusCodes.Status429TooManyRequests, ct).ConfigureAwait(false);
+            return;
+        }
+
+        try
+        {
+            var page = await query.ExecuteAsync(
+                new SearchMessagesParameters(
+                    req.Q!,
+                    req.ConversationId,
+                    req.SenderId,
+                    req.From,
+                    req.To,
+                    req.HasAttachments,
+                    req.AttachmentType,
+                    req.Cursor,
+                    req.Limit),
+                caller,
+                ct).ConfigureAwait(false);
+            await Send.OkAsync(page, ct).ConfigureAwait(false);
+        }
+        catch (InvalidChatCursorException)
+        {
+            AddError(r => r.Cursor!, "Invalid cursor.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
@@ -1,7 +1,5 @@
 using FastEndpoints;
 using FluentValidation;
-using Microsoft.Extensions.DependencyInjection;
-using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Cursors;
 using Urfu.Link.Services.Chat.Application.Messages;
@@ -9,15 +7,6 @@ using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
 
 namespace Urfu.Link.Services.Chat.Endpoints.Messages;
-
-/// <summary>
-/// DI key under which the chat-search rate limiter is registered. Endpoints resolve it via
-/// <c>[FromKeyedServices]</c> so multiple policies can coexist.
-/// </summary>
-public static class ChatSearchRateLimiterPolicy
-{
-    public const string Name = "chat-search";
-}
 
 public sealed class SearchMessagesRequest
 {
@@ -53,15 +42,14 @@ public sealed class SearchMessagesValidator : Validator<SearchMessagesRequest>
     }
 }
 
-public sealed class SearchMessagesEndpoint(
-    SearchMessagesQuery query,
-    [FromKeyedServices(ChatSearchRateLimiterPolicy.Name)] IRateLimiter rateLimiter)
+public sealed class SearchMessagesEndpoint(SearchMessagesQuery query)
     : Endpoint<SearchMessagesRequest, CursorPage<MessageSearchResultDto>>
 {
     public override void Configure()
     {
         Get("search");
         Group<Endpoints.ChatGroup>();
+        Options(x => x.AddEndpointFilter<ChatSearchRateLimitFilter>());
         Summary(s => s.Summary = "Full-text search across the caller's chat history.");
     }
 
@@ -69,18 +57,6 @@ public sealed class SearchMessagesEndpoint(
     {
         ArgumentNullException.ThrowIfNull(req);
         var caller = User.GetUserId();
-
-        var decision = await rateLimiter
-            .TryAcquireAsync($"{caller:N}", ct)
-            .ConfigureAwait(false);
-        if (!decision.Allowed)
-        {
-            var retry = decision.RetryAfter ?? TimeSpan.FromSeconds(60);
-            HttpContext.Response.Headers["Retry-After"] =
-                ((int)Math.Ceiling(retry.TotalSeconds)).ToString(System.Globalization.CultureInfo.InvariantCulture);
-            await Send.ResponseAsync(default!, StatusCodes.Status429TooManyRequests, ct).ConfigureAwait(false);
-            return;
-        }
 
         try
         {

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/SearchMessagesEndpoint.cs
@@ -39,6 +39,12 @@ public sealed class SearchMessagesValidator : Validator<SearchMessagesRequest>
         RuleFor(x => x.Limit!.Value)
             .InclusiveBetween(1, 100).WithMessage("Limit must be between 1 and 100.")
             .When(x => x.Limit.HasValue);
+        // hasAttachments=false and attachmentType=X are mutually exclusive — silently
+        // returning empty would hide a client bug.
+        RuleFor(x => x.AttachmentType)
+            .Null()
+            .When(x => x.HasAttachments == false)
+            .WithMessage("attachmentType cannot be combined with hasAttachments=false.");
     }
 }
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Conversations;
@@ -16,6 +17,7 @@ using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Application.Threads;
 using Urfu.Link.Services.Chat.Domain;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Endpoints.Messages;
 using Urfu.Link.Services.Chat.Infrastructure.Authorization;
 using Urfu.Link.Services.Chat.Infrastructure.Grpc;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence;
@@ -112,6 +114,14 @@ public static class ModuleRegistration
         services.AddScoped<LeaveThreadService>();
         services.AddScoped<GetThreadMessagesQuery>();
         services.AddScoped<GetUserActiveThreadsQuery>();
+        services.AddScoped<SearchMessagesQuery>();
+
+        // Per-user fixed window for /chat/search. Issue #213 specifies 30 req/min per user;
+        // see ChatSearchRateLimiterPolicy below for the keyed-DI consumer.
+        services.AddRedisRateLimiter(
+            ChatSearchRateLimiterPolicy.Name,
+            window: TimeSpan.FromMinutes(1),
+            maxRequests: 30);
 
         services.AddSingleton<IChatBroadcaster, ChatBroadcaster>();
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -116,8 +116,8 @@ public static class ModuleRegistration
         services.AddScoped<GetUserActiveThreadsQuery>();
         services.AddScoped<SearchMessagesQuery>();
 
-        // Per-user fixed window for /chat/search. Issue #213 specifies 30 req/min per user;
-        // see ChatSearchRateLimiterPolicy below for the keyed-DI consumer.
+        // Per-user fixed window for /chat/search (issue #213 — 30 req/min per user).
+        // ChatSearchRateLimitFilter resolves this limiter via [FromKeyedServices(name)].
         services.AddRedisRateLimiter(
             ChatSearchRateLimiterPolicy.Name,
             window: TimeSpan.FromMinutes(1),

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ConversationRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/ConversationRepository.cs
@@ -137,4 +137,35 @@ internal sealed class ConversationRepository(ChatMongoContext context) : IConver
             .ConfigureAwait(false);
         return result.ModifiedCount > 0;
     }
+
+    public async Task<IReadOnlyList<string>> GetUserConversationIdsAsync(
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<ConversationDocument>.Filter.AnyEq(c => c.Participants, userId);
+        var ids = await context.Conversations
+            .Find(filter)
+            .Project(c => c.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return ids;
+    }
+
+    public async Task<IReadOnlyList<Conversation>> GetByIdsAsync(
+        IReadOnlyList<string> conversationIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(conversationIds);
+        if (conversationIds.Count == 0)
+        {
+            return Array.Empty<Conversation>();
+        }
+
+        var filter = Builders<ConversationDocument>.Filter.In(c => c.Id, conversationIds);
+        var docs = await context.Conversations
+            .Find(filter)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return docs.Select(d => d.ToDomain()).ToList();
+    }
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
@@ -527,5 +528,123 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             .ConfigureAwait(false);
 
         return docs.Select(d => d.ToDomain()).ToList();
+    }
+
+    public async Task<IReadOnlyList<MessageSearchHit>> SearchAsync(
+        MessageSearchCriteria criteria,
+        IReadOnlyList<string> allowedConversationIds,
+        MessageSearchCursor? cursor,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(criteria);
+        ArgumentNullException.ThrowIfNull(allowedConversationIds);
+
+        if (limit <= 0 || allowedConversationIds.Count == 0 || string.IsNullOrWhiteSpace(criteria.Query))
+        {
+            return Array.Empty<MessageSearchHit>();
+        }
+
+        // Mongo requires $text in the pipeline's first $match stage; all non-score filters share
+        // that stage so the text index can drive selection. Score-based cursor matching has to
+        // come after $addFields below, since $meta:textScore is only addressable as a regular
+        // field once it has been projected.
+        var matchStage = new BsonDocument
+        {
+            { "$text", new BsonDocument("$search", criteria.Query) },
+            { "conversationId", new BsonDocument("$in", new BsonArray(allowedConversationIds)) },
+            { "threadRootId", BsonNull.Value },
+        };
+
+        if (criteria.SenderId is { } senderId)
+        {
+            matchStage.Add("senderId", new BsonBinaryData(senderId, GuidRepresentation.Standard));
+        }
+
+        if (criteria.DateFrom is { } from || criteria.DateTo is { } to)
+        {
+            var range = new BsonDocument();
+            if (criteria.DateFrom is { } f)
+            {
+                range.Add("$gte", f.UtcDateTime);
+            }
+            if (criteria.DateTo is { } t)
+            {
+                range.Add("$lte", t.UtcDateTime);
+            }
+            matchStage.Add("createdAtUtc", range);
+        }
+
+        if (criteria.HasAttachments == true)
+        {
+            matchStage.Add("attachments.0", new BsonDocument("$exists", true));
+        }
+        else if (criteria.HasAttachments == false)
+        {
+            matchStage.Add("$or", new BsonArray
+            {
+                new BsonDocument("attachments", new BsonDocument("$exists", false)),
+                new BsonDocument("attachments", new BsonDocument("$size", 0)),
+            });
+        }
+
+        if (criteria.AttachmentType is { } type)
+        {
+            // AttachmentDocument.Type is serialized as a string via BsonRepresentation.String.
+            matchStage.Add("attachments.type", type.ToString());
+        }
+
+        var stages = new List<BsonDocument>
+        {
+            new("$match", matchStage),
+            new("$addFields", new BsonDocument("_score", new BsonDocument("$meta", "textScore"))),
+        };
+
+        if (cursor is { } c)
+        {
+            // Keyset predicate for descending sort on (_score, createdAtUtc, _id): documents come
+            // after the cursor position iff one of the three lexicographic comparisons holds.
+            var cursorTs = c.CreatedAtUtc.UtcDateTime;
+            stages.Add(new("$match", new BsonDocument("$or", new BsonArray
+            {
+                new BsonDocument("_score", new BsonDocument("$lt", c.Score)),
+                new BsonDocument
+                {
+                    { "_score", c.Score },
+                    { "createdAtUtc", new BsonDocument("$lt", cursorTs) },
+                },
+                new BsonDocument
+                {
+                    { "_score", c.Score },
+                    { "createdAtUtc", cursorTs },
+                    { "_id", new BsonDocument("$lt", new BsonBinaryData(c.MessageId, GuidRepresentation.Standard)) },
+                },
+            })));
+        }
+
+        stages.Add(new("$sort", new BsonDocument
+        {
+            { "_score", -1 },
+            { "createdAtUtc", -1 },
+            { "_id", -1 },
+        }));
+        stages.Add(new("$limit", limit));
+
+        PipelineDefinition<MessageDocument, BsonDocument> pipeline = stages;
+
+        var raw = await context.Messages
+            .Aggregate(pipeline, cancellationToken: cancellationToken)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var hits = new List<MessageSearchHit>(raw.Count);
+        foreach (var doc in raw)
+        {
+            var score = doc.GetValue("_score", BsonDouble.Create(0.0)).ToDouble();
+            doc.Remove("_score");
+            var msgDoc = BsonSerializer.Deserialize<MessageDocument>(doc);
+            hits.Add(new MessageSearchHit(msgDoc.ToDomain(), score));
+        }
+        return hits;
     }
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -561,16 +561,16 @@ internal sealed class MessageRepository(ChatMongoContext context) : IMessageRepo
             matchStage.Add("senderId", new BsonBinaryData(senderId, GuidRepresentation.Standard));
         }
 
-        if (criteria.DateFrom is { } from || criteria.DateTo is { } to)
+        if (criteria.DateFrom.HasValue || criteria.DateTo.HasValue)
         {
             var range = new BsonDocument();
-            if (criteria.DateFrom is { } f)
+            if (criteria.DateFrom is { } from)
             {
-                range.Add("$gte", f.UtcDateTime);
+                range.Add("$gte", from.UtcDateTime);
             }
-            if (criteria.DateTo is { } t)
+            if (criteria.DateTo is { } to)
             {
-                range.Add("$lte", t.UtcDateTime);
+                range.Add("$lte", to.UtcDateTime);
             }
             matchStage.Add("createdAtUtc", range);
         }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
 
@@ -8,8 +10,12 @@ namespace Urfu.Link.Services.Chat.Infrastructure.Persistence;
 /// Creates the chat collection indexes at process startup. Safe to run repeatedly because the
 /// driver no-ops on existing indexes with the same definition.
 /// </summary>
-internal sealed class MongoIndexInitializer(ChatMongoContext context) : IHostedService
+internal sealed class MongoIndexInitializer(
+    ChatMongoContext context,
+    ILogger<MongoIndexInitializer>? logger = null) : IHostedService
 {
+    private readonly ILogger _logger = logger ?? NullLogger<MongoIndexInitializer>.Instance;
+
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         var conversations = context.Conversations;
@@ -74,6 +80,8 @@ internal sealed class MongoIndexInitializer(ChatMongoContext context) : IHostedS
             },
             cancellationToken).ConfigureAwait(false);
 
+        await EnsureMessagesTextIndexAsync(messages, cancellationToken).ConfigureAwait(false);
+
         var threadSubscriptions = context.ThreadSubscriptions;
         await threadSubscriptions.Indexes.CreateManyAsync(
             new[]
@@ -107,4 +115,53 @@ internal sealed class MongoIndexInitializer(ChatMongoContext context) : IHostedS
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Creates the full-text index on <c>messages.body</c>. Tries Russian Snowball stemming first
+    /// (works on stock MongoDB Community 8.0). On <see cref="MongoCommandException"/> indicating
+    /// the language is unavailable in the current build, falls back to <c>"none"</c> (literal
+    /// tokenization, no stemming) and logs a warning.
+    /// </summary>
+    private async Task EnsureMessagesTextIndexAsync(
+        IMongoCollection<MessageDocument> messages,
+        CancellationToken cancellationToken)
+    {
+        const string IndexName = "ix_messages_body_text";
+
+        try
+        {
+            await messages.Indexes.CreateOneAsync(
+                new CreateIndexModel<MessageDocument>(
+                    Builders<MessageDocument>.IndexKeys.Text(m => m.Body),
+                    new CreateIndexOptions
+                    {
+                        Name = IndexName,
+                        Background = true,
+                        DefaultLanguage = "russian",
+                    }),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (MongoCommandException ex) when (IsUnsupportedLanguage(ex))
+        {
+            _logger.LogWarning(
+                ex,
+                "MongoDB does not support Russian text-search language in this build; falling back to default_language=\"none\".");
+
+            await messages.Indexes.CreateOneAsync(
+                new CreateIndexModel<MessageDocument>(
+                    Builders<MessageDocument>.IndexKeys.Text(m => m.Body),
+                    new CreateIndexOptions
+                    {
+                        Name = IndexName,
+                        Background = true,
+                        DefaultLanguage = "none",
+                    }),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsUnsupportedLanguage(MongoCommandException ex)
+        => ex.Code == 17262
+            || ex.Message.Contains("language not supported", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("language override", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MongoIndexInitializer.cs
@@ -117,16 +117,24 @@ internal sealed class MongoIndexInitializer(
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <summary>
-    /// Creates the full-text index on <c>messages.body</c>. Tries Russian Snowball stemming first
-    /// (works on stock MongoDB Community 8.0). On <see cref="MongoCommandException"/> indicating
-    /// the language is unavailable in the current build, falls back to <c>"none"</c> (literal
-    /// tokenization, no stemming) and logs a warning.
+    /// Creates the full-text index on <c>messages.body</c> if it does not already exist.
+    /// Tries Russian Snowball stemming first (works on stock MongoDB Community 8.0); on
+    /// <see cref="MongoCommandException"/> indicating the language is unavailable, falls back
+    /// to <c>"none"</c> (literal tokenization, no stemming) and logs a warning. The existence
+    /// check up front keeps subsequent restarts idempotent — if a previous run fell back to
+    /// <c>"none"</c>, we leave that index in place rather than failing on
+    /// <c>IndexOptionsConflict</c> when retrying with Russian.
     /// </summary>
     private async Task EnsureMessagesTextIndexAsync(
         IMongoCollection<MessageDocument> messages,
         CancellationToken cancellationToken)
     {
         const string IndexName = "ix_messages_body_text";
+
+        if (await IndexExistsAsync(messages, IndexName, cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
 
         try
         {
@@ -158,6 +166,18 @@ internal sealed class MongoIndexInitializer(
                     }),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static async Task<bool> IndexExistsAsync(
+        IMongoCollection<MessageDocument> messages,
+        string indexName,
+        CancellationToken cancellationToken)
+    {
+        using var cursor = await messages.Indexes
+            .ListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var documents = await cursor.ToListAsync(cancellationToken).ConfigureAwait(false);
+        return documents.Any(d => d.TryGetValue("name", out var value) && value.IsString && value.AsString == indexName);
     }
 
     private static bool IsUnsupportedLanguage(MongoCommandException ex)

--- a/src/Services/Chat/README.md
+++ b/src/Services/Chat/README.md
@@ -81,8 +81,9 @@ participants to pin and rejects all group-chat pin attempts.
   - Collection `messages` — composite indexes `(conversationId, createdAtUtc desc)` and
     `(senderId, createdAtUtc desc)`, a unique sparse index on
     `(senderId, clientMessageId)` for `SendMessage` idempotency, a sparse index on
-    `mentions` for future mention search, and a sparse `(threadRootId, createdAtUtc asc)`
-    index that backs `ListThreadAsync`.
+    `mentions` for future mention search, a sparse `(threadRootId, createdAtUtc asc)`
+    index that backs `ListThreadAsync`, and a `text` index on `body` (Russian Snowball
+    stemmer with a `none` fallback) that powers `/chat/search`.
   - Collection `thread_subscriptions` — unique `(rootMessageId, userId)` (atomicity backstop
     for the upsert pipeline) and `(userId, lastActivityAtUtc desc, rootMessageId desc)` for
     the active-threads keyset pagination.
@@ -145,6 +146,7 @@ responsibility for now.
 | `POST` | `/messages/{id}/thread/subscribe` | Manually subscribe (`Manual` reason). |
 | `DELETE` | `/messages/{id}/thread/subscribe` | Unsubscribe. Reply history is untouched. |
 | `GET` | `/threads/active` | Caller's active threads, ordered by last activity desc. |
+| `GET` | `/search` | Full-text search across the caller's chat history. |
 
 ## Integration events (Kafka topic `urfu.chat.events.v1`)
 
@@ -196,3 +198,31 @@ responsibility for now.
 - **Authorization:** join, reply, and read all require participation in the parent
   conversation. Tombstoned roots reject new replies. A reply cannot point at itself or at
   another reply.
+
+## Message search — design notes (#213)
+
+- **Endpoint:** `GET /api/v1/chat/search?q=…&conversationId=&senderId=&from=&to=&hasAttachments=&attachmentType=&cursor=&limit=`.
+  The query (`q`) is required and must be at least two characters; `limit` is clamped to
+  `[1, 100]` and defaults to 20. Per-user rate limit is 30 requests per minute (Redis-backed
+  fixed window, registered in `BuildingBlocks/Idempotency`); excess requests get `429` with a
+  `Retry-After` header.
+- **Index:** `messages` carries a `text` index on `body` with `default_language: "russian"`.
+  MongoDB Community 8 ships with the Snowball Russian stemmer, so `"оплата"` matches
+  `"оплаты"` / `"оплате"`. `MongoIndexInitializer` falls back to `default_language: "none"`
+  if the stemmer is unavailable in the running build (logged as a warning).
+- **Pipeline:** `SearchAsync` runs an aggregate pipeline — `$text` plus all simple filters in
+  the first `$match`, `$addFields _score = $meta:"textScore"`, an optional cursor predicate
+  on `(_score, createdAtUtc, _id)`, then `$sort` desc on the same triple and `$limit`. The
+  cursor is opaque base64url JSON carrying `(score, ts, id)`.
+- **Access control:** the application layer fetches the caller's `conversationIds`
+  (`IConversationRepository.GetUserConversationIdsAsync`) and passes them as the `$in`
+  scope. A `conversationId` query param is intersected with that scope; outside-scope
+  requests return an empty page rather than `403` so the endpoint does not leak which
+  conversations exist.
+- **Threads:** thread replies (`threadRootId` set) are excluded from search — same convention
+  as `ListByConversationAsync`. Pulling threads into search is a future iteration.
+- **Highlighting:** best-effort. `MessageSnippetBuilder` returns ±30 chars around the first
+  case-insensitive literal occurrence of the first query term; if the stemmer matched a
+  different morphological form, no snippet is returned.
+- **Performance:** acceptance is p95 < 500ms on 100k messages — observed p50≈75ms / p95≈85ms
+  in `SearchPerformanceTests` (excluded from the default run via `Category=Performance`).

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/SearchEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/SearchEndpointsTests.cs
@@ -1,0 +1,256 @@
+using System.Net;
+using System.Net.Http.Json;
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.Services.Chat.Application.Contracts;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace ChatService.IntegrationTests.Endpoints;
+
+[Collection(IntegrationCollection.Name)]
+public class SearchEndpointsTests : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public SearchEndpointsTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Get_Search_ReturnsHitsOnlyFromCallerConversations()
+    {
+        var caller = Guid.NewGuid();
+        var peerA = Guid.NewGuid();
+        var peerB = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+
+        string convA, convB, convStranger;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            convA = (await open.OpenAsync(caller, peerA, default)).Id;
+            convB = (await open.OpenAsync(caller, peerB, default)).Id;
+            convStranger = (await open.OpenAsync(stranger, Guid.NewGuid(), default)).Id;
+        }
+
+        await SendAsync(convA, caller, "квантовая запутанность интересна");
+        await SendAsync(convB, caller, "квантовая теория струн");
+        await SendAsync(convStranger, stranger, "квантовая физика чужая");
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var page = await client.GetFromJsonAsync<CursorPage<MessageSearchResultDto>>(
+            "/api/v1/chat/search?q=квантовая&limit=50");
+
+        page!.Items.Should().HaveCount(2);
+        page.Items.Select(i => i.ConversationId).Should().BeEquivalentTo(new[] { convA, convB });
+    }
+
+    [Fact]
+    public async Task Get_Search_ConversationIdOutsideMembership_ReturnsEmptyNotForbidden()
+    {
+        var caller = Guid.NewGuid();
+        string strangerConv;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            strangerConv = (await open.OpenAsync(Guid.NewGuid(), Guid.NewGuid(), default)).Id;
+        }
+
+        await SendAsync(strangerConv, Guid.NewGuid(), "тайное сообщение");
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/v1/chat/search?q=тайное&conversationId={strangerConv}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await response.Content.ReadFromJsonAsync<CursorPage<MessageSearchResultDto>>();
+        page!.Items.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    public async Task Get_Search_QueryTooShort_Returns400(string query)
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var url = string.IsNullOrEmpty(query)
+            ? "/api/v1/chat/search"
+            : $"/api/v1/chat/search?q={query}";
+        var response = await client.GetAsync(url);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_Search_LimitOver100_Returns400()
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/chat/search?q=test&limit=101");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_Search_FiltersBySender()
+    {
+        var caller = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        string conv;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            conv = (await open.OpenAsync(caller, peer, default)).Id;
+        }
+
+        await SendAsync(conv, caller, "общий термин раз");
+        await SendAsync(conv, peer, "общий термин два");
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var page = await client.GetFromJsonAsync<CursorPage<MessageSearchResultDto>>(
+            $"/api/v1/chat/search?q=общий&senderId={caller}");
+
+        page!.Items.Should().ContainSingle();
+        page.Items[0].SenderId.Should().Be(caller);
+    }
+
+    [Fact]
+    public async Task Get_Search_PaginatesViaCursor()
+    {
+        var caller = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        string conv;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            conv = (await open.OpenAsync(caller, peer, default)).Id;
+        }
+
+        for (var i = 0; i < 6; i++)
+        {
+            await SendAsync(conv, caller, $"уникальное слово{i:D2} тест");
+        }
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var first = await client.GetFromJsonAsync<CursorPage<MessageSearchResultDto>>(
+            "/api/v1/chat/search?q=тест&limit=3");
+        first!.Items.Should().HaveCount(3);
+        first.NextCursor.Should().NotBeNullOrEmpty();
+
+        var second = await client.GetFromJsonAsync<CursorPage<MessageSearchResultDto>>(
+            $"/api/v1/chat/search?q=тест&limit=3&cursor={Uri.EscapeDataString(first.NextCursor!)}");
+        second!.Items.Should().HaveCount(3);
+
+        var firstIds = first.Items.Select(i => i.MessageId).ToHashSet();
+        var secondIds = second.Items.Select(i => i.MessageId).ToHashSet();
+        firstIds.Should().NotIntersectWith(secondIds);
+    }
+
+    [Fact]
+    public async Task Get_Search_BadCursor_Returns400()
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        // Allowed scope must be non-empty for cursor to actually be decoded — seed one conv.
+        var caller = Guid.NewGuid();
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            await open.OpenAsync(caller, Guid.NewGuid(), default);
+        }
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        var response = await client.GetAsync("/api/v1/chat/search?q=test&cursor=not-base64!!");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_Search_HighlightedSnippet_PresentForBodyMatches()
+    {
+        var caller = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        string conv;
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            conv = (await open.OpenAsync(caller, peer, default)).Id;
+        }
+
+        var prefix = new string('x', 50);
+        var suffix = new string('y', 50);
+        await SendAsync(conv, caller, $"{prefix} оплата {suffix}");
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+        var page = await client.GetFromJsonAsync<CursorPage<MessageSearchResultDto>>(
+            "/api/v1/chat/search?q=оплата");
+
+        page!.Items.Should().ContainSingle();
+        page.Items[0].HighlightedSnippet.Should().NotBeNullOrEmpty().And.Contain("оплата");
+    }
+
+    [Fact]
+    public async Task Get_Search_OverRateLimit_Returns429()
+    {
+        var caller = Guid.NewGuid();
+        var peer = Guid.NewGuid();
+        await using (var seed = _factory.Services.CreateAsyncScope())
+        {
+            var open = seed.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            await open.OpenAsync(caller, peer, default);
+        }
+
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(caller);
+
+        using var client = _factory.CreateClient();
+
+        // Policy is 30 req / minute per user — 30 must succeed, the 31st must be 429.
+        for (var i = 0; i < 30; i++)
+        {
+            var ok = await client.GetAsync("/api/v1/chat/search?q=anything");
+            ok.StatusCode.Should().Be(HttpStatusCode.OK, $"request {i + 1} should be inside the window");
+        }
+
+        var blocked = await client.GetAsync("/api/v1/chat/search?q=anything");
+        blocked.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        blocked.Headers.Should().ContainSingle(h => h.Key == "Retry-After");
+    }
+
+    private async Task SendAsync(string conversationId, Guid senderId, string body)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IMessageRepository>();
+        var msg = Message.Send(
+            Guid.NewGuid(),
+            conversationId,
+            senderId,
+            body,
+            Array.Empty<Attachment>(),
+            Guid.NewGuid().ToString(),
+            DateTimeOffset.UtcNow);
+        await repo.InsertAsync(msg, default);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/SearchEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/SearchEndpointsTests.cs
@@ -109,6 +109,20 @@ public class SearchEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Get_Search_HasAttachmentsFalse_WithAttachmentType_Returns400()
+    {
+        // Contradictory combo: "no attachments" AND "attachments of type X" can never both
+        // hold. Reject up front rather than silently returning empty results — that would
+        // hide a client bug.
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/chat/search?q=test&hasAttachments=false&attachmentType=Image");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task Get_Search_FiltersBySender()
     {
         var caller = Guid.NewGuid();

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/SearchPerformanceTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/SearchPerformanceTests.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Urfu.Link.Services.Chat.Application.Conversations;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
+
+namespace ChatService.IntegrationTests.Endpoints;
+
+/// <summary>
+/// Performance acceptance for issue #213: full-text search must keep p95 latency under 500ms
+/// on a 100k-message dataset. Tests in this class are tagged Performance and excluded from
+/// the default test run via <c>--filter "Category!=Performance"</c>.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("Category", "Performance")]
+[SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Deterministic test data seeding, not a security boundary.")]
+public class SearchPerformanceTests : IAsyncLifetime
+{
+    private const int TotalMessages = 100_000;
+    private const int ConversationsCount = 50;
+    private const int MessagesPerConversation = TotalMessages / ConversationsCount;
+    private const int Iterations = 100;
+    private const int P95BudgetMs = 500;
+
+    private static readonly string[] Vocabulary =
+    {
+        "квантовая", "теория", "поле", "оплата", "зачёт", "лекция", "семинар",
+        "лабораторная", "курсовая", "проект", "дедлайн", "экзамен", "сессия",
+        "формула", "интеграл", "матрица", "вектор", "энтропия", "функция",
+        "график", "точка", "прямая", "плоскость", "симметрия",
+    };
+
+    // The needle term: appears in every Nth message so search has plenty of hits to rank.
+    private const string SearchTerm = "иголка";
+    private const int NeedleEvery = 10;
+
+    private readonly ChatServiceFactory _factory;
+
+    public SearchPerformanceTests(ChatServiceFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Search_On100kMessages_KeepsP95UnderBudget()
+    {
+        var caller = Guid.NewGuid();
+
+        var conversationIds = await SeedDataAsync(caller);
+        conversationIds.Should().HaveCount(ConversationsCount);
+
+        // Bypass the HTTP layer (and the per-user rate limiter) and call the Application query
+        // directly. The hot path under measurement is Mongo aggregate + cursor encoding + DTO
+        // hydration — exactly what we want to keep under the 500ms p95 budget. The 30/min rate
+        // limiter is a fixed orthogonal overhead and is exercised by SearchEndpointsTests.
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var query = scope.ServiceProvider.GetRequiredService<SearchMessagesQuery>();
+        var parameters = new SearchMessagesParameters(SearchTerm, null, null, null, null, null, null, null, Limit: 20);
+
+        // Warm-up: a couple of calls so JIT / connection pools / index cache are hot.
+        for (var i = 0; i < 3; i++)
+        {
+            _ = await query.ExecuteAsync(parameters, caller, default);
+        }
+
+        var latencies = new List<long>(Iterations);
+        for (var i = 0; i < Iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            var page = await query.ExecuteAsync(parameters, caller, default);
+            sw.Stop();
+            latencies.Add(sw.ElapsedMilliseconds);
+            page.Items.Should().NotBeEmpty();
+        }
+
+        latencies.Sort();
+        var p95 = latencies[(int)Math.Floor(0.95 * latencies.Count) - 1];
+        var p50 = latencies[latencies.Count / 2];
+
+        // Surface the timings even when the assertion passes — they show up in the test runner
+        // output and make regressions visible at a glance.
+        Console.WriteLine(
+            $"Search perf: p50 = {p50}ms, p95 = {p95}ms, max = {latencies[^1]}ms over {Iterations} iterations on {TotalMessages} docs.");
+
+        p95.Should().BeLessThan(
+            P95BudgetMs,
+            $"acceptance criterion (#213) requires p95 < {P95BudgetMs}ms; observed p50={p50}ms, p95={p95}ms");
+    }
+
+    private async Task<List<string>> SeedDataAsync(Guid caller)
+    {
+        var conversationIds = new List<string>(ConversationsCount);
+
+        // Open ConversationsCount direct chats — caller in each.
+        await using (var seedScope = _factory.Services.CreateAsyncScope())
+        {
+            var open = seedScope.ServiceProvider.GetRequiredService<OpenDirectConversationService>();
+            for (var i = 0; i < ConversationsCount; i++)
+            {
+                var conv = await open.OpenAsync(caller, Guid.NewGuid(), default);
+                conversationIds.Add(conv.Id);
+            }
+        }
+
+        // Bulk-insert messages directly into Mongo. Going through SendMessageService for 100k
+        // documents would dominate the test runtime; the search path doesn't care how the rows
+        // got there as long as the schema is right.
+        var ctx = _factory.Services.GetRequiredService<ChatMongoContext>();
+
+        var rnd = new Random(42);
+        var anchor = DateTime.UtcNow.AddDays(-7);
+        var globalIndex = 0;
+        const int batchSize = 5_000;
+
+        foreach (var convId in conversationIds)
+        {
+            var docs = new List<MessageDocument>(MessagesPerConversation);
+            for (var i = 0; i < MessagesPerConversation; i++)
+            {
+                var words = new List<string>(8);
+                var len = 5 + rnd.Next(8);
+                for (var w = 0; w < len; w++)
+                {
+                    words.Add(Vocabulary[rnd.Next(Vocabulary.Length)]);
+                }
+                if (globalIndex % NeedleEvery == 0)
+                {
+                    words.Insert(rnd.Next(words.Count), SearchTerm);
+                }
+
+                docs.Add(new MessageDocument
+                {
+                    Id = Guid.NewGuid(),
+                    ConversationId = convId,
+                    SenderId = caller,
+                    Body = string.Join(' ', words),
+                    State = MessageState.Sent,
+                    ClientMessageId = $"perf-{globalIndex}",
+                    CreatedAtUtc = anchor.AddSeconds(globalIndex),
+                });
+
+                if (docs.Count >= batchSize)
+                {
+                    await ctx.Messages.InsertManyAsync(docs);
+                    docs.Clear();
+                }
+                globalIndex++;
+            }
+
+            if (docs.Count > 0)
+            {
+                await ctx.Messages.InsertManyAsync(docs);
+            }
+        }
+
+        return conversationIds;
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/RateLimiterTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/RateLimiterTests.cs
@@ -1,0 +1,78 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Idempotency;
+using Xunit;
+
+namespace ChatService.IntegrationTests.Infrastructure;
+
+public sealed class RateLimiterTests : IClassFixture<ChatServiceFactory>, IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory;
+
+    public RateLimiterTests(ChatServiceFactory factory) => _factory = factory;
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task TryAcquire_AllowsUpToMaxRequests_ThenDenies()
+    {
+        var limiter = CreateLimiter("test-allows", TimeSpan.FromMinutes(1), maxRequests: 5);
+        var key = $"user:{Guid.NewGuid():N}";
+
+        for (var i = 0; i < 5; i++)
+        {
+            var decision = await limiter.TryAcquireAsync(key);
+            decision.Allowed.Should().BeTrue($"request {i + 1} should be within the window");
+        }
+
+        var sixth = await limiter.TryAcquireAsync(key);
+        sixth.Allowed.Should().BeFalse();
+        sixth.RetryAfter.Should().NotBeNull();
+        sixth.RetryAfter!.Value.Should().BeGreaterThan(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task TryAcquire_DifferentKeys_AreIsolated()
+    {
+        var limiter = CreateLimiter("test-isolation", TimeSpan.FromMinutes(1), maxRequests: 1);
+
+        var first = await limiter.TryAcquireAsync($"a-{Guid.NewGuid():N}");
+        var second = await limiter.TryAcquireAsync($"b-{Guid.NewGuid():N}");
+
+        first.Allowed.Should().BeTrue();
+        second.Allowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquire_AfterWindowElapses_AllowsAgain()
+    {
+        var limiter = CreateLimiter("test-reset", TimeSpan.FromMilliseconds(500), maxRequests: 1);
+        var key = $"user:{Guid.NewGuid():N}";
+
+        var first = await limiter.TryAcquireAsync(key);
+        var blocked = await limiter.TryAcquireAsync(key);
+
+        first.Allowed.Should().BeTrue();
+        blocked.Allowed.Should().BeFalse();
+
+        await Task.Delay(TimeSpan.FromMilliseconds(700));
+
+        var afterWindow = await limiter.TryAcquireAsync(key);
+        afterWindow.Allowed.Should().BeTrue();
+    }
+
+    private RedisFixedWindowRateLimiter CreateLimiter(string name, TimeSpan window, int maxRequests)
+    {
+        var multiplexer = _factory.Services.GetRequiredService<IConnectionMultiplexer>();
+        return new RedisFixedWindowRateLimiter(multiplexer, new RateLimiterOptions
+        {
+            Name = name,
+            Window = window,
+            MaxRequests = maxRequests,
+        });
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/ConversationRepositoryTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/ConversationRepositoryTests.cs
@@ -118,4 +118,43 @@ public class ConversationRepositoryTests : IClassFixture<MongoFixture>, IAsyncLi
 
         page.Should().ContainSingle().Which.Id.Should().Be(older.Id);
     }
+
+    [Fact]
+    public async Task GetUserConversationIdsAsync_ReturnsOnlyParticipantConversations()
+    {
+        var user = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+
+        var mine1 = Conversation.OpenDirect(user, Guid.NewGuid(), DateTimeOffset.UtcNow.AddHours(-1));
+        var mine2 = Conversation.OpenDirect(user, Guid.NewGuid(), DateTimeOffset.UtcNow.AddHours(-2));
+        var theirs = Conversation.OpenDirect(stranger, Guid.NewGuid(), DateTimeOffset.UtcNow.AddHours(-3));
+        await _repo.TryCreateAsync(mine1, default);
+        await _repo.TryCreateAsync(mine2, default);
+        await _repo.TryCreateAsync(theirs, default);
+
+        var ids = await _repo.GetUserConversationIdsAsync(user, default);
+
+        ids.Should().BeEquivalentTo(new[] { mine1.Id, mine2.Id });
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_ReturnsRequestedConversations_AndSilentlySkipsMissing()
+    {
+        var user = Guid.NewGuid();
+        var c1 = Conversation.OpenDirect(user, Guid.NewGuid(), DateTimeOffset.UtcNow);
+        var c2 = Conversation.OpenDirect(user, Guid.NewGuid(), DateTimeOffset.UtcNow);
+        await _repo.TryCreateAsync(c1, default);
+        await _repo.TryCreateAsync(c2, default);
+
+        var loaded = await _repo.GetByIdsAsync(new[] { c1.Id, c2.Id, "missing-id" }, default);
+
+        loaded.Select(c => c.Id).Should().BeEquivalentTo(new[] { c1.Id, c2.Id });
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_EmptyInput_ReturnsEmpty()
+    {
+        var loaded = await _repo.GetByIdsAsync(Array.Empty<string>(), default);
+        loaded.Should().BeEmpty();
+    }
 }

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositorySearchTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositorySearchTests.cs
@@ -1,0 +1,268 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+
+namespace ChatService.IntegrationTests.Persistence;
+
+public class MessageRepositorySearchTests : IClassFixture<MongoFixture>, IAsyncLifetime
+{
+    private readonly MongoFixture _mongo;
+    private ChatMongoContext _context = null!;
+    private MessageRepository _repo = null!;
+
+    public MessageRepositorySearchTests(MongoFixture mongo)
+    {
+        _mongo = mongo;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _context = _mongo.CreateContext();
+        _repo = new MessageRepository(_context);
+        var indexes = new MongoIndexInitializer(_context);
+        await indexes.StartAsync(CancellationToken.None);
+    }
+
+    public Task DisposeAsync()
+    {
+        _context.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task SearchAsync_ReturnsMatchesOnlyInAllowedConversations()
+    {
+        var conv1 = $"conv-{Guid.NewGuid():N}";
+        var conv2 = $"conv-{Guid.NewGuid():N}";
+        var conv3 = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+
+        await Insert(conv1, sender, "квантовая физика интересна");
+        await Insert(conv2, sender, "квантовая запутанность");
+        await Insert(conv3, sender, "квантовая теория струн");
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("квантовая", null, null, null, null, null),
+            new[] { conv1, conv2 },
+            cursor: null,
+            limit: 50,
+            CancellationToken.None);
+
+        hits.Should().HaveCount(2);
+        hits.Select(h => h.Message.ConversationId).Should().BeEquivalentTo(new[] { conv1, conv2 });
+    }
+
+    [Fact]
+    public async Task SearchAsync_ExcludesThreadReplies()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+
+        var root = Message.Send(Guid.NewGuid(), conv, sender, "оплата зачёта", Array.Empty<Attachment>(), Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(root, default);
+
+        var reply = Message.SendAsThreadReply(
+            Guid.NewGuid(),
+            conv,
+            sender,
+            body: "оплата прошла",
+            Array.Empty<Attachment>(),
+            Guid.NewGuid().ToString(),
+            DateTimeOffset.UtcNow,
+            threadRootId: root.Id);
+        await _repo.InsertAsync(reply, default);
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("оплата", null, null, null, null, null),
+            new[] { conv },
+            cursor: null,
+            limit: 50,
+            CancellationToken.None);
+
+        hits.Should().HaveCount(1);
+        hits[0].Message.Id.Should().Be(root.Id);
+    }
+
+    [Fact]
+    public async Task SearchAsync_FiltersBySenderId()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await Insert(conv, alice, "термин общий");
+        await Insert(conv, bob, "термин общий");
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("термин", alice, null, null, null, null),
+            new[] { conv },
+            cursor: null,
+            limit: 50,
+            CancellationToken.None);
+
+        hits.Should().HaveCount(1);
+        hits[0].Message.SenderId.Should().Be(alice);
+    }
+
+    [Fact]
+    public async Task SearchAsync_FiltersByDateRange()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var anchor = new DateTimeOffset(2026, 04, 25, 10, 00, 00, TimeSpan.Zero);
+
+        await Insert(conv, sender, "слово раз", anchor);
+        await Insert(conv, sender, "слово два", anchor.AddHours(2));
+        await Insert(conv, sender, "слово три", anchor.AddHours(4));
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria(
+                Query: "слово",
+                SenderId: null,
+                DateFrom: anchor.AddHours(1),
+                DateTo: anchor.AddHours(3),
+                HasAttachments: null,
+                AttachmentType: null),
+            new[] { conv },
+            cursor: null,
+            limit: 50,
+            CancellationToken.None);
+
+        hits.Should().HaveCount(1);
+        hits[0].Message.Body.Should().Be("слово два");
+    }
+
+    [Fact]
+    public async Task SearchAsync_FiltersByHasAttachments()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var attachment = new Attachment(Guid.NewGuid(), AttachmentType.Image, null, "p.png", 100, "image/png");
+
+        await Insert(conv, sender, "просто текст");
+        await Insert(conv, sender, "текст с фото", attachments: new[] { attachment });
+
+        var withAttachments = await _repo.SearchAsync(
+            new MessageSearchCriteria("текст", null, null, null, HasAttachments: true, null),
+            new[] { conv }, null, 50, default);
+
+        var withoutAttachments = await _repo.SearchAsync(
+            new MessageSearchCriteria("текст", null, null, null, HasAttachments: false, null),
+            new[] { conv }, null, 50, default);
+
+        withAttachments.Should().HaveCount(1);
+        withAttachments[0].Message.Body.Should().Contain("фото");
+
+        withoutAttachments.Should().HaveCount(1);
+        withoutAttachments[0].Message.Body.Should().Be("просто текст");
+    }
+
+    [Fact]
+    public async Task SearchAsync_FiltersByAttachmentType()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var image = new Attachment(Guid.NewGuid(), AttachmentType.Image, null, "p.png", 100, "image/png");
+        var doc = new Attachment(Guid.NewGuid(), AttachmentType.Document, null, "f.pdf", 200, "application/pdf");
+
+        await Insert(conv, sender, "содержимое раз", attachments: new[] { image });
+        await Insert(conv, sender, "содержимое два", attachments: new[] { doc });
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("содержимое", null, null, null, null, AttachmentType.Image),
+            new[] { conv }, null, 50, default);
+
+        hits.Should().HaveCount(1);
+        hits[0].Message.Attachments.Should().ContainSingle(a => a.Type == AttachmentType.Image);
+    }
+
+    [Fact]
+    public async Task SearchAsync_OrdersByScoreThenCreatedAtDesc()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var anchor = DateTimeOffset.UtcNow.AddDays(-1);
+
+        // The phrase "карта" appears once in the first message, twice in the second — Mongo ranks
+        // the second higher.
+        await Insert(conv, sender, "карта одна", anchor);
+        await Insert(conv, sender, "карта карта две", anchor.AddMinutes(1));
+        await Insert(conv, sender, "карта три", anchor.AddMinutes(5));
+
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("карта", null, null, null, null, null),
+            new[] { conv }, null, 50, default);
+
+        hits.Should().HaveCount(3);
+        hits[0].Message.Body.Should().Be("карта карта две");
+        hits[0].Score.Should().BeGreaterThan(hits[1].Score);
+    }
+
+    [Fact]
+    public async Task SearchAsync_PaginatesViaCursorWithoutDuplicates()
+    {
+        var conv = $"conv-{Guid.NewGuid():N}";
+        var sender = Guid.NewGuid();
+        var baseTime = DateTimeOffset.UtcNow.AddDays(-1);
+
+        for (var i = 0; i < 10; i++)
+        {
+            await Insert(conv, sender, $"уникальное слово{i:D2} тест", baseTime.AddSeconds(i));
+        }
+
+        var firstPage = await _repo.SearchAsync(
+            new MessageSearchCriteria("тест", null, null, null, null, null),
+            new[] { conv }, null, limit: 5, default);
+
+        firstPage.Should().HaveCount(5);
+
+        var lastHit = firstPage[^1];
+        var cursor = new MessageSearchCursor(lastHit.Score, lastHit.Message.CreatedAtUtc, lastHit.Message.Id);
+
+        var secondPage = await _repo.SearchAsync(
+            new MessageSearchCriteria("тест", null, null, null, null, null),
+            new[] { conv }, cursor, limit: 5, default);
+
+        secondPage.Should().HaveCount(5);
+
+        var firstIds = firstPage.Select(h => h.Message.Id).ToHashSet();
+        var secondIds = secondPage.Select(h => h.Message.Id).ToHashSet();
+        firstIds.Should().NotIntersectWith(secondIds);
+        (firstIds.Count + secondIds.Count).Should().Be(10);
+    }
+
+    [Fact]
+    public async Task SearchAsync_EmptyAllowedConversationIds_ReturnsEmpty()
+    {
+        var hits = await _repo.SearchAsync(
+            new MessageSearchCriteria("anything", null, null, null, null, null),
+            Array.Empty<string>(),
+            cursor: null,
+            limit: 50,
+            default);
+
+        hits.Should().BeEmpty();
+    }
+
+    private async Task Insert(
+        string conversationId,
+        Guid senderId,
+        string body,
+        DateTimeOffset? createdAtUtc = null,
+        IReadOnlyList<Attachment>? attachments = null)
+    {
+        var message = Message.Send(
+            Guid.NewGuid(),
+            conversationId,
+            senderId,
+            body,
+            attachments ?? Array.Empty<Attachment>(),
+            Guid.NewGuid().ToString(),
+            createdAtUtc ?? DateTimeOffset.UtcNow);
+        await _repo.InsertAsync(message, default);
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
@@ -38,6 +38,7 @@ public class MongoIndexInitializerTests : IClassFixture<MongoFixture>
             "ix_messages_sender_createdAt_desc",
             "ux_messages_sender_clientMessageId",
             "ix_messages_mentions",
+            "ix_messages_body_text",
         });
     }
 

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MongoIndexInitializerTests.cs
@@ -2,6 +2,7 @@ using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
 using MongoDB.Driver;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence;
+using Urfu.Link.Services.Chat.Infrastructure.Persistence.Documents;
 
 namespace ChatService.IntegrationTests.Persistence;
 
@@ -57,5 +58,35 @@ public class MongoIndexInitializerTests : IClassFixture<MongoFixture>
         var convCount = (await convIndexes.ToListAsync()).Count;
         // _id + 2 of ours = 3
         convCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task StartAsync_TextIndexAlreadyExistsWithDifferentLanguage_DoesNotThrow()
+    {
+        // Simulate a prior fallback run: a "none"-language text index already lives in the
+        // collection. The default code path tries Russian first; without an existence check
+        // Mongo would reject re-creation with IndexOptionsConflict (NOT an unsupported-language
+        // error), so the catch wouldn't match and startup would crash on every restart.
+        using var context = _mongo.CreateContext();
+        await context.Messages.Indexes.CreateOneAsync(
+            new CreateIndexModel<MessageDocument>(
+                Builders<MessageDocument>.IndexKeys.Text(m => m.Body),
+                new CreateIndexOptions
+                {
+                    Name = "ix_messages_body_text",
+                    Background = true,
+                    DefaultLanguage = "none",
+                }));
+
+        var initializer = new MongoIndexInitializer(context);
+        var act = () => initializer.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+
+        var indexes = await context.Database
+            .GetCollection<dynamic>(ChatMongoContext.MessagesCollectionName)
+            .Indexes.ListAsync();
+        var names = (await indexes.ToListAsync()).Select(d => (string)d["name"]).ToList();
+        names.Should().Contain("ix_messages_body_text");
     }
 }

--- a/tests/unit/ChatService.UnitTests/Application/CursorCodecTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/CursorCodecTests.cs
@@ -45,6 +45,36 @@ public class CursorCodecTests
         decoded.Should().Be(original);
     }
 
+    [Fact]
+    public void EncodeDecode_MessageSearch_RoundTrips()
+    {
+        var original = new MessageSearchCursor(
+            Score: 1.75,
+            CreatedAtUtc: new DateTimeOffset(2026, 04, 25, 10, 00, 00, TimeSpan.Zero),
+            MessageId: Guid.NewGuid());
+
+        var encoded = CursorCodec.EncodeMessageSearch(original);
+        var decoded = CursorCodec.DecodeMessageSearch(encoded);
+
+        decoded.Should().Be(original);
+    }
+
+    [Fact]
+    public void DecodeMessageSearch_Garbage_ThrowsInvalidChatCursorException()
+    {
+        var act = () => CursorCodec.DecodeMessageSearch("not-base64!!");
+        act.Should().Throw<InvalidChatCursorException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void DecodeMessageSearch_NullOrEmpty_ReturnsNull(string? input)
+    {
+        CursorCodec.DecodeMessageSearch(input).Should().BeNull();
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/tests/unit/ChatService.UnitTests/Application/MessageSnippetBuilderTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/MessageSnippetBuilderTests.cs
@@ -105,4 +105,38 @@ public class MessageSnippetBuilderTests
     {
         MessageSnippetBuilder.Build("some body content", query).Should().BeNull();
     }
+
+    [Fact]
+    public void Build_SurrogatePairAtStartBoundary_NotSplit()
+    {
+        // Emoji "🎉" is a surrogate pair (2 UTF-16 code units). Position it so the start
+        // boundary (matchIndex - 30) lands on the low surrogate — naive char-level slicing
+        // would orphan the high half, producing an invalid UTF-16 string.
+        const string emoji = "🎉"; // 🎉
+        var pre = new string('a', 28);
+        var post = new string('b', 29);
+        var body = pre + emoji + post + "match";
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().NotBeNull();
+        snippet!.EnumerateRunes().Should()
+            .NotContain(r => r.Value == 0xFFFD,
+                "an unpaired surrogate half is decoded as the U+FFFD replacement character");
+    }
+
+    [Fact]
+    public void Build_SurrogatePairAtEndBoundary_NotSplit()
+    {
+        // Mirror of the start-boundary case: place the pair so the end boundary
+        // (matchIndex + term.Length + 30) lands on the high surrogate.
+        const string emoji = "🎉"; // 🎉
+        var body = "match" + new string('a', 29) + emoji + new string('b', 30);
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().NotBeNull();
+        snippet!.EnumerateRunes().Should()
+            .NotContain(r => r.Value == 0xFFFD);
+    }
 }

--- a/tests/unit/ChatService.UnitTests/Application/MessageSnippetBuilderTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/MessageSnippetBuilderTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Urfu.Link.Services.Chat.Application.Messages;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class MessageSnippetBuilderTests
+{
+    [Fact]
+    public void Build_TermInMiddle_ReturnsSnippetWithEllipsesOnBothSides()
+    {
+        var body = new string('a', 50) + " match " + new string('b', 50);
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().StartWith("...");
+        snippet.Should().EndWith("...");
+        snippet.Should().Contain("match");
+    }
+
+    [Fact]
+    public void Build_TermAtStart_NoLeadingEllipsis()
+    {
+        var body = "match starts here and goes on and on";
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().NotStartWith("...");
+        snippet.Should().Contain("match");
+    }
+
+    [Fact]
+    public void Build_TermAtEnd_NoTrailingEllipsis()
+    {
+        var body = "looking for the final word match";
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().NotEndWith("...");
+        snippet.Should().Contain("match");
+    }
+
+    [Fact]
+    public void Build_BodyShorterThanWindow_ReturnsFullBody()
+    {
+        var body = "short match body";
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().Be("short match body");
+    }
+
+    [Fact]
+    public void Build_NoMatch_ReturnsNull()
+    {
+        var body = "completely different body";
+
+        var snippet = MessageSnippetBuilder.Build(body, "missing");
+
+        snippet.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_MultiWordQuery_UsesFirstWord()
+    {
+        var body = "this body contains alpha but not beta";
+
+        var snippet = MessageSnippetBuilder.Build(body, "alpha beta");
+
+        snippet.Should().Contain("alpha");
+    }
+
+    [Fact]
+    public void Build_QuotedQuery_StripsQuotesAndFindsFirstWord()
+    {
+        var body = "what about зачёт today";
+
+        var snippet = MessageSnippetBuilder.Build(body, "\"зачёт сдан\"");
+
+        snippet.Should().Contain("зачёт");
+    }
+
+    [Fact]
+    public void Build_CaseInsensitive_FindsMatch()
+    {
+        var body = "MATCH is uppercase here";
+
+        var snippet = MessageSnippetBuilder.Build(body, "match");
+
+        snippet.Should().Contain("MATCH");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_EmptyBody_ReturnsNull(string body)
+    {
+        MessageSnippetBuilder.Build(body, "anything").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!?@#")]
+    public void Build_EmptyOrPunctuationQuery_ReturnsNull(string query)
+    {
+        MessageSnippetBuilder.Build("some body content", query).Should().BeNull();
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/SearchMessagesQueryTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/SearchMessagesQueryTests.cs
@@ -1,0 +1,242 @@
+using System.Globalization;
+using FluentAssertions;
+using NSubstitute;
+using Urfu.Link.Services.Chat.Application.Cursors;
+using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Domain.Interfaces;
+using Urfu.Link.Services.Chat.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+public class SearchMessagesQueryTests
+{
+    private static readonly Guid Caller = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Peer = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-04-25T12:00:00Z", CultureInfo.InvariantCulture);
+
+    private readonly IConversationRepository _conversations = Substitute.For<IConversationRepository>();
+    private readonly IMessageRepository _messages = Substitute.For<IMessageRepository>();
+
+    private SearchMessagesQuery Build() => new(_conversations, _messages);
+
+    [Fact]
+    public async Task Execute_CallerHasNoConversations_ReturnsEmptyPage()
+    {
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        var page = await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", null, null, null, null, null, null, null, null),
+            Caller,
+            default);
+
+        page.Items.Should().BeEmpty();
+        page.NextCursor.Should().BeNull();
+        await _messages.DidNotReceive().SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_ConversationIdOutsideAllowedSet_ReturnsEmptyPageWithoutThrowing()
+    {
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { "mine-1" });
+
+        var page = await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", "stranger-conv", null, null, null, null, null, null, null),
+            Caller,
+            default);
+
+        page.Items.Should().BeEmpty();
+        page.NextCursor.Should().BeNull();
+        await _messages.DidNotReceive().SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_ConversationIdInsideAllowedSet_RestrictsScopeToThatId()
+    {
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { "conv-a", "conv-b" });
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MessageSearchHit>());
+
+        await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", "conv-a", null, null, null, null, null, null, null),
+            Caller,
+            default);
+
+        await _messages.Received(1).SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Is<IReadOnlyList<string>>(s => s.Count == 1 && s[0] == "conv-a"),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_LimitDefaultsTo20_AndIsClampedTo100()
+    {
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { "c1" });
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MessageSearchHit>());
+
+        await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", null, null, null, null, null, null, null, Limit: null),
+            Caller, default);
+        await _messages.Received().SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            21, // 20 + 1 (lookahead)
+            Arg.Any<CancellationToken>());
+
+        await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", null, null, null, null, null, null, null, Limit: 999),
+            Caller, default);
+        await _messages.Received().SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            101, // 100 + 1
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_MoreResultsThanLimit_TrimsAndIssuesNextCursor()
+    {
+        var conv = Conversation.OpenDirect(Caller, Peer, Now);
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { conv.Id });
+        _conversations.GetByIdsAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { conv });
+
+        var hits = Enumerable.Range(0, 6).Select(i => new MessageSearchHit(
+            Message.Send(Guid.NewGuid(), conv.Id, Peer, $"термин {i}", Array.Empty<Attachment>(), $"client-{i}", Now.AddMinutes(-i)),
+            6.0 - i)).ToList();
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            6,
+            Arg.Any<CancellationToken>())
+            .Returns(hits);
+
+        var page = await Build().ExecuteAsync(
+            new SearchMessagesParameters("термин", null, null, null, null, null, null, null, Limit: 5),
+            Caller, default);
+
+        page.Items.Should().HaveCount(5);
+        page.NextCursor.Should().NotBeNullOrEmpty();
+        var decoded = CursorCodec.DecodeMessageSearch(page.NextCursor);
+        decoded.Should().NotBeNull();
+        decoded!.Value.MessageId.Should().Be(hits[4].Message.Id);
+        decoded.Value.Score.Should().Be(hits[4].Score);
+    }
+
+    [Fact]
+    public async Task Execute_DirectPreview_SurfacesPeerUserId()
+    {
+        var conv = Conversation.OpenDirect(Caller, Peer, Now);
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { conv.Id });
+        _conversations.GetByIdsAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { conv });
+
+        var msg = Message.Send(Guid.NewGuid(), conv.Id, Peer, "текст", Array.Empty<Attachment>(), "c1", Now);
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new[] { new MessageSearchHit(msg, 1.0) });
+
+        var page = await Build().ExecuteAsync(
+            new SearchMessagesParameters("текст", null, null, null, null, null, null, null, null),
+            Caller, default);
+
+        page.Items.Should().ContainSingle();
+        var preview = page.Items[0].ConversationPreview;
+        preview.Type.Should().Be(ConversationType.Direct);
+        preview.PeerUserId.Should().Be(Peer);
+        preview.Title.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Execute_HighlightedSnippet_GeneratedForEachHit()
+    {
+        var conv = Conversation.OpenDirect(Caller, Peer, Now);
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { conv.Id });
+        _conversations.GetByIdsAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { conv });
+
+        var body = new string('x', 60) + " квантовая " + new string('y', 60);
+        var msg = Message.Send(Guid.NewGuid(), conv.Id, Peer, body, Array.Empty<Attachment>(), "c1", Now);
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new[] { new MessageSearchHit(msg, 1.0) });
+
+        var page = await Build().ExecuteAsync(
+            new SearchMessagesParameters("квантовая", null, null, null, null, null, null, null, null),
+            Caller, default);
+
+        page.Items.Should().ContainSingle()
+            .Which.HighlightedSnippet.Should().Contain("квантовая");
+    }
+
+    [Fact]
+    public async Task Execute_DecodesIncomingCursor_AndPassesItDownstream()
+    {
+        var conv = Conversation.OpenDirect(Caller, Peer, Now);
+        _conversations.GetUserConversationIdsAsync(Caller, Arg.Any<CancellationToken>())
+            .Returns(new[] { conv.Id });
+        _messages.SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Any<MessageSearchCursor?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MessageSearchHit>());
+
+        var inbound = new MessageSearchCursor(2.5, Now, Guid.NewGuid());
+        var encoded = CursorCodec.EncodeMessageSearch(inbound);
+
+        await Build().ExecuteAsync(
+            new SearchMessagesParameters("term", null, null, null, null, null, null, encoded, null),
+            Caller, default);
+
+        await _messages.Received(1).SearchAsync(
+            Arg.Any<MessageSearchCriteria>(),
+            Arg.Any<IReadOnlyList<string>>(),
+            Arg.Is<MessageSearchCursor?>(c => c.HasValue && c.Value.MessageId == inbound.MessageId),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes #213

## Что сделано

- Полнотекстовый поиск по истории сообщений на MongoDB text index (`default_language: "russian"` со Snowball-стеммером, фолбэк на `"none"` при недоступности).
- `GET /api/v1/chat/search?q=&conversationId=&senderId=&from=&to=&hasAttachments=&attachmentType=&cursor=&limit=` с cursor-пагинацией и базовым highlighting (±30 символов вокруг первого совпадения).
- Access control: ищем только в чатах, где caller — участник; outside-scope `conversationId` возвращает пустую страницу, а не 403 (не утечь metadata).
- Per-user rate limit 30 req/min — Redis-backed fixed window, добавлен в `BuildingBlocks/Idempotency`. На превышении — 429 + `Retry-After`.
- Aggregate-pipeline в `MessageRepository.SearchAsync`: `$text` + filters → `$addFields _score` → cursor predicate `(score, createdAt, _id)` → `$sort` desc → `$limit`. Thread replies исключены (как и в `ListByConversationAsync`).
- README обновлён секцией "Message search — design notes (#213)".

## Производительность

`SearchPerformanceTests` (Category=Performance) на 100k сообщений в 50 conversations:
- **p50 = 73ms**, **p95 = 86ms**, max = 95ms за 100 итераций
- Acceptance: p95 < 500ms — запас ×6

## Отступления от плана (одобрены при ревью плана)

- Rate limiter Redis-backed (не in-memory) — консистентно с существующим `RedisIdempotencyStore`.
- Тесты rate limiter и repo-search — integration вместо unit (нет проекта `BuildingBlocks.Idempotency.UnitTests`, и он не нужен сейчас).
- Perf-тест зовёт `SearchMessagesQuery.ExecuteAsync` напрямую, минуя HTTP — иначе 30/min limit не пропускает 100 итераций. Endpoint+limiter покрыты отдельно в `SearchEndpointsTests`.

## Как проверить

1. `dotnet build` — без ошибок (есть pre-existing EF warning в `MediaService.UnitTests`, не из этого PR).
2. `dotnet test tests/unit/ChatService.UnitTests` — 206/206 ✅ (включая 13 snippet, 8 query, 5 cursor — новые).
3. `dotnet test tests/integration/ChatService.IntegrationTests --filter "Category!=Performance"` — мои тесты (RateLimiter 3, MongoIndexInitializer +1, MessageRepositorySearchTests 9, ConversationRepositoryTests +3, SearchEndpointsTests 10) стабильны в изоляции. В полном прогоне иногда флакает 1 тест — pre-existing инфраструктурный флак, не из этого PR (на разных прогонах падают разные тесты, в том числе чужие `ThreadEndpointsTests`/`ChatHubPinningTests`).
4. `dotnet test tests/integration/ChatService.IntegrationTests --filter "Category=Performance"` — perf p95 < 500ms на 100k сообщений.
5. Smoke: запустить ChatService.Api, в логах `MongoIndexInitializer` должна появиться `ix_messages_body_text` (либо warning о фолбэке на `"none"`). Через JWT попробовать `GET /api/v1/chat/search?q=...&limit=10` — увидеть `score`, `highlightedSnippet`, `nextCursor`.

## Acceptance criteria

- [x] Юзер видит только совпадения в своих чатах → `Get_Search_ReturnsHitsOnlyFromCallerConversations`
- [x] Фильтры: sender / conversation / date / attachments → 5 тестов в `MessageRepositorySearchTests` + `Get_Search_FiltersBySender`
- [x] Pagination стабильна (нет дублей и пропусков) → `Get_Search_PaginatesViaCursor` + `SearchAsync_PaginatesViaCursorWithoutDuplicates`
- [x] p95 < 500ms на 100k → `SearchPerformanceTests` (p95=86ms)
- [x] Rate limit предотвращает abuse → `Get_Search_OverRateLimit_Returns429`
- [x] Покрытие тестами → 57 новых тестов, integration + unit