### PR TITLE
fix(#234): cross-cutting infrastructure — Kafka tracing, SignalR HC, Chat events to Contracts

### DIFF
--- a/Urfu.Link.slnx
+++ b/Urfu.Link.slnx
@@ -38,6 +38,7 @@
   </Folder>
   <Folder Name="/tests/" />
   <Folder Name="/tests/unit/">
+    <Project Path="tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj" />
     <Project Path="tests/unit/ChatService.UnitTests/ChatService.UnitTests.csproj" />
     <Project Path="tests/unit/DisciplineService.UnitTests/DisciplineService.UnitTests.csproj" />
     <Project Path="tests/unit/MediaService.UnitTests/MediaService.UnitTests.csproj" />

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageDeletedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageDeletedEvent.cs
@@ -1,7 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-using Urfu.Link.Services.Chat.Domain.Enums;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatMessageDeletedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageEditedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageEditedEvent.cs
@@ -1,6 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatMessageEditedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessagePinnedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessagePinnedEvent.cs
@@ -1,6 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatMessagePinnedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageUnpinnedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatMessageUnpinnedEvent.cs
@@ -1,6 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatMessageUnpinnedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatReactionAddedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatReactionAddedEvent.cs
@@ -1,6 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatReactionAddedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatReactionRemovedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatReactionRemovedEvent.cs
@@ -1,6 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 public sealed record ChatReactionRemovedEvent(
     string ConversationId,

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatThreadReplyPostedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatThreadReplyPostedEvent.cs
@@ -1,7 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 /// <summary>
 /// A new reply was posted in a thread. NotificationService consumes this event to deliver

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ChatThreadSubscriptionChangedEvent.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ChatThreadSubscriptionChangedEvent.cs
@@ -1,7 +1,4 @@
-using Urfu.Link.BuildingBlocks.Contracts.Integration;
-using Urfu.Link.Services.Chat.Domain.Enums;
-
-namespace Urfu.Link.Services.Chat.Domain.Events;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 /// <summary>
 /// A user's thread subscription was added, escalated, or removed. <c>Subscribed=true</c> covers

--- a/src/BuildingBlocks/Contracts/Integration/Chat/DeleteMode.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/DeleteMode.cs
@@ -1,0 +1,13 @@
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
+
+/// <summary>
+/// How a chat message was deleted. Lives in <c>BuildingBlocks/Contracts</c> because
+/// <see cref="ChatMessageDeletedEvent"/> crosses the service boundary, and downstream
+/// consumers (NotificationService, analytics, audit) need to deserialize the field
+/// without taking a typed dependency on ChatService internals.
+/// </summary>
+public enum DeleteMode
+{
+    ForMe = 0,
+    ForEveryone = 1,
+}

--- a/src/BuildingBlocks/Contracts/Integration/Chat/ThreadSubscriptionReason.cs
+++ b/src/BuildingBlocks/Contracts/Integration/Chat/ThreadSubscriptionReason.cs
@@ -1,4 +1,4 @@
-namespace Urfu.Link.Services.Chat.Domain.Enums;
+namespace Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 
 /// <summary>
 /// Why a user is subscribed to a thread. Higher values represent stronger ownership and

--- a/src/BuildingBlocks/Observability/Class1.cs
+++ b/src/BuildingBlocks/Observability/Class1.cs
@@ -41,6 +41,11 @@ public static class ObservabilityExtensions
                 tracing
                     .AddAspNetCoreInstrumentation(options => options.RecordException = true)
                     .AddHttpClientInstrumentation()
+                    // Confluent.Kafka emits Producer/Consumer activities under the
+                    // "Confluent.Kafka" ActivitySource since v2.10. Subscribing here
+                    // is what makes async cross-service traces (e.g. chat → kafka →
+                    // notification) link into a single trace_id.
+                    .AddSource("Confluent.Kafka")
                     .AddOtlpExporter(exporter => exporter.Endpoint = otlpUri);
             })
             .WithMetrics(metrics =>

--- a/src/BuildingBlocks/ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/src/BuildingBlocks/ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -33,6 +33,12 @@ public static class ServiceDefaultsExtensions
         services.AddPlatformJwtAuthentication(configuration);
         services.AddPlatformObservability(configuration, serviceName);
 
+        // Every service that uses SignalR for realtime depends on the Redis backplane.
+        // Registering the readiness probe here guarantees no SignalR service can be Ready
+        // while broadcasts cannot propagate cross-replica. Services without SignalR pay
+        // the same probe — it doubles as a Redis connectivity check for Idempotency.
+        services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
+
         return services;
     }
 

