### PR TITLE
feat(#215): ApiGateway routes & SignalR proxy for new services

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />

--- a/Urfu.Link.slnx
+++ b/Urfu.Link.slnx
@@ -10,6 +10,7 @@
   </Folder>
   <Folder Name="/src/Gateway/">
     <Project Path="src/Gateway/ApiGateway/ApiGateway.csproj" />
+    <Project Path="src/Gateway/ApiGateway.Tests/ApiGateway.Tests.csproj" />
   </Folder>
   <Folder Name="/src/Services/" />
   <Folder Name="/src/Services/Call/">

--- a/src/BuildingBlocks/ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/src/BuildingBlocks/ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -42,8 +42,17 @@ public static class ServiceDefaultsExtensions
         app.UseAuthentication();
         app.UseAuthorization();
 
-        app.MapHealthChecks("/health/live", new HealthCheckOptions());
-        app.MapHealthChecks("/health/ready", new HealthCheckOptions());
+        // Liveness must not depend on external resources — kubelet liveness failures restart the pod.
+        // Readiness aggregates checks tagged "ready" (e.g. SignalR Redis backplane); a degraded
+        // dependency takes the pod out of rotation but does not trigger a restart.
+        app.MapHealthChecks("/health/live", new HealthCheckOptions
+        {
+            Predicate = _ => false,
+        });
+        app.MapHealthChecks("/health/ready", new HealthCheckOptions
+        {
+            Predicate = check => check.Tags.Contains("ready"),
+        });
         app.MapOpenApi();
 
         return app;

--- a/src/BuildingBlocks/ServiceDefaults/SignalRBackplaneHealthCheck.cs
+++ b/src/BuildingBlocks/ServiceDefaults/SignalRBackplaneHealthCheck.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace Urfu.Link.BuildingBlocks.ServiceDefaults;
+
+/// <summary>
+/// Reports whether the Redis connection underlying the SignalR backplane is established.
+/// SignalR clients can connect to this replica regardless of backplane state, but broadcasts
+/// will not propagate cross-replica until the connection is up — so the service must not be
+/// marked Ready until the backplane is connected.
+/// </summary>
+public sealed class SignalRBackplaneHealthCheck(IConnectionMultiplexer multiplexer) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (multiplexer.IsConnected)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"Redis backplane connected ({multiplexer.GetEndPoints().Length} endpoint(s))."));
+        }
+
+        return Task.FromResult(HealthCheckResult.Unhealthy(
+            "Redis backplane disconnected — SignalR broadcasts will not propagate cross-replica."));
+    }
+}
+
+public static class SignalRBackplaneHealthCheckExtensions
+{
+    /// <summary>
+    /// Registers a readiness check that reports Unhealthy while the SignalR Redis backplane
+    /// connection is not established. Reuses the singleton <see cref="IConnectionMultiplexer"/>
+    /// already wired by <see cref="ServiceDefaultsExtensions.AddServiceDefaults"/> via
+    /// <c>AddIdempotency</c>.
+    /// </summary>
+    public static IHealthChecksBuilder AddSignalRBackplaneHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "signalr-backplane")
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new SignalRBackplaneHealthCheck(sp.GetRequiredService<IConnectionMultiplexer>()),
+            HealthStatus.Unhealthy,
+            ["ready"]));
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/ApiGateway.Tests.csproj
+++ b/src/Gateway/ApiGateway.Tests/ApiGateway.Tests.csproj
@@ -6,8 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Test naming convention uses underscores; null validation is unnecessary in test code -->
-    <NoWarn>$(NoWarn);CA1707;CA1062</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CA1062;CA1001;CA2234</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" />

--- a/src/Gateway/ApiGateway.Tests/HealthCheckIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/HealthCheckIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using ApiGateway.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public sealed class HealthCheckIntegrationTests : IAsyncLifetime
+{
+    private StubDownstreamServer _userStub = null!;
+    private StubDownstreamServer _chatStub = null!;
+    private GatewayTestFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _userStub = await StubDownstreamServer.StartAsync();
+        _chatStub = await StubDownstreamServer.StartAsync();
+
+        _factory = new GatewayTestFactory(
+            new Dictionary<string, string>
+            {
+                ["user-cluster"] = _userStub.BaseUrl,
+                ["chat-cluster"] = _chatStub.BaseUrl,
+                ["media-cluster"] = _userStub.BaseUrl,
+                ["presence-cluster"] = _userStub.BaseUrl,
+                ["notification-cluster"] = _userStub.BaseUrl,
+                ["call-cluster"] = _userStub.BaseUrl,
+                ["discipline-cluster"] = _userStub.BaseUrl,
+            },
+            extraConfiguration: new Dictionary<string, string?>
+            {
+                // Enable active checks at a high cadence so the test does not hang.
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Enabled"] = "true",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Interval"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Timeout"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Path"] = "/health/ready",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Policy"] = "ConsecutiveFailures",
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _chatStub.DisposeAsync();
+        await _userStub.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Live_AlwaysReturns200_RegardlessOfDownstream()
+    {
+        using var response = await _client.GetAsync("/health/live");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Ready_ReturnsHealthy_WhenAllDownstreamReachable()
+    {
+        using var response = await _client.GetAsync("/health/ready");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/HealthCheckIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/HealthCheckIntegrationTests.cs
@@ -62,4 +62,54 @@ public sealed class HealthCheckIntegrationTests : IAsyncLifetime
         using var response = await _client.GetAsync("/health/ready");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task Ready_ReturnsServiceUnavailable_WhenAnyClusterHasNoUsableDestinations()
+    {
+        // Active YARP probes mark the destination Unhealthy after one failure round-trip.
+        // We point user-cluster at an unreachable endpoint, then wait until a probe round runs.
+        var unreachableFactory = new GatewayTestFactory(
+            new Dictionary<string, string>
+            {
+                ["user-cluster"] = "http://127.0.0.1:1",
+                ["chat-cluster"] = _chatStub.BaseUrl,
+                ["media-cluster"] = _chatStub.BaseUrl,
+                ["presence-cluster"] = _chatStub.BaseUrl,
+                ["notification-cluster"] = _chatStub.BaseUrl,
+                ["call-cluster"] = _chatStub.BaseUrl,
+                ["discipline-cluster"] = _chatStub.BaseUrl,
+            },
+            extraConfiguration: new Dictionary<string, string?>
+            {
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Enabled"] = "true",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Interval"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Timeout"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Path"] = "/health/ready",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Policy"] = "ConsecutiveFailures",
+            });
+        await using var _ = unreachableFactory;
+        using var unreachableClient = unreachableFactory.CreateClient();
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            for (var attempt = 0; attempt < 10; attempt++)
+            {
+                response?.Dispose();
+                response = await unreachableClient.GetAsync("/health/ready");
+                if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+                {
+                    break;
+                }
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+            }
+
+            response!.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
+                "active probes mark unreachable user-cluster Unhealthy and the readiness check aggregates that into 503");
+        }
+        finally
+        {
+            response?.Dispose();
+        }
+    }
 }

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/GatewayTestFactory.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/GatewayTestFactory.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+
+namespace ApiGateway.Tests.Infrastructure;
+
+/// <summary>
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> wrapper that wires the API Gateway against
+/// arbitrary downstream URLs, swaps JWT auth for <see cref="TestAuthHandler"/>, and stubs out Redis-backed
+/// session revocation. Per-cluster active health checks are disabled by default so that probe traffic
+/// does not interfere with assertions.
+/// </summary>
+public sealed class GatewayTestFactory : WebApplicationFactory<Program>
+{
+    private readonly IReadOnlyDictionary<string, string> _clusterAddresses;
+    private readonly IReadOnlyDictionary<string, string?>? _extraConfiguration;
+
+    public GatewayTestFactory(
+        IReadOnlyDictionary<string, string> clusterAddresses,
+        IReadOnlyDictionary<string, string?>? extraConfiguration = null)
+    {
+        _clusterAddresses = clusterAddresses;
+        _extraConfiguration = extraConfiguration;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            var overrides = new Dictionary<string, string?>
+            {
+                ["Cors:AllowedOrigins:0"] = "https://urfu-link.ghjc.ru",
+                ["Auth:Authority"] = "http://localhost:9999/realms/test",
+                ["Observability:Otlp:Endpoint"] = "http://localhost:9999",
+                ["Infrastructure:Redis:Configuration"] = "localhost:6379",
+            };
+
+            foreach (var (cluster, url) in _clusterAddresses)
+            {
+                overrides[$"ReverseProxy:Clusters:{cluster}:Destinations:d1:Address"] = url;
+                overrides[$"ReverseProxy:Clusters:{cluster}:HealthCheck:Active:Enabled"] = "false";
+            }
+
+            if (_extraConfiguration is not null)
+            {
+                foreach (var (key, value) in _extraConfiguration)
+                {
+                    overrides[key] = value;
+                }
+            }
+
+            config.AddInMemoryCollection(overrides);
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication()
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                    TestAuthHandler.SchemeName,
+                    _ => { });
+
+            services.PostConfigure<AuthenticationOptions>(options =>
+            {
+                options.DefaultScheme = TestAuthHandler.SchemeName;
+                options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+                options.DefaultForbidScheme = TestAuthHandler.SchemeName;
+            });
+
+            services.RemoveAll<ISessionRevocationStore>();
+            services.AddSingleton<ISessionRevocationStore, StubSessionRevocationStore>();
+        });
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/GatewayTestFactory.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/GatewayTestFactory.cs
@@ -71,7 +71,6 @@ public sealed class GatewayTestFactory : WebApplicationFactory<Program>
                 options.DefaultScheme = TestAuthHandler.SchemeName;
                 options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
                 options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