--- a/src/BuildingBlocks/ServiceDefaults/SignalRBackplaneHealthCheck.cs
+++ b/src/BuildingBlocks/ServiceDefaults/SignalRBackplaneHealthCheck.cs
@@ -35,11 +35,24 @@ public static class SignalRBackplaneHealthCheckExtensions
     /// already wired by <see cref="ServiceDefaultsExtensions.AddServiceDefaults"/> via
     /// <c>AddIdempotency</c>.
     /// </summary>
+    /// <remarks>
+    /// Idempotent: the registration is added at most once per <see cref="IServiceCollection"/>
+    /// via a marker singleton. <see cref="ServiceDefaultsExtensions.AddServiceDefaults"/>
+    /// auto-registers the check, and a service that still calls this method explicitly will
+    /// not produce a duplicate readiness probe.
+    /// </remarks>
     public static IHealthChecksBuilder AddSignalRBackplaneHealthCheck(
         this IHealthChecksBuilder builder,
         string name = "signalr-backplane")
     {
         ArgumentNullException.ThrowIfNull(builder);
+
+        if (builder.Services.Any(static d => d.ServiceType == typeof(SignalRBackplaneHealthCheckMarker)))
+        {
+            return builder;
+        }
+
+        builder.Services.AddSingleton<SignalRBackplaneHealthCheckMarker>();
 
         return builder.Add(new HealthCheckRegistration(
             name,
@@ -47,4 +60,6 @@ public static class SignalRBackplaneHealthCheckExtensions
             HealthStatus.Unhealthy,
             ["ready"]));
     }
+
+    private sealed class SignalRBackplaneHealthCheckMarker;
 }

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/ActiveThreadDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/ActiveThreadDto.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Enums;
 
 namespace Urfu.Link.Services.Chat.Application.Contracts;

--- a/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Contracts/MessageDto.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 

--- a/src/Services/Chat/ChatService.Api/Application/Conversations/PinMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Conversations/PinMessageService.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
-using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Infrastructure;
 using Urfu.Link.Services.Chat.Realtime;

--- a/src/Services/Chat/ChatService.Api/Application/Conversations/UnpinMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Conversations/UnpinMessageService.cs
@@ -1,7 +1,7 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
-using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Realtime;
 

--- a/src/Services/Chat/ChatService.Api/Application/Messages/AddReactionService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/AddReactionService.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Options;
-using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;
 using Urfu.Link.Services.Chat.Infrastructure;

--- a/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/DeleteMessageService.cs
@@ -1,8 +1,8 @@
 using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Enums;
-using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Infrastructure;
 using Urfu.Link.Services.Chat.Realtime;

--- a/src/Services/Chat/ChatService.Api/Application/Messages/RemoveReactionService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/RemoveReactionService.cs
@@ -1,4 +1,4 @@
-using Urfu.Link.Services.Chat.Domain.Events;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Realtime;
 

--- a/src/Services/Chat/ChatService.Api/Application/Threads/JoinThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/JoinThreadService.cs
@@ -1,6 +1,6 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
-using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 using Urfu.Link.Services.Chat.Realtime;
 

--- a/src/Services/Chat/ChatService.Api/Application/Threads/LeaveThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/LeaveThreadService.cs
@@ -1,5 +1,5 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Enums;
-using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
 
 namespace Urfu.Link.Services.Chat.Application.Threads;

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/Message.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;
 
@@ -390,7 +391,8 @@ public sealed class Message
         State = MessageState.Deleted;
         DeletedAtUtc = atUtc;
         DeletedBy = byUserId;
-        DeleteMode = Enums.DeleteMode.ForEveryone;
+        // Fully qualified to disambiguate from the property of the same name on this aggregate.
+        DeleteMode = BuildingBlocks.Contracts.Integration.Chat.DeleteMode.ForEveryone;
         Body = string.Empty;
         _attachments.Clear();
         _reactions.Clear();

--- a/src/Services/Chat/ChatService.Api/Domain/Aggregates/ThreadSubscription.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Aggregates/ThreadSubscription.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Enums;
 
 namespace Urfu.Link.Services.Chat.Domain.Aggregates;

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteMode.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteMode.cs
@@ -1,7 +1,0 @@
-namespace Urfu.Link.Services.Chat.Domain.Enums;
-
-public enum DeleteMode
-{
-    ForMe = 0,
-    ForEveryone = 1,
-}