-                options.DefaultForbidScheme = TestAuthHandler.SchemeName;
             });
 
             services.RemoveAll<ISessionRevocationStore>();

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/StubDownstreamServer.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/StubDownstreamServer.cs
@@ -14,62 +14,42 @@ namespace ApiGateway.Tests.Infrastructure;
 /// <summary>
 /// Real Kestrel-backed HTTP server used as a downstream stub in YARP integration tests.
 /// Records every received request and lets the test assert on Method, Path, Headers, QueryString, Body.
+/// Recorded requests and the optional response handler are stored in DI as singletons so the request
+/// pipeline does not capture a closure on a partially-initialised <see cref="StubDownstreamServer"/>.
 /// </summary>
 public sealed class StubDownstreamServer : IAsyncDisposable
 {
     private readonly WebApplication _app;
+    private readonly StubState _state;
 
     public string BaseUrl { get; }
 
-    public ConcurrentQueue<RecordedRequest> Requests { get; } = new();
+    public IReadOnlyCollection<RecordedRequest> Requests => _state.Requests;
 
-    public Func<HttpContext, RecordedRequest, Task>? ResponseHandler { get; set; }
+    public Func<HttpContext, RecordedRequest, Task>? ResponseHandler
+    {
+        get => _state.ResponseHandler;
+        set => _state.ResponseHandler = value;
+    }
 
-    private StubDownstreamServer(WebApplication app, string baseUrl)
+    private StubDownstreamServer(WebApplication app, string baseUrl, StubState state)
     {
         _app = app;
         BaseUrl = baseUrl;
+        _state = state;
     }
 
     public static async Task<StubDownstreamServer> StartAsync()
     {
+        var state = new StubState();
+
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddSingleton(state);
 
         var app = builder.Build();
-
-        StubDownstreamServer? instance = null;
-
-        app.Run(async ctx =>
-        {
-            using var ms = new MemoryStream();
-            await ctx.Request.Body.CopyToAsync(ms).ConfigureAwait(false);
-            var body = Encoding.UTF8.GetString(ms.ToArray());
-            var headers = ctx.Request.Headers
-                .ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-
-            var recorded = new RecordedRequest(
-                ctx.Request.Method,
-                ctx.Request.Path.Value ?? string.Empty,
-                ctx.Request.QueryString.Value ?? string.Empty,
-                headers,
-                body);
-
-            instance!.Requests.Enqueue(recorded);
-
-            if (instance.ResponseHandler is not null)
-            {
-                await instance.ResponseHandler(ctx, recorded).ConfigureAwait(false);
-                return;
-            }
-
-            ctx.Response.StatusCode = StatusCodes.Status200OK;
-            ctx.Response.ContentType = "application/json";
-            await ctx.Response
-                .WriteAsync($"{{\"ok\":true,\"path\":\"{recorded.Path}\"}}")
-                .ConfigureAwait(false);
-        });
+        app.Run(HandleRequestAsync);
 
         await app.StartAsync().ConfigureAwait(false);
 
@@ -80,15 +60,52 @@ public sealed class StubDownstreamServer : IAsyncDisposable
             ?.Addresses
             ?? throw new InvalidOperationException("Stub downstream failed to expose any addresses.");
 
-        var url = addresses.First();
-        instance = new StubDownstreamServer(app, url);
-        return instance;
+        return new StubDownstreamServer(app, addresses.First(), state);
+    }
+
+    private static async Task HandleRequestAsync(HttpContext ctx)
+    {
+        var state = ctx.RequestServices.GetRequiredService<StubState>();
+
+        using var ms = new MemoryStream();
+        await ctx.Request.Body.CopyToAsync(ms).ConfigureAwait(false);
+        var body = Encoding.UTF8.GetString(ms.ToArray());
+        var headers = ctx.Request.Headers
+            .ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+
+        var recorded = new RecordedRequest(
+            ctx.Request.Method,
+            ctx.Request.Path.Value ?? string.Empty,
+            ctx.Request.QueryString.Value ?? string.Empty,
+            headers,
+            body);
+
+        state.Requests.Enqueue(recorded);
+
+        var handler = state.ResponseHandler;
+        if (handler is not null)
+        {
+            await handler(ctx, recorded).ConfigureAwait(false);
+            return;
+        }
+
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        ctx.Response.ContentType = "application/json";
+        await ctx.Response
+            .WriteAsync($"{{\"ok\":true,\"path\":\"{recorded.Path}\"}}")
+            .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
         await _app.StopAsync().ConfigureAwait(false);
         await _app.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed class StubState
+    {
+        public ConcurrentQueue<RecordedRequest> Requests { get; } = new();
+        public Func<HttpContext, RecordedRequest, Task>? ResponseHandler { get; set; }
     }
 }
 

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/StubDownstreamServer.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/StubDownstreamServer.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ApiGateway.Tests.Infrastructure;
+
+/// <summary>
+/// Real Kestrel-backed HTTP server used as a downstream stub in YARP integration tests.
+/// Records every received request and lets the test assert on Method, Path, Headers, QueryString, Body.
+/// </summary>
+public sealed class StubDownstreamServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    public string BaseUrl { get; }
+
+    public ConcurrentQueue<RecordedRequest> Requests { get; } = new();
+
+    public Func<HttpContext, RecordedRequest, Task>? ResponseHandler { get; set; }
+
+    private StubDownstreamServer(WebApplication app, string baseUrl)
+    {
+        _app = app;
+        BaseUrl = baseUrl;
+    }
+
+    public static async Task<StubDownstreamServer> StartAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        var app = builder.Build();
+
+        StubDownstreamServer? instance = null;
+
+        app.Run(async ctx =>
+        {
+            using var ms = new MemoryStream();
+            await ctx.Request.Body.CopyToAsync(ms).ConfigureAwait(false);
+            var body = Encoding.UTF8.GetString(ms.ToArray());
+            var headers = ctx.Request.Headers
+                .ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+
+            var recorded = new RecordedRequest(
+                ctx.Request.Method,
+                ctx.Request.Path.Value ?? string.Empty,
+                ctx.Request.QueryString.Value ?? string.Empty,
+                headers,
+                body);
+
+            instance!.Requests.Enqueue(recorded);
+
+            if (instance.ResponseHandler is not null)
+            {
+                await instance.ResponseHandler(ctx, recorded).ConfigureAwait(false);
+                return;
+            }
+
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response
+                .WriteAsync($"{{\"ok\":true,\"path\":\"{recorded.Path}\"}}")
+                .ConfigureAwait(false);
+        });
+
+        await app.StartAsync().ConfigureAwait(false);
+
+        var addresses = app.Services
+            .GetRequiredService<IServer>()
+            .Features
+            .Get<IServerAddressesFeature>()
+            ?.Addresses
+            ?? throw new InvalidOperationException("Stub downstream failed to expose any addresses.");
+
+        var url = addresses.First();
+        instance = new StubDownstreamServer(app, url);
+        return instance;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync().ConfigureAwait(false);
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+public sealed record RecordedRequest(
+    string Method,
+    string Path,
+    string QueryString,
+    IReadOnlyDictionary<string, string> Headers,
+    string Body);

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/StubSessionRevocationStore.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/StubSessionRevocationStore.cs
@@ -1,0 +1,19 @@
+using Urfu.Link.BuildingBlocks.SessionRevocation;
+
+namespace ApiGateway.Tests.Infrastructure;
+
+/// <summary>
+/// In-memory <see cref="ISessionRevocationStore"/> stub: nothing is ever revoked.
+/// Replaces the Redis-backed store in integration tests so the gateway can run without Redis.
+/// </summary>
+public sealed class StubSessionRevocationStore : ISessionRevocationStore
+{
+    public Task RevokeAsync(string userId, string callerSessionId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task RevokeSingleAsync(string userId, string sessionId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<bool> IsRevokedAsync(string userId, string sessionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+}

--- a/src/Gateway/ApiGateway.Tests/Infrastructure/TestAuthHandler.cs
+++ b/src/Gateway/ApiGateway.Tests/Infrastructure/TestAuthHandler.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ApiGateway.Tests.Infrastructure;
+
+/// <summary>
+/// Minimal JWT-Bearer-shaped auth scheme for tests.
+/// Reads <c>Authorization: Bearer &lt;sub&gt;</c> and produces a principal with <c>sub</c> claim equal to the token.
+/// </summary>
+public sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "TestBearer";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("Authorization", out var header))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var token = header.ToString();
+        const string prefix = "Bearer ";
+        if (!token.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var sub = token[prefix.Length..].Trim();
+        if (string.IsNullOrEmpty(sub))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Empty token"));
+        }
+
+        var claims = new[]
+        {
+            new Claim("sub", sub),
+            new Claim(ClaimTypes.NameIdentifier, sub),
+            new Claim("sid", $"sid-{sub}"),
+        };
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/RateLimitIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/RateLimitIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Net.Http.Headers;
+using ApiGateway.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public sealed class RateLimitIntegrationTests : IAsyncLifetime
+{
+    private StubDownstreamServer _chatStub = null!;
+    private StubDownstreamServer _mediaStub = null!;
+    private GatewayTestFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _chatStub = await StubDownstreamServer.StartAsync();
+        _mediaStub = await StubDownstreamServer.StartAsync();
+
+        _factory = new GatewayTestFactory(new Dictionary<string, string>
+        {
+            ["chat-cluster"] = _chatStub.BaseUrl,
+            ["media-cluster"] = _mediaStub.BaseUrl,
+        });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _mediaStub.DisposeAsync();
+        await _chatStub.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ChatSend_Returns429_AfterPermitLimit()
+    {
+        const string sub = "user-rate-1";
+        const int limit = 60;
+        var statuses = new List<HttpStatusCode>();
+
+        for (var i = 0; i < limit + 5; i++)
+        {
+            using var request = BuildSendMessage(sub, conversationId: "conv-1");
+            using var response = await _client.SendAsync(request);
+            statuses.Add(response.StatusCode);
+        }
+
+        statuses.Take(limit).Should().AllSatisfy(s => s.Should().Be(HttpStatusCode.OK));
+        statuses.Skip(limit).Should().Contain(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task ChatSend_RateLimit_PartitionedBySub()
+    {
+        const int limit = 60;
+
+        for (var i = 0; i < limit; i++)
+        {
+            using var exhausting = BuildSendMessage("user-A", conversationId: "conv-1");
+            using var _ = await _client.SendAsync(exhausting);
+        }
+
+        using var anotherUserRequest = BuildSendMessage("user-B", conversationId: "conv-1");
+        using var anotherResponse = await _client.SendAsync(anotherUserRequest);
+
+        anotherResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "rate limit partitions by Keycloak sub claim, so user-B has its own bucket");
+    }
+
+    [Fact]
+    public async Task MediaUploadInit_Returns429_AfterStricterLimit()
+    {
+        const string sub = "user-rate-media";
+        const int limit = 30;
+        var statuses = new List<HttpStatusCode>();
+
+        for (var i = 0; i < limit + 5; i++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/api/media/upload/init")
+            {
+                Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sub);
+
+            using var response = await _client.SendAsync(request);
+            statuses.Add(response.StatusCode);
+        }
+
+        statuses.Take(limit).Should().AllSatisfy(s => s.Should().Be(HttpStatusCode.OK));
+        statuses.Skip(limit).Should().Contain(HttpStatusCode.TooManyRequests);
+    }
+
+    private static HttpRequestMessage BuildSendMessage(string sub, string conversationId)
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/chat/conversations/{conversationId}/messages")
+        {
+            Content = new StringContent("{\"text\":\"hi\"}", System.Text.Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sub);
+        return request;
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/RateLimitIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/RateLimitIntegrationTests.cs
@@ -64,11 +64,17 @@ public sealed class RateLimitIntegrationTests : IAsyncLifetime
             using var _ = await _client.SendAsync(exhausting);
         }
 
-        using var anotherUserRequest = BuildSendMessage("user-B", conversationId: "conv-1");
-        using var anotherResponse = await _client.SendAsync(anotherUserRequest);
+        using var userARequest = BuildSendMessage("user-A", conversationId: "conv-1");
+        using var userAOverflow = await _client.SendAsync(userARequest);
 
-        anotherResponse.StatusCode.Should().Be(HttpStatusCode.OK,
-            "rate limit partitions by Keycloak sub claim, so user-B has its own bucket");
+        userAOverflow.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "user-A has exhausted its bucket — proves the policy is enforced");
+
+        using var userBRequest = BuildSendMessage("user-B", conversationId: "conv-1");
+        using var userBResponse = await _client.SendAsync(userBRequest);
+
+        userBResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "user-B has its own bucket — proves partitioning by Keycloak sub claim");
     }
 
     [Fact]

--- a/src/Gateway/ApiGateway.Tests/RoutingIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/RoutingIntegrationTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Headers;
+using ApiGateway.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace ApiGateway.Tests;
+
+public sealed class RoutingIntegrationTests : IAsyncLifetime
+{
+    private StubDownstreamServer _userStub = null!;
+    private StubDownstreamServer _chatStub = null!;
+    private GatewayTestFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _userStub = await StubDownstreamServer.StartAsync();
+        _chatStub = await StubDownstreamServer.StartAsync();
+
+        _factory = new GatewayTestFactory(new Dictionary<string, string>
+        {
+            ["user-cluster"] = _userStub.BaseUrl,
+            ["chat-cluster"] = _chatStub.BaseUrl,
+        });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _chatStub.DisposeAsync();
+        await _userStub.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task RestRequest_ForwardsCorrelationIdAndAuthorization_ToDownstream()
+    {
+        const string correlationId = "test-correlation-abc";
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+        request.Headers.Add("X-Correlation-Id", correlationId);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "user-42");
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _userStub.Requests.Should().HaveCount(1);
+        var recorded = _userStub.Requests.First();
+        recorded.Path.Should().Be("/api/v1/me");
+        recorded.Headers.Should().ContainKey("X-Correlation-Id")
+            .WhoseValue.Should().Be(correlationId);
+        recorded.Headers.Should().ContainKey("Authorization")
+            .WhoseValue.Should().Be("Bearer user-42");
+
+        response.Headers.GetValues("X-Correlation-Id").Should().Contain(correlationId);
+    }
+
+    [Fact]
+    public async Task RestRequest_GeneratesCorrelationId_WhenAbsentFromClient()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "user-42");
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _userStub.Requests.Should().HaveCount(1);
+        var recorded = _userStub.Requests.First();
+        recorded.Headers.Should().ContainKey("X-Correlation-Id");
+        recorded.Headers["X-Correlation-Id"].Should().NotBeNullOrWhiteSpace();
+        response.Headers.GetValues("X-Correlation-Id").Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task RestRequest_WithoutAuth_Returns401()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/users/me");
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        _userStub.Requests.Should().BeEmpty("authorization is enforced at the gateway for REST routes");
+    }
+
+    [Fact]
+    public async Task DirectHubRoute_ChatNegotiate_ProxiesWithoutGatewayAuth()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/chat/negotiate?access_token=user-42")
+        {
+            Content = new StringContent(string.Empty),
+        };
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _chatStub.Requests.Should().HaveCount(1);
+        var recorded = _chatStub.Requests.First();
+        recorded.Path.Should().Be("/hubs/chat/negotiate");
+        recorded.QueryString.Should().Contain("access_token=user-42");
+    }
+
+    [Fact]
+    public async Task DirectHubRoute_PresenceConnect_ProxiesWebSocketHandshake()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/presence/negotiate")
+        {
+            Content = new StringContent(string.Empty),
+        };
+
+        // chat stub also serves as presence stub for this test (same shape).
+        // Switch the factory cluster mapping when we need both Hubs in one test.
+        var presenceFactory = new GatewayTestFactory(new Dictionary<string, string>
+        {
+            ["presence-cluster"] = _chatStub.BaseUrl,
+        });
+        using var presenceClient = presenceFactory.CreateClient();
+
+        var response = await presenceClient.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _chatStub.Requests.Should().Contain(r => r.Path == "/hubs/presence/negotiate");
+
+        await presenceFactory.DisposeAsync();
+    }
+}