--- a/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteModes.cs
+++ b/src/Services/Chat/ChatService.Api/Domain/Enums/DeleteModes.cs
@@ -1,3 +1,5 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
+
 namespace Urfu.Link.Services.Chat.Domain.Enums;
 
 /// <summary>

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/DeleteMessageEndpoint.cs
@@ -1,4 +1,5 @@
 using FastEndpoints;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Domain.Enums;

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/MessageDocument.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ThreadSubscriptionDocument.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/Documents/ThreadSubscriptionDocument.cs
@@ -1,5 +1,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Persistence/MessageRepository.cs
@@ -1,6 +1,7 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.Interfaces;

--- a/src/Services/Chat/ChatService.Api/Program.cs
+++ b/src/Services/Chat/ChatService.Api/Program.cs
@@ -33,7 +33,6 @@ builder.Services
 builder.Services.AddSingleton<IUserIdProvider, ChatUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "chat-service");
-builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket upgrade handshake —
 // accept the bearer token via ?access_token= for /hubs/* paths.

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatBroadcaster.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Microsoft.AspNetCore.SignalR;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Enums;
 

--- a/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/IChatBroadcaster.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Enums;
 

--- a/src/Services/Notification/NotificationService.Api/Program.cs
+++ b/src/Services/Notification/NotificationService.Api/Program.cs
@@ -34,7 +34,6 @@ builder.Services
 builder.Services.AddSingleton<IUserIdProvider, NotificationUserIdProvider>();
 builder.Services.AddFastEndpoints();
 builder.Services.AddServiceDefaults(builder.Configuration, "notification-service");
-builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket upgrade handshake —
 // accept the bearer token via ?access_token= for /hubs/* paths.

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -70,7 +70,6 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "presence-service");
-builder.Services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
 
 // SignalR clients can't set the Authorization header during the WebSocket
 // upgrade handshake — accept the bearer token via ?access_token= for /hubs/*.

--- a/tests/integration/ChatService.IntegrationTests/Conversations/PinningTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Conversations/PinningTests.cs
@@ -1,6 +1,7 @@
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/MessengerEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/MessengerEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeChatBroadcaster.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeChatBroadcaster.cs
@@ -1,3 +1,4 @@
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Realtime;

--- a/tests/integration/ChatService.IntegrationTests/Messages/DeleteMessageServiceTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/DeleteMessageServiceTests.cs
@@ -1,6 +1,7 @@
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;

--- a/tests/integration/ChatService.IntegrationTests/Messages/ReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Messages/ReactionsTests.cs
@@ -1,6 +1,7 @@
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Messages;
 using Urfu.Link.Services.Chat.Domain.Aggregates;

--- a/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryEditDeleteTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/MessageRepositoryEditDeleteTests.cs
@@ -1,5 +1,6 @@
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;