--- a/src/Gateway/ApiGateway.Tests/RoutingIntegrationTests.cs
+++ b/src/Gateway/ApiGateway.Tests/RoutingIntegrationTests.cs
@@ -102,16 +102,30 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task DirectHubRoute_PresenceConnect_ProxiesWebSocketHandshake()
+    public async Task HubRoute_WithoutAccessToken_Returns401_BeforeDownstream()
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/presence/negotiate")
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/chat/negotiate")
         {
             Content = new StringContent(string.Empty),
         };
 
-        // chat stub also serves as presence stub for this test (same shape).
-        // Switch the factory cluster mapping when we need both Hubs in one test.
-        var presenceFactory = new GatewayTestFactory(new Dictionary<string, string>
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.WwwAuthenticate.ToString().Should().Contain("Bearer");
+        _chatStub.Requests.Should().BeEmpty(
+            "anonymous hub traffic is rejected at the gateway before reaching downstream");
+    }
+
+    [Fact]
+    public async Task DirectHubRoute_PresenceConnect_ProxiesWebSocketHandshake()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/presence/negotiate?access_token=user-42")
+        {
+            Content = new StringContent(string.Empty),
+        };
+
+        await using var presenceFactory = new GatewayTestFactory(new Dictionary<string, string>
         {
             ["presence-cluster"] = _chatStub.BaseUrl,
         });
@@ -121,7 +135,5 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         _chatStub.Requests.Should().Contain(r => r.Path == "/hubs/presence/negotiate");
-
-        await presenceFactory.DisposeAsync();
     }
 }

--- a/src/Gateway/ApiGateway/HealthChecks/YarpClusterStateRegistry.cs
+++ b/src/Gateway/ApiGateway/HealthChecks/YarpClusterStateRegistry.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using Yarp.ReverseProxy.Model;
+
+namespace Urfu.Link.Gateway.ApiGateway.HealthChecks;
+
+/// <summary>
+/// Singleton sink for YARP cluster state notifications. Captures clusters from
+/// <see cref="IClusterChangeListener"/> events so readiness checks can read live destination
+/// health (driven by YARP active probes) without issuing their own HTTP traffic.
+/// </summary>
+public sealed class YarpClusterStateRegistry : IClusterChangeListener
+{
+    private readonly ConcurrentDictionary<string, ClusterState> _clusters = new(StringComparer.Ordinal);
+
+    public IReadOnlyCollection<ClusterState> Clusters => (IReadOnlyCollection<ClusterState>)_clusters.Values;
+
+    public void OnClusterAdded(ClusterState cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        _clusters[cluster.ClusterId] = cluster;
+    }
+
+    public void OnClusterChanged(ClusterState cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        _clusters[cluster.ClusterId] = cluster;
+    }
+
+    public void OnClusterRemoved(ClusterState cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        _clusters.TryRemove(cluster.ClusterId, out _);
+    }
+}

--- a/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
+++ b/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Yarp.ReverseProxy.Configuration;
+
+namespace Urfu.Link.Gateway.ApiGateway.HealthChecks;
+
+/// <summary>
+/// Aggregates downstream cluster availability into a single readiness signal.
+/// For each cluster, probes <c>/health/ready</c> on every configured destination; cluster is considered usable if at
+/// least one destination responded within the timeout. Result is cached to amortise overhead across kubelet probes.
+/// </summary>
+public sealed class YarpDestinationsHealthCheck : IHealthCheck, IDisposable
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly IProxyConfigProvider _configProvider;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+    private DateTimeOffset _cacheExpiresAt = DateTimeOffset.MinValue;
+    private HealthCheckResult _cachedResult = HealthCheckResult.Healthy("not yet probed");
+
+    public YarpDestinationsHealthCheck(
+        IProxyConfigProvider configProvider,
+        IHttpClientFactory httpClientFactory)
+    {
+        _configProvider = configProvider;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (DateTimeOffset.UtcNow < _cacheExpiresAt)
+        {
+            return _cachedResult;
+        }
+
+        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (DateTimeOffset.UtcNow < _cacheExpiresAt)
+            {
+                return _cachedResult;
+            }
+
+            _cachedResult = await ProbeAsync(cancellationToken).ConfigureAwait(false);
+            _cacheExpiresAt = DateTimeOffset.UtcNow.Add(CacheDuration);
+            return _cachedResult;
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task<HealthCheckResult> ProbeAsync(CancellationToken cancellationToken)
+    {
+        var config = _configProvider.GetConfig();
+        var clusters = config.Clusters;
+        if (clusters is null || clusters.Count == 0)
+        {
+            return HealthCheckResult.Healthy("No clusters configured.");
+        }
+
+        var unhealthy = new List<string>();
+        var probes = clusters
+            .Select(cluster => ProbeClusterAsync(cluster, cancellationToken))
+            .ToArray();
+
+        var results = await Task.WhenAll(probes).ConfigureAwait(false);
+        for (var i = 0; i < clusters.Count; i++)
+        {
+            if (!results[i])
+            {
+                unhealthy.Add(clusters[i].ClusterId);
+            }
+        }
+
+        if (unhealthy.Count == 0)
+        {
+            return HealthCheckResult.Healthy(
+                $"All {clusters.Count} downstream clusters have at least one reachable destination.");
+        }
+
+        return HealthCheckResult.Degraded(
+            $"Clusters with no reachable destinations: {string.Join(", ", unhealthy)}.",
+            data: new Dictionary<string, object> { ["unhealthyClusters"] = unhealthy });
+    }
+
+    private async Task<bool> ProbeClusterAsync(ClusterConfig cluster, CancellationToken cancellationToken)
+    {
+        var destinations = cluster.Destinations;
+        if (destinations is null || destinations.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var (_, destination) in destinations)
+        {
+            if (string.IsNullOrWhiteSpace(destination.Address))
+            {
+                continue;
+            }
+
+            if (await IsReachableAsync(destination.Address, cancellationToken).ConfigureAwait(false))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> IsReachableAsync(string address, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var baseUri))
+        {
+            return false;
+        }
+
+        var probeUri = new Uri(baseUri, "/health/ready");
+        using var client = _httpClientFactory.CreateClient();
+        client.Timeout = ProbeTimeout;
+
+        try
+        {
+            using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            probeCts.CancelAfter(ProbeTimeout);
+            using var response = await client
+                .GetAsync(probeUri, HttpCompletionOption.ResponseHeadersRead, probeCts.Token)
+                .ConfigureAwait(false);
+            return (int)response.StatusCode < 500;
+        }
+#pragma warning disable CA1031 // Health probes intentionally swallow exceptions to mark destination unhealthy.
+        catch
+#pragma warning restore CA1031
+        {
+            return false;
+        }
+    }
+
+    public void Dispose() => _refreshLock.Dispose();
+}