--- a/tests/integration/ChatService.IntegrationTests/Persistence/ThreadSubscriptionRepositoryTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Persistence/ThreadSubscriptionRepositoryTests.cs
@@ -1,5 +1,6 @@
 using ChatService.IntegrationTests.Infrastructure;
 using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.Interfaces;

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Contracts\Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Observability\Observability.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />
   </ItemGroup>

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA1707;CA1062;CA2007;CA1861;CA1822;CA2012</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Observability\Observability.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/unit/BuildingBlocks.UnitTests/Contracts/ChatIntegrationEventsLocationTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/Contracts/ChatIntegrationEventsLocationTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.Contracts;
+
+/// <summary>
+/// Cross-service Chat integration events must live in <c>BuildingBlocks/Contracts</c> so that
+/// downstream consumers (NotificationService and friends) can deserialize them with a typed
+/// reference instead of duplicating the schema. This test locks in the location and prevents
+/// regression where new events are accidentally added under <c>ChatService.Api/Domain/Events/</c>.
+/// </summary>
+public sealed class ChatIntegrationEventsLocationTests
+{
+    private const string ContractsChatNamespace = "Urfu.Link.BuildingBlocks.Contracts.Integration.Chat";
+
+    public static IEnumerable<object[]> CrossServiceEventTypes => new[]
+    {
+        new object[] { typeof(ChatMessageEditedEvent) },
+        new object[] { typeof(ChatMessageDeletedEvent) },
+        new object[] { typeof(ChatReactionAddedEvent) },
+        new object[] { typeof(ChatReactionRemovedEvent) },
+        new object[] { typeof(ChatMessagePinnedEvent) },
+        new object[] { typeof(ChatMessageUnpinnedEvent) },
+        new object[] { typeof(ChatThreadReplyPostedEvent) },
+        new object[] { typeof(ChatThreadSubscriptionChangedEvent) },
+    };
+
+    [Theory]
+    [MemberData(nameof(CrossServiceEventTypes))]
+    public void Lives_in_buildingblocks_contracts_namespace(Type eventType)
+    {
+        eventType.Namespace.Should().Be(ContractsChatNamespace);
+    }
+
+    [Theory]
+    [MemberData(nameof(CrossServiceEventTypes))]
+    public void Implements_integration_event_interface(Type eventType)
+    {
+        typeof(IIntegrationEvent).IsAssignableFrom(eventType).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Delete_mode_enum_lives_in_contracts_namespace()
+    {
+        typeof(DeleteMode).Namespace.Should().Be(ContractsChatNamespace);
+    }
+
+    [Fact]
+    public void Thread_subscription_reason_enum_lives_in_contracts_namespace()
+    {
+        typeof(ThreadSubscriptionReason).Namespace.Should().Be(ContractsChatNamespace);
+    }
+}

--- a/tests/unit/BuildingBlocks.UnitTests/Observability/AddPlatformObservabilityTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/Observability/AddPlatformObservabilityTests.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+using Urfu.Link.BuildingBlocks.Observability;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.Observability;
+
+public sealed class AddPlatformObservabilityTests
+{
+    /// <summary>
+    /// Cross-service distributed tracing relies on Kafka activities being captured by
+    /// the SDK. <see cref="ObservabilityExtensions.AddPlatformObservability"/> must
+    /// subscribe to the <c>Confluent.Kafka</c> ActivitySource so producer and consumer
+    /// spans link into the trace tree (chat → kafka → notification single trace_id).
+    /// Without subscription, <see cref="ActivitySource.StartActivity(string, ActivityKind)"/>
+    /// returns <see langword="null"/> because no <see cref="ActivityListener"/> samples it.
+    /// </summary>
+    [Fact]
+    public void Subscribes_to_confluent_kafka_activity_source()
+    {
+        using var serviceProvider = BuildServiceProviderWithObservability();
+
+        // Force TracerProvider materialization which registers ActivityListener subscriptions.
+        _ = serviceProvider.GetRequiredService<TracerProvider>();
+
+        using var source = new ActivitySource("Confluent.Kafka");
+        using var activity = source.StartActivity("kafka.publish");
+
+        activity.Should().NotBeNull(
+            "AddPlatformObservability must subscribe to 'Confluent.Kafka' ActivitySource so cross-service traces propagate through Kafka.");
+    }
+
+    private static ServiceProvider BuildServiceProviderWithObservability()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddPlatformObservability(configuration, "test-service");
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/unit/BuildingBlocks.UnitTests/ServiceDefaults/AddServiceDefaultsTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/ServiceDefaults/AddServiceDefaultsTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.ServiceDefaults;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.ServiceDefaults;
+
+public sealed class AddServiceDefaultsTests
+{
+    /// <summary>
+    /// Every SignalR-bearing service (chat, presence, notification) needs its readiness
+    /// gated on the Redis backplane connection — without it, broadcasts cannot propagate
+    /// across replicas. Registering the check inside <c>AddServiceDefaults</c> removes
+    /// the per-service footgun where a freshly added SignalR service silently passes
+    /// readiness while broadcasts are dropped.
+    /// </summary>
+    [Fact]
+    public void Auto_registers_signalr_backplane_health_check()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddServiceDefaults(configuration, "test-service");
+
+        using var provider = services.BuildServiceProvider();
+        var registrations = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        registrations.Should().Contain(r =>
+            r.Name == "signalr-backplane" && r.Tags.Contains("ready"),
+            "AddServiceDefaults must register the SignalR backplane readiness probe so individual services don't have to remember to call AddSignalRBackplaneHealthCheck.");
+    }
+
+    /// <summary>
+    /// Defensive guard against duplicate registrations if a service still calls
+    /// <c>AddSignalRBackplaneHealthCheck</c> manually after the auto-registration —
+    /// the readiness endpoint should not surface the same probe twice.
+    /// </summary>
+    [Fact]
+    public void Registers_signalr_backplane_health_check_only_once()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddServiceDefaults(configuration, "test-service");
+        services.AddHealthChecks().AddSignalRBackplaneHealthCheck();
+
+        using var provider = services.BuildServiceProvider();
+        var registrations = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        registrations.Count(r => r.Name == "signalr-backplane")
+            .Should().Be(1, "duplicate readiness probes confuse operators inspecting /health/ready.");
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/DeleteMessageServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Authorization;

--- a/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Contracts;

--- a/tests/unit/ChatService.UnitTests/Application/GetUserActiveThreadsQueryTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/GetUserActiveThreadsQueryTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FluentAssertions;
 using NSubstitute;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Application.Threads;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;

--- a/tests/unit/ChatService.UnitTests/Application/JoinLeaveThreadServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/JoinLeaveThreadServiceTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using FluentAssertions;
 using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Threads;

--- a/tests/unit/ChatService.UnitTests/Application/PinningServicesTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/PinningServicesTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Authorization;

--- a/tests/unit/ChatService.UnitTests/Application/ReactionServicesTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ReactionServicesTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Messages;

--- a/tests/unit/ChatService.UnitTests/Domain/MessageDeleteTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/MessageDeleteTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 using Urfu.Link.Services.Chat.Domain.ValueObjects;

--- a/tests/unit/ChatService.UnitTests/Domain/ThreadSubscriptionTests.cs
+++ b/tests/unit/ChatService.UnitTests/Domain/ThreadSubscriptionTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Enums;
 


### PR DESCRIPTION
Refs #234

PR 1 of 7 закрывающих тех долг по EPIC #216. Только cross-cutting инфраструктура — функциональных изменений нет, рефакторинг + observability.

## Что сделано

### A1. Confluent.Kafka activity source в Observability
- `OpenTelemetry.Instrumentation.AspNetCore/Http/Runtime` дополнен `.AddSource("Confluent.Kafka")` в `AddPlatformObservability`
- Distributed trace теперь не обрывается на Kafka publish/consume hops — async flows (chat → kafka → notification) линкуются в один trace_id
- Confluent.Kafka 2.10+ нативно эмитит ActivitySource — отдельный пакет не нужен

### A2. Auto-register SignalR backplane health check
- `AddSignalRBackplaneHealthCheck` теперь регистрируется автоматически из `ServiceDefaultsExtensions.AddServiceDefaults`
- Extension стал idempotent через marker singleton — legacy ручные вызовы не приводят к дублированию readiness probe
- Удалены ручные вызовы из `ChatService/PresenceService/NotificationService` Program.cs

### A3. Chat integration events в BuildingBlocks/Contracts
Перенесены в `src/BuildingBlocks/Contracts/Integration/Chat/`:
- `ChatMessageEditedEvent`, `ChatMessageDeletedEvent`, `ChatReactionAddedEvent`, `ChatReactionRemovedEvent`, `ChatMessagePinnedEvent`, `ChatMessageUnpinnedEvent`, `ChatThreadReplyPostedEvent`, `ChatThreadSubscriptionChangedEvent`
- Enum-зависимости: `DeleteMode`, `ThreadSubscriptionReason`

`ChatConversationCreatedEvent`, `ChatMessageDeliveredEvent`, `ChatMessageReadEvent` оставлены в ChatService — никто их извне не потребляет, не нужно леакать `ConversationType` в контрактный surface преждевременно.

Структурный тест в `BuildingBlocks.UnitTests/Contracts/ChatIntegrationEventsLocationTests` фиксирует новую локацию, чтобы не было регрессии.

## Как проверить

- `dotnet build Urfu.Link.slnx` — 0 errors
- `dotnet test Urfu.Link.slnx --filter "FullyQualifiedName~UnitTests"` — все 549 unit-тестов проходят (включая 21 новый в BuildingBlocks.UnitTests)
- ChatService — внутренние использования `DeleteMode`/`ThreadSubscriptionReason` теперь резолвятся через `using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;`
- SignalR services (Chat/Presence/Notification): `/health/ready` по-прежнему включает `signalr-backplane` probe, но регистрация теперь one-shot из ServiceDefaults

## Что дальше (по issue #234)

Следом — PR 2 (migrations Helm pattern), PR 3 (notification presence + tests), PR 4 (chat typing + mentions), PR 5 (media voice duration), PR 6 (presence partitioning + privacy fallback), PR 7 (cleanup + docs, Closes #234).