--- a/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
+++ b/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
@@ -1,110 +1,66 @@
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Model;
 
 namespace Urfu.Link.Gateway.ApiGateway.HealthChecks;
 
 /// <summary>
-/// Aggregates downstream cluster availability into a single readiness signal.
-/// For each cluster, probes <c>/health/ready</c> on every configured destination; cluster is considered usable if at
-/// least one destination responded within the timeout. Result is cached to amortise overhead across kubelet probes.
+/// Reads destination health populated by YARP active probes (configured per-cluster in
+/// <c>appsettings.json</c>) and aggregates it into a single readiness signal:
+/// <list type="bullet">
+///   <item><description><see cref="HealthStatus.Healthy"/> — every cluster has at least one destination whose Active or Passive health is not <see cref="DestinationHealth.Unhealthy"/>.</description></item>
+///   <item><description><see cref="HealthStatus.Unhealthy"/> — at least one cluster has no usable destinations.</description></item>
+/// </list>
+/// Probes themselves are owned by YARP (<c>HealthCheck.Active</c> in cluster config); this check
+/// does not issue HTTP traffic.
 /// </summary>
-public sealed class YarpDestinationsHealthCheck : IHealthCheck, IDisposable
+public sealed class YarpDestinationsHealthCheck(YarpClusterStateRegistry registry) : IHealthCheck
 {
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(2);
-
-    private readonly IProxyConfigProvider _configProvider;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly SemaphoreSlim _refreshLock = new(1, 1);
-
-    private DateTimeOffset _cacheExpiresAt = DateTimeOffset.MinValue;
-    private HealthCheckResult _cachedResult = HealthCheckResult.Healthy("not yet probed");
-
-    public YarpDestinationsHealthCheck(
-        IProxyConfigProvider configProvider,
-        IHttpClientFactory httpClientFactory)
-    {
-        _configProvider = configProvider;
-        _httpClientFactory = httpClientFactory;
-    }
-
-    public async Task<HealthCheckResult> CheckHealthAsync(
+    public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
-        if (DateTimeOffset.UtcNow < _cacheExpiresAt)
+        var clusters = registry.Clusters;
+        if (clusters.Count == 0)
         {
-            return _cachedResult;
-        }
-
-        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            if (DateTimeOffset.UtcNow < _cacheExpiresAt)
-            {
-                return _cachedResult;
-            }
-
-            _cachedResult = await ProbeAsync(cancellationToken).ConfigureAwait(false);
-            _cacheExpiresAt = DateTimeOffset.UtcNow.Add(CacheDuration);
-            return _cachedResult;
-        }
-        finally
-        {
-            _refreshLock.Release();
-        }
-    }
-
-    private async Task<HealthCheckResult> ProbeAsync(CancellationToken cancellationToken)
-    {
-        var config = _configProvider.GetConfig();
-        var clusters = config.Clusters;
-        if (clusters is null || clusters.Count == 0)
-        {
-            return HealthCheckResult.Healthy("No clusters configured.");
+            return Task.FromResult(HealthCheckResult.Healthy("No clusters configured."));
         }
 
         var unhealthy = new List<string>();
-        var probes = clusters
-            .Select(cluster => ProbeClusterAsync(cluster, cancellationToken))
-            .ToArray();
-
-        var results = await Task.WhenAll(probes).ConfigureAwait(false);
-        for (var i = 0; i < clusters.Count; i++)
+        foreach (var cluster in clusters)
         {
-            if (!results[i])
+            if (!HasUsableDestination(cluster))
             {
-                unhealthy.Add(clusters[i].ClusterId);
+                unhealthy.Add(cluster.ClusterId);
             }
         }
 
         if (unhealthy.Count == 0)
         {
-            return HealthCheckResult.Healthy(
-                $"All {clusters.Count} downstream clusters have at least one reachable destination.");
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"All {clusters.Count} downstream clusters have at least one usable destination."));
         }
 
-        return HealthCheckResult.Degraded(
-            $"Clusters with no reachable destinations: {string.Join(", ", unhealthy)}.",
-            data: new Dictionary<string, object> { ["unhealthyClusters"] = unhealthy });
+        var data = new Dictionary<string, object>
+        {
+            ["unhealthyClusters"] = unhealthy,
+        };
+        return Task.FromResult(HealthCheckResult.Unhealthy(
+            $"Clusters with no usable destinations: {string.Join(", ", unhealthy)}.",
+            data: data));
     }
 
-    private async Task<bool> ProbeClusterAsync(ClusterConfig cluster, CancellationToken cancellationToken)
+    private static bool HasUsableDestination(ClusterState cluster)
     {
-        var destinations = cluster.Destinations;
-        if (destinations is null || destinations.Count == 0)
+        if (cluster.Destinations.IsEmpty)
         {
             return false;
         }
 
-        foreach (var (_, destination) in destinations)
+        foreach (var destination in cluster.Destinations.Values)
         {
-            if (string.IsNullOrWhiteSpace(destination.Address))
-            {
-                continue;
-            }
-
-            if (await IsReachableAsync(destination.Address, cancellationToken).ConfigureAwait(false))
+            var health = destination.Health;
+            if (health.Active != DestinationHealth.Unhealthy
+                && health.Passive != DestinationHealth.Unhealthy)
             {
                 return true;
             }
@@ -112,34 +68,4 @@ public sealed class YarpDestinationsHealthCheck : IHealthCheck, IDisposable
 
         return false;
     }
-
-    private async Task<bool> IsReachableAsync(string address, CancellationToken cancellationToken)
-    {
-        if (!Uri.TryCreate(address, UriKind.Absolute, out var baseUri))
-        {
-            return false;
-        }
-
-        var probeUri = new Uri(baseUri, "/health/ready");
-        using var client = _httpClientFactory.CreateClient();
-        client.Timeout = ProbeTimeout;
-
-        try
-        {
-            using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            probeCts.CancelAfter(ProbeTimeout);
-            using var response = await client
-                .GetAsync(probeUri, HttpCompletionOption.ResponseHeadersRead, probeCts.Token)
-                .ConfigureAwait(false);
-            return (int)response.StatusCode < 500;
-        }
-#pragma warning disable CA1031 // Health probes intentionally swallow exceptions to mark destination unhealthy.
-        catch
-#pragma warning restore CA1031
-        {
-            return false;
-        }
-    }
-
-    public void Dispose() => _refreshLock.Dispose();
 }

--- a/src/Gateway/ApiGateway/Middleware/HubAccessTokenPresenceMiddleware.cs
+++ b/src/Gateway/ApiGateway/Middleware/HubAccessTokenPresenceMiddleware.cs
@@ -1,0 +1,33 @@
+namespace Urfu.Link.Gateway.ApiGateway.Middleware;
+
+/// <summary>
+/// Defence-in-depth for SignalR hub routes (<c>/hubs/*</c>): the gateway cannot validate the JWT
+/// (downstream services accept it via <c>?access_token=</c> query parameter), but it can require
+/// the parameter to be present. Anonymous traffic that did not provide a token at all is rejected
+/// here with 401 Unauthorized, before it reaches downstream.
+/// </summary>
+public sealed class HubAccessTokenPresenceMiddleware(RequestDelegate next)
+{
+    private const string HubsPathSegment = "/hubs";
+    private const string AccessTokenQueryKey = "access_token";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Request.Path.StartsWithSegments(HubsPathSegment, StringComparison.Ordinal))
+        {
+            var hasAccessToken = context.Request.Query.TryGetValue(AccessTokenQueryKey, out var token)
+                && !string.IsNullOrWhiteSpace(token);
+
+            if (!hasAccessToken)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                context.Response.Headers["WWW-Authenticate"] = "Bearer";
+                return;
+            }
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/src/Gateway/ApiGateway/Middleware/SecurityHeadersMiddleware.cs
+++ b/src/Gateway/ApiGateway/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,33 @@
+namespace Urfu.Link.Gateway.ApiGateway.Middleware;
+
+/// <summary>
+/// Adds defensive HTTP response headers (no-sniff, frame deny, referrer policy, permissions policy).
+/// Cache-Control: no-store is applied to non-hub paths; SignalR transports manage their own caching semantics.
+/// HSTS is intentionally not emitted here — it is the responsibility of the edge proxy / ingress.
+/// </summary>
+public sealed class SecurityHeadersMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        context.Response.OnStarting(static state =>
+        {
+            var ctx = (HttpContext)state;
+            var headers = ctx.Response.Headers;
+            headers["X-Content-Type-Options"] = "nosniff";
+            headers["X-Frame-Options"] = "DENY";
+            headers["Referrer-Policy"] = "no-referrer";
+            headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()";
+
+            if (!ctx.Request.Path.StartsWithSegments("/hubs", StringComparison.Ordinal))
+            {
+                headers["Cache-Control"] = "no-store";
+            }
+
+            return Task.CompletedTask;
+        }, context);
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/src/Gateway/ApiGateway/Program.cs
+++ b/src/Gateway/ApiGateway/Program.cs
@@ -1,9 +1,11 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Security.Claims;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Yarp.ReverseProxy.Model;
 using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Observability;
 using Urfu.Link.BuildingBlocks.SessionRevocation;
@@ -41,78 +43,60 @@ builder.Services.AddResponseCompression(options =>
     options.Providers.Add<BrotliCompressionProvider>();
     options.Providers.Add<GzipCompressionProvider>();
     options.MimeTypes = ResponseCompressionDefaults.MimeTypes
-        .Concat(["application/json", "application/problem+json"]);
+        .Concat(["application/problem+json"]);
 });
-builder.Services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
-builder.Services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+builder.Services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Optimal);
+builder.Services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Optimal);
 
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
-    {
-        var partitionKey =
-            context.User.FindFirst("sub")?.Value
-            ?? context.Connection.RemoteIpAddress?.ToString()
-            ?? "anonymous";
-
-        return RateLimitPartition.GetTokenBucketLimiter(partitionKey, _ => new TokenBucketRateLimiterOptions
+        RateLimitPartition.GetTokenBucketLimiter(ResolvePartitionKey(context), _ => new TokenBucketRateLimiterOptions
         {
             TokenLimit = 200,
             TokensPerPeriod = 200,
             ReplenishmentPeriod = TimeSpan.FromSeconds(1),
             QueueLimit = 0,
             AutoReplenishment = true,
-        });
-    });
+        }));
 
     options.AddPolicy("chat-send", context =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
-            _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 60,
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-                AutoReplenishment = true,
-            }));
+        RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(context), _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 60,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            AutoReplenishment = true,
+        }));
 
     options.AddPolicy("media-upload", context =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
-            _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 30,
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-                AutoReplenishment = true,
-            }));
-
-    options.AddPolicy("search", context =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
-            _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 30,
-                Window = TimeSpan.FromMinutes(1),
-                QueueLimit = 0,
-                AutoReplenishment = true,
-            }));
+        RateLimitPartition.GetFixedWindowLimiter(ResolvePartitionKey(context), _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 30,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            AutoReplenishment = true,
+        }));
 });
 
 builder.Services
     .AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
-builder.Services.AddHttpClient();
+builder.Services.AddSingleton<YarpClusterStateRegistry>();
+builder.Services.AddSingleton<IClusterChangeListener>(sp =>
+    sp.GetRequiredService<YarpClusterStateRegistry>());
+builder.Services.AddSingleton<YarpDestinationsHealthCheck>();
 
 builder.Services
     .AddHealthChecks()
-    .AddCheck<YarpDestinationsHealthCheck>(
+    .Add(new HealthCheckRegistration(
         name: "yarp-destinations",
-        failureStatus: HealthStatus.Degraded,
-        tags: ["ready"]);
+        factory: sp => sp.GetRequiredService<YarpDestinationsHealthCheck>(),
+        failureStatus: HealthStatus.Unhealthy,
+        tags: ["ready"]));
 
 var app = builder.Build();
 
@@ -142,6 +126,10 @@ app.Use((context, next) =>
     return next();
 });
 
+// Defence in depth for SignalR hub routes: gateway does not validate the JWT (downstream does), but
+// it requires the access_token query parameter to be present so anonymous traffic is rejected here.
+app.UseMiddleware<HubAccessTokenPresenceMiddleware>();
+
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -157,6 +145,13 @@ app.MapGet("/", () => Results.Ok(new
     utc = DateTimeOffset.UtcNow,
 }));
 
+var readinessStatusCodes = new Dictionary<HealthStatus, int>
+{
+    [HealthStatus.Healthy] = StatusCodes.Status200OK,
+    [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable,
+};
+
 app.MapHealthChecks("/health/live", new HealthCheckOptions
 {
     Predicate = _ => false,
@@ -164,11 +159,17 @@ app.MapHealthChecks("/health/live", new HealthCheckOptions
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
     Predicate = check => check.Tags.Contains("ready"),
+    ResultStatusCodes = readinessStatusCodes,
 });
 
 app.MapOpenApi();
 app.MapReverseProxy();
 
 await app.RunAsync().ConfigureAwait(false);
+
+static string ResolvePartitionKey(HttpContext context) =>
+    context.User.FindFirstValue("sub")
+    ?? context.Connection.RemoteIpAddress?.ToString()
+    ?? "anonymous";
 
 public partial class Program;

--- a/src/Gateway/ApiGateway/Program.cs
+++ b/src/Gateway/ApiGateway/Program.cs
@@ -1,8 +1,15 @@
+using System.Diagnostics;
+using System.IO.Compression;
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Observability;
 using Urfu.Link.BuildingBlocks.SessionRevocation;
 using Urfu.Link.Gateway.ApiGateway;
+using Urfu.Link.Gateway.ApiGateway.HealthChecks;
+using Urfu.Link.Gateway.ApiGateway.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,55 +34,120 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
-builder.Services.AddHealthChecks();
+
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes
+        .Concat(["application/json", "application/problem+json"]);
+});
+builder.Services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+builder.Services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
     {
-        var clientId = context.Request.Headers["X-Client-Id"].ToString();
-        clientId = string.IsNullOrWhiteSpace(clientId) ? "anonymous" : clientId;
+        var partitionKey =
+            context.User.FindFirst("sub")?.Value
+            ?? context.Connection.RemoteIpAddress?.ToString()
+            ?? "anonymous";
 
-        return RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: clientId,
-            factory: _ => new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 100,
-                QueueLimit = 0,
-                Window = TimeSpan.FromSeconds(1),
-                AutoReplenishment = true,
-            });
+        return RateLimitPartition.GetTokenBucketLimiter(partitionKey, _ => new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = 200,
+            TokensPerPeriod = 200,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+            QueueLimit = 0,
+            AutoReplenishment = true,
+        });
     });
+
+    options.AddPolicy("chat-send", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            }));
+
+    options.AddPolicy("media-upload", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 30,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            }));
+
+    options.AddPolicy("search", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            context.User.FindFirst("sub")?.Value ?? context.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 30,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            }));
 });
 
 builder.Services
     .AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
+builder.Services.AddHttpClient();
+
+builder.Services
+    .AddHealthChecks()
+    .AddCheck<YarpDestinationsHealthCheck>(
+        name: "yarp-destinations",
+        failureStatus: HealthStatus.Degraded,
+        tags: ["ready"]);
+
 var app = builder.Build();
 
 app.UseExceptionHandler();
-// Required for SignalR WebSocket upgrades to be proxied by YARP (used by
-// /api/presence/hubs/presence). Must be enabled before MapReverseProxy.
+
+app.UseResponseCompression();
+
+app.UseMiddleware<SecurityHeadersMiddleware>();
+
+// Required for SignalR WebSocket upgrades to be proxied by YARP. Must be enabled before MapReverseProxy.
 app.UseWebSockets();
-app.UseRateLimiter();
+
 app.UseCors();
 
 app.Use((context, next) =>
 {
     const string header = "X-Correlation-Id";
-    if (!context.Request.Headers.TryGetValue(header, out var correlationId) || string.IsNullOrWhiteSpace(correlationId))
+    if (!context.Request.Headers.TryGetValue(header, out var correlationId)
+        || string.IsNullOrWhiteSpace(correlationId))
     {
         correlationId = Guid.NewGuid().ToString("N");
         context.Request.Headers[header] = correlationId;
     }
 
     context.Response.Headers[header] = correlationId;
+    Activity.Current?.SetTag("correlation.id", correlationId.ToString());
     return next();
 });
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Rate limiter must come after authentication so that policies can partition by Keycloak `sub`.
+app.UseRateLimiter();
+
 app.UseMiddleware<SessionRevocationMiddleware>();
 
 app.MapGet("/", () => Results.Ok(new
@@ -84,11 +156,19 @@ app.MapGet("/", () => Results.Ok(new
     status = "ready",
     utc = DateTimeOffset.UtcNow,
 }));
-app.MapHealthChecks("/health/live");
-app.MapHealthChecks("/health/ready");
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = _ => false,
+});
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready"),
+});
+
 app.MapOpenApi();
 app.MapReverseProxy();
 
-app.Run();
+await app.RunAsync().ConfigureAwait(false);
 
 public partial class Program;

--- a/src/Gateway/ApiGateway/appsettings.json
+++ b/src/Gateway/ApiGateway/appsettings.json
@@ -28,12 +28,20 @@
           "Path": "/api/users/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/users"
-          },
-          {
-            "PathPrefix": "/api/v1"
-          }
+          { "PathRemovePrefix": "/api/users" },
+          { "PathPrefix": "/api/v1" }
+        ]
+      },
+      "media-upload-init": {
+        "ClusterId": "media-cluster",
+        "AuthorizationPolicy": "default",
+        "RateLimiterPolicy": "media-upload",
+        "Match": {
+          "Path": "/api/media/upload/init",
+          "Methods": ["POST"]
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/media" }
         ]
       },
       "media-api": {
@@ -43,9 +51,19 @@
           "Path": "/api/media/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/media"
-          }
+          { "PathRemovePrefix": "/api/media" }
+        ]
+      },
+      "chat-send-message": {
+        "ClusterId": "chat-cluster",
+        "AuthorizationPolicy": "default",
+        "RateLimiterPolicy": "chat-send",
+        "Match": {
+          "Path": "/api/chat/conversations/{conversationId}/messages",
+          "Methods": ["POST"]
+        },
+        "Transforms": [
+          { "PathRemovePrefix": "/api/chat" }
         ]
       },
       "chat-api": {
@@ -55,9 +73,7 @@
           "Path": "/api/chat/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/chat"
-          }
+          { "PathRemovePrefix": "/api/chat" }
         ]
       },
       "presence-api": {
@@ -67,9 +83,7 @@
           "Path": "/api/presence/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/presence"
-          }
+          { "PathRemovePrefix": "/api/presence" }
         ]
       },
       "notification-api": {
@@ -79,9 +93,7 @@
           "Path": "/api/notifications/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/notifications"
-          }
+          { "PathRemovePrefix": "/api/notifications" }
         ]
       },
       "call-api": {
@@ -91,9 +103,7 @@
           "Path": "/api/calls/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/calls"
-          }
+          { "PathRemovePrefix": "/api/calls" }
         ]
       },
       "discipline-api": {
@@ -103,62 +113,128 @@
           "Path": "/api/disciplines/{**catch-all}"
         },
         "Transforms": [
-          {
-            "PathRemovePrefix": "/api/disciplines"
-          },
-          {
-            "PathPrefix": "/api/v1/disciplines"
-          }
+          { "PathRemovePrefix": "/api/disciplines" },
+          { "PathPrefix": "/api/v1/disciplines" }
         ]
+      },
+      "chat-hub": {
+        "ClusterId": "chat-cluster",
+        "Match": {
+          "Path": "/hubs/chat/{**catch-all}"
+        }
+      },
+      "presence-hub": {
+        "ClusterId": "presence-cluster",
+        "Match": {
+          "Path": "/hubs/presence/{**catch-all}"
+        }
+      },
+      "notification-hub": {
+        "ClusterId": "notification-cluster",
+        "Match": {
+          "Path": "/hubs/notifications/{**catch-all}"
+        }
       }
     },
     "Clusters": {
       "user-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://user-service:8080"
+          "d1": { "Address": "http://user-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       },
       "media-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://media-service:8080"
+          "d1": { "Address": "http://media-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
+        },
+        "HttpRequest": {
+          "ActivityTimeout": "00:05:00"
         }
       },
       "chat-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://chat-service:8080"
+          "d1": { "Address": "http://chat-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       },
       "presence-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://presence-service:8080"
+          "d1": { "Address": "http://presence-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       },
       "notification-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://notification-service:8080"
+          "d1": { "Address": "http://notification-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       },
       "call-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://call-service:8080"
+          "d1": { "Address": "http://call-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       },
       "discipline-cluster": {
         "Destinations": {
-          "d1": {
-            "Address": "http://discipline-service:8080"
+          "d1": { "Address": "http://discipline-service:8080" }
+        },
+        "HealthCheck": {
+          "Active": {
+            "Enabled": true,
+            "Interval": "00:00:30",
+            "Timeout": "00:00:05",
+            "Policy": "ConsecutiveFailures",
+            "Path": "/health/ready"
           }
         }
       }

--- a/src/Services/Chat/ChatService.Api/ChatService.Api.csproj
+++ b/src/Services/Chat/ChatService.Api/ChatService.Api.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
     <PackageReference Include="MongoDB.Driver" />
   </ItemGroup>
 

--- a/src/Services/Chat/ChatService.Api/Program.cs
+++ b/src/Services/Chat/ChatService.Api/Program.cs
@@ -33,6 +33,7 @@ builder.Services
 builder.Services.AddSingleton<IUserIdProvider, ChatUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "chat-service");
+builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket upgrade handshake —
 // accept the bearer token via ?access_token= for /hubs/* paths.

--- a/src/Services/Chat/ChatService.Api/Program.cs
+++ b/src/Services/Chat/ChatService.Api/Program.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
+using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Domain;
@@ -11,7 +12,24 @@ using Urfu.Link.Services.Chat.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
-builder.Services.AddSignalR();
+builder.Services
+    .AddSignalR(options =>
+    {
+        options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+        options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+        options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+        options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+        options.MaximumReceiveMessageSize = 64 * 1024;
+    })
+    .AddStackExchangeRedis(
+        builder.Configuration["Infrastructure:Redis:Configuration"]
+            ?? throw new InvalidOperationException("Infrastructure:Redis:Configuration is missing"),
+        options =>
+        {
+            options.Configuration.ChannelPrefix = RedisChannel.Literal("urfu:signalr:chat");
+            options.Configuration.AbortOnConnectFail = false;
+            options.Configuration.ConnectRetry = 5;
+        });
 builder.Services.AddSingleton<IUserIdProvider, ChatUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "chat-service");

--- a/src/Services/Notification/NotificationService.Api/NotificationService.Api.csproj
+++ b/src/Services/Notification/NotificationService.Api/NotificationService.Api.csproj
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="MailKit" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/Services/Notification/NotificationService.Api/Program.cs
+++ b/src/Services/Notification/NotificationService.Api/Program.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
+using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.Services.Notification.Domain;
@@ -12,7 +13,24 @@ using Urfu.Link.Services.Notification.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
-builder.Services.AddSignalR();
+builder.Services
+    .AddSignalR(options =>
+    {
+        options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+        options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+        options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+        options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+        options.MaximumReceiveMessageSize = 64 * 1024;
+    })
+    .AddStackExchangeRedis(
+        builder.Configuration["Infrastructure:Redis:Configuration"]
+            ?? throw new InvalidOperationException("Infrastructure:Redis:Configuration is missing"),
+        options =>
+        {
+            options.Configuration.ChannelPrefix = RedisChannel.Literal("urfu:signalr:notifications");
+            options.Configuration.AbortOnConnectFail = false;
+            options.Configuration.ConnectRetry = 5;
+        });
 builder.Services.AddSingleton<IUserIdProvider, NotificationUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "notification-service");

--- a/src/Services/Notification/NotificationService.Api/Program.cs
+++ b/src/Services/Notification/NotificationService.Api/Program.cs
@@ -34,6 +34,7 @@ builder.Services
 builder.Services.AddSingleton<IUserIdProvider, NotificationUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "notification-service");
+builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket upgrade handshake —
 // accept the bearer token via ?access_token= for /hubs/* paths.

--- a/src/Services/Presence/PresenceService.Api/PresenceService.Api.csproj
+++ b/src/Services/Presence/PresenceService.Api/PresenceService.Api.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -70,6 +70,7 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "presence-service");
+builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket
 // upgrade handshake — accept the bearer token via ?access_token= for /hubs/*.

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
+using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.Services.Presence.Infrastructure;
@@ -40,7 +41,24 @@ if (args.Any(a => string.Equals(a, "--migrate", StringComparison.OrdinalIgnoreCa
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
-builder.Services.AddSignalR();
+builder.Services
+    .AddSignalR(options =>
+    {
+        options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+        options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+        options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+        options.HandshakeTimeout = TimeSpan.FromSeconds(15);
+        options.MaximumReceiveMessageSize = 64 * 1024;
+    })
+    .AddStackExchangeRedis(
+        builder.Configuration["Infrastructure:Redis:Configuration"]
+            ?? throw new InvalidOperationException("Infrastructure:Redis:Configuration is missing"),
+        options =>
+        {
+            options.Configuration.ChannelPrefix = RedisChannel.Literal("urfu:signalr:presence");
+            options.Configuration.AbortOnConnectFail = false;
+            options.Configuration.ConnectRetry = 5;
+        });
 builder.Services.AddFastEndpoints();
 builder.Services.SwaggerDocument(o =>
 {


### PR DESCRIPTION
Closes #215

## Что сделано

### SignalR scale-out (chat / presence / notification)
- Подключён `Microsoft.AspNetCore.SignalR.StackExchangeRedis` с per-service ChannelPrefix (`urfu:signalr:<name>`) — broadcasts разносятся между репликами через Redis backplane, sticky sessions на gateway не требуются.
- Tuned SignalR options: keep-alive 15s, client timeout 30s, handshake 15s, max receive 64KB.
- Resilient Redis: `AbortOnConnectFail=false`, `ConnectRetry=5` — сервис не падает при холодном старте, если Redis ещё не готов.
- IConnectionMultiplexer переиспользуется (singleton от Idempotency/SessionRevocation), новых подключений не плодим.

### Gateway YARP routes
- Новые прямые SignalR-маршруты `/hubs/chat|presence|notifications/{**catch-all}` без AuthorizationPolicy — auth выполняет downstream через `?access_token=` (gateway middleware читать query token не умеет).
- `chat-send-message` (POST `/api/chat/conversations/{id}/messages`) → policy `chat-send` (60 rpm).
- `media-upload-init` (POST `/api/media/upload/init`) → policy `media-upload` (30 rpm).
- Active `/health/ready` probe на каждый cluster (30s interval, ConsecutiveFailures), HTTP timeout 5 минут для media.

### Pipeline / hardening
- `UseRateLimiter` перенесён после `UseAuthentication` — partition по Keycloak `sub` теперь работает; глобальный limiter — token bucket по sub/RemoteIpAddress (был X-Client-Id).
- Response compression (Brotli + Gzip) для `application/json` и стандартных MIME.
- Security headers middleware (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Cache-Control: no-store` вне `/hubs/*`). HSTS остаётся за edge / Pomerium.
- OTel correlation enrichment: `X-Correlation-Id` пробрасывается тегом в `Activity.Current` — viден в Jaeger/Tempo.
- Custom `YarpDestinationsHealthCheck` агрегирует доступность downstream в `/health/ready` (10s cache, fan-out по кластерам).

### Tests
- `StubDownstreamServer` (реальный Kestrel на dynamic port) + `TestAuthHandler` + `StubSessionRevocationStore` — без новых зависимостей.
- 10 интеграционных тестов: REST proxying (correlation, auth forward, 401), hub negotiate routing, endpoint rate-limit с partitioning по `sub`, live/ready endpoints.
- Итого 12/12 passed (включая существующие CORS).

## Как проверить

- [ ] `dotnet build Urfu.Link.slnx` — без ошибок (только pre-existing EF Core conflict warnings в Discipline/Presence test проектах).
- [ ] `dotnet test src/Gateway/ApiGateway.Tests/ApiGateway.Tests.csproj` — 12 passed.
- [ ] Локально: `docker compose -f platform/dev/docker-compose.dev.yml up -d` → `curl http://localhost:5080/health/ready` → 200; остановить notification-service → через ~30s статус Degraded.
- [ ] Подключиться к `/hubs/chat?access_token=<jwt>` через gateway, послать `SendMessage`, второй клиент получает (с одной репликой backplane не задействован, но pipeline отрабатывает).
- [ ] При желании смоук scale-out: `docker compose up -d --scale chat-service=2` — broadcasts разносятся через Redis между репликами.

## Что НЕ в этом PR
- MessagePack клиент-сайд (frontend) — отдельная задача.
- Helm/compose без правок (структура уже подходит, новые сервисы в values уже описаны).