### PR TITLE
fix(#234): migrations standardization on Helm Job pattern

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
 
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />

--- a/deploy/helm/services/discipline-service/values-dev.yaml
+++ b/deploy/helm/services/discipline-service/values-dev.yaml
@@ -32,3 +32,10 @@ resources:
   limits:
     cpu: 200m
     memory: 256Mi
+
+# Helm pre-upgrade Job (helm.sh/hook-weight: -5) runs `--migrate` against the
+# same image and secrets before any new app pod starts. A non-zero exit aborts
+# the rollout so the new pods never face an un-migrated schema.
+migrations:
+  enabled: true
+  command: ["dotnet", "DisciplineService.Api.dll", "--migrate"]

--- a/deploy/helm/services/notification-service/values-dev.yaml
+++ b/deploy/helm/services/notification-service/values-dev.yaml
@@ -33,3 +33,7 @@ resources:
     cpu: 200m
     memory: 256Mi
 
+migrations:
+  enabled: true
+  command: ["dotnet", "NotificationService.Api.dll", "--migrate"]
+

--- a/deploy/helm/services/notification-service/values-prod.yaml
+++ b/deploy/helm/services/notification-service/values-prod.yaml
@@ -44,3 +44,10 @@ resources:
   limits:
     cpu: 250m
     memory: 256Mi
+
+# Helm pre-upgrade Job (helm.sh/hook-weight: -5) runs `--migrate` against the
+# same image and secrets before any new app pod starts. A non-zero exit aborts
+# the rollout so the new pods never face an un-migrated schema.
+migrations:
+  enabled: true
+  command: ["dotnet", "NotificationService.Api.dll", "--migrate"]

--- a/deploy/helm/services/user-service/values-dev.yaml
+++ b/deploy/helm/services/user-service/values-dev.yaml
@@ -33,3 +33,7 @@ resources:
     cpu: 200m
     memory: 256Mi
 
+migrations:
+  enabled: true
+  command: ["dotnet", "UserService.Api.dll", "--migrate"]
+

--- a/deploy/helm/services/user-service/values-prod.yaml
+++ b/deploy/helm/services/user-service/values-prod.yaml
@@ -50,3 +50,10 @@ resources:
   limits:
     cpu: 250m
     memory: 256Mi
+
+# Helm pre-upgrade Job (helm.sh/hook-weight: -5) runs `--migrate` against the
+# same image and secrets before any new app pod starts. A non-zero exit aborts
+# the rollout so the new pods never face an un-migrated schema.
+migrations:
+  enabled: true
+  command: ["dotnet", "UserService.Api.dll", "--migrate"]

--- a/platform/dev/docker-compose.dev.yml
+++ b/platform/dev/docker-compose.dev.yml
@@ -218,6 +218,27 @@ services:
 
   # ── .NET Services ──────────────────────────────────────────────────────────
 
+  # ── Migration sidecars ─────────────────────────────────────────────────────
+  # One-shot containers that mirror the production Helm pre-upgrade Job: run
+  # `dotnet *.Api.dll --migrate` once, then exit. Main app pods depend on
+  # `service_completed_successfully` so the schema is applied before anything
+  # else opens a connection. This intentionally matches the prod flow — devs
+  # should never see "auto-migrate on startup" behaviour locally either.
+
+  user-migrations:
+    build:
+      context: ../..
+      dockerfile: src/Services/User/UserService.Api/Dockerfile
+    container_name: urfu-user-migrations
+    command: ["dotnet", "UserService.Api.dll", "--migrate"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Primary: Host=postgres;Port=5432;Database=user_db;Username=user;Password=user
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   user-service:
     build:
       context: ../..
@@ -230,6 +251,8 @@ services:
       Auth__ValidIssuer: http://localhost:8080/realms/urfu-link
       Storage__PublicEndpoint: http://localhost:9000
     depends_on:
+      user-migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -264,6 +287,20 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
 
+  media-migrations:
+    build:
+      context: ../..
+      dockerfile: src/Services/Media/MediaService.Api/Dockerfile
+    container_name: urfu-media-migrations
+    command: ["dotnet", "MediaService.Api.dll", "--migrate"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Primary: Host=postgres;Port=5432;Database=media_db;Username=media;Password=media
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   media-service:
     build:
       context: ../..
@@ -281,6 +318,8 @@ services:
       Storage__PrivateBucket: media-private
       Storage__PublicBucket: media-public
     depends_on:
+      media-migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -297,6 +336,20 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
 
+  presence-migrations:
+    build:
+      context: ../..
+      dockerfile: src/Services/Presence/PresenceService.Api/Dockerfile
+    container_name: urfu-presence-migrations
+    command: ["dotnet", "PresenceService.Api.dll", "--migrate"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Primary: Host=postgres;Port=5432;Database=presence_db;Username=presence;Password=presence
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   presence-service:
     build:
       context: ../..
@@ -311,6 +364,8 @@ services:
       ConnectionStrings__Primary: Host=postgres;Port=5432;Database=presence_db;Username=presence;Password=presence
       Infrastructure__Redis__Configuration: redis:6379
     depends_on:
+      presence-migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -322,6 +377,20 @@ services:
       kafka-init:
         condition: service_completed_successfully
     restart: unless-stopped
+
+  notification-migrations:
+    build:
+      context: ../..
+      dockerfile: src/Services/Notification/NotificationService.Api/Dockerfile
+    container_name: urfu-notification-migrations
+    command: ["dotnet", "NotificationService.Api.dll", "--migrate"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Primary: Host=postgres;Port=5432;Database=notification_db;Username=notification;Password=notification
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
 
   notification-service:
     build:
@@ -344,6 +413,8 @@ services:
       UserService__GrpcEndpoint: http://user-service:8080
       PresenceService__GrpcEndpoint: http://presence-service:8080
     depends_on:
+      notification-migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -386,6 +457,20 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
 
+  discipline-migrations:
+    build:
+      context: ../..
+      dockerfile: src/Services/Discipline/DisciplineService.Api/Dockerfile
+    container_name: urfu-discipline-migrations
+    command: ["dotnet", "DisciplineService.Api.dll", "--migrate"]
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Primary: Host=postgres;Port=5432;Database=discipline_db;Username=discipline;Password=discipline
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
   discipline-service:
     build:
       context: ../..
@@ -398,6 +483,8 @@ services:
       ConnectionStrings__Primary: Host=postgres;Port=5432;Database=discipline_db;Username=discipline;Password=discipline
       Infrastructure__Redis__Configuration: redis:6379
     depends_on:
+      discipline-migrations:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:

--- a/src/BuildingBlocks/ServiceDefaults/MigrationCliRunner.cs
+++ b/src/BuildingBlocks/ServiceDefaults/MigrationCliRunner.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Urfu.Link.BuildingBlocks.ServiceDefaults;
+
+/// <summary>
+/// Centralised <c>--migrate</c> entry point for every EF-backed service.
+/// </summary>
+/// <remarks>
+/// In production the Helm <c>migrations</c> Job (a <c>pre-install,pre-upgrade</c> hook with
+/// <c>helm.sh/hook-weight: -5</c>) spawns a one-shot container with the same image, the same
+/// secrets, and a single argument: <c>--migrate</c>. The Job blocks the rollout until it
+/// finishes — a non-zero exit aborts the upgrade so the new app pods never start against an
+/// un-migrated schema. <see cref="MigrationCliRunner"/> is the single piece of code that
+/// implements that contract; calling it from <c>Program.cs</c> before <c>WebApplication.CreateBuilder</c>
+/// keeps the normal startup path free of any auto-migration hazards (race between replicas,
+/// silent schema upgrades on every pod restart, etc.).
+/// </remarks>
+public static class MigrationCliRunner
+{
+    /// <summary>The CLI flag that selects migration mode.</summary>
+    public const string MigrateArg = "--migrate";
+
+    /// <summary>
+    /// Inspects <paramref name="args"/> for <see cref="MigrateArg"/>; if present, materialises
+    /// <typeparamref name="TContext"/> via <paramref name="configureServices"/> and applies all
+    /// pending migrations. Returns <see langword="true"/> when migration mode was triggered so
+    /// the caller can <c>return</c> from <c>Program.cs</c> instead of starting the web host.
+    /// On migration failure <see cref="Environment.ExitCode"/> is set to <c>1</c> so the
+    /// container exits non-zero and Helm aborts the rollout.
+    /// </summary>
+    public static async Task<bool> TryRunMigrationsAsync<TContext>(
+        string[] args,
+        string serviceName,
+        Action<IServiceCollection> configureServices,
+        CancellationToken cancellationToken = default)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentNullException.ThrowIfNull(configureServices);
+
+        if (!args.Any(a => string.Equals(a, MigrateArg, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        try
+        {
+            var services = new ServiceCollection();
+            configureServices(services);
+
+            await using var provider = services.BuildServiceProvider();
+            await using var scope = provider.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<TContext>();
+
+            await db.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+            await Console.Out.WriteLineAsync($"{serviceName} migrations applied successfully.").ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // CLI entry-point must catch any failure to surface a non-zero exit code for Helm.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            await Console.Error.WriteLineAsync(
+                $"{serviceName} migration failed: {ex.GetType().Name}: {ex.Message}").ConfigureAwait(false);
+            await Console.Error.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
+            Environment.ExitCode = 1;
+        }
+
+        return true;
+    }
+}

--- a/src/BuildingBlocks/ServiceDefaults/ServiceDefaults.csproj
+++ b/src/BuildingBlocks/ServiceDefaults/ServiceDefaults.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="Confluent.Kafka" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/Discipline/DisciplineService.Api/Program.cs
+++ b/src/Services/Discipline/DisciplineService.Api/Program.cs
@@ -12,6 +12,18 @@ using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Migration mode: invoked by the Helm pre-upgrade Job (or the docker-compose
+// `discipline-migrations` sidecar in dev). When triggered, applies pending EF
+// migrations and exits — no web host is started, no HostedServices run.
+if (await MigrationCliRunner.TryRunMigrationsAsync<DisciplineDbContext>(
+    args,
+    "DisciplineService",
+    services => services.AddDbContext<DisciplineDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("Primary")))))
+{
+    return;
+}
+
 builder.Services.AddGrpc();
 builder.Services.AddFastEndpoints();
 builder.Services.SwaggerDocument(o =>
@@ -44,15 +56,10 @@ builder.Services.AddDisciplineModule(builder.Configuration);
 
 var app = builder.Build();
 
-await using (var scope = app.Services.CreateAsyncScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<DisciplineDbContext>();
-    if (db.Database.IsRelational())
-    {
-        await db.Database.MigrateAsync().ConfigureAwait(false);
-    }
-}
-
+// Schema is owned by the Helm pre-upgrade migrations Job (or the dev sidecar)
+// and applied via `dotnet DisciplineService.Api.dll --migrate` exactly once
+// per release. Auto-migrating in startup raced replicas on the schema upgrade
+// at boot — moved out deliberately.
 app.MapServiceDefaults();
 app.UseFastEndpoints(c =>
 {

--- a/src/Services/Media/MediaService.Api/Program.cs
+++ b/src/Services/Media/MediaService.Api/Program.cs
@@ -14,32 +14,19 @@ using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
-if (args.Any(a => string.Equals(a, "--migrate", StringComparison.OrdinalIgnoreCase)))
-{
-    try
-    {
-        var migrateBuilder = WebApplication.CreateBuilder(args);
-        migrateBuilder.Services.AddDbContextPool<MediaDbContext>(options =>
-            options.UseNpgsql(migrateBuilder.Configuration.GetConnectionString("Primary")));
-        var migrateApp = migrateBuilder.Build();
-        await using var migrateScope = migrateApp.Services.CreateAsyncScope();
-        var migrateDb = migrateScope.ServiceProvider.GetRequiredService<MediaDbContext>();
-        await migrateDb.Database.MigrateAsync();
-        await Console.Out.WriteLineAsync("MediaService migrations applied successfully.");
-        return;
-    }
-#pragma warning disable CA1031 // Migration entry-point must catch any failure to surface it as a non-zero exit code for Helm.
-    catch (Exception ex)
-#pragma warning restore CA1031
-    {
-        await Console.Error.WriteLineAsync($"MediaService migration failed: {ex.GetType().Name}: {ex.Message}");
-        await Console.Error.WriteLineAsync(ex.ToString());
-        Environment.ExitCode = 1;
-        return;
-    }
-}
-
 var builder = WebApplication.CreateBuilder(args);
+
+// Migration mode: invoked by the Helm pre-upgrade Job (or the docker-compose
+// `media-migrations` sidecar in dev). When triggered, applies pending EF
+// migrations and exits — no web host is started, no HostedServices run.
+if (await MigrationCliRunner.TryRunMigrationsAsync<MediaDbContext>(
+    args,
+    "MediaService",
+    services => services.AddDbContext<MediaDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("Primary")))))
+{
+    return;
+}
 
 builder.Services.AddGrpc();
 builder.Services.AddFastEndpoints();

--- a/src/Services/Notification/NotificationService.Api/Program.cs
+++ b/src/Services/Notification/NotificationService.Api/Program.cs
@@ -1,16 +1,31 @@
 using FastEndpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
 using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.Services.Notification.Domain;
 using Urfu.Link.Services.Notification.Infrastructure;
+using Urfu.Link.Services.Notification.Infrastructure.Persistence;
 using Urfu.Link.Services.Notification.Messaging;
 using Urfu.Link.Services.Notification.Realtime;
 using Urfu.Link.Services.Notification.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Migration mode: invoked by the Helm pre-upgrade Job (or the docker-compose `*-migrations`
+// sidecar in dev). When triggered, applies pending EF migrations and exits — no web host
+// is started, no HostedServices run. Normal app startup must NEVER auto-migrate, otherwise
+// every replica races on the schema upgrade at boot.
+if (await MigrationCliRunner.TryRunMigrationsAsync<NotificationDbContext>(
+    args,
+    "NotificationService",
+    services => services.AddDbContext<NotificationDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("Primary")))))
+{
+    return;
+}
 
 builder.Services.AddGrpc();
 builder.Services
@@ -84,6 +99,6 @@ app.MapGet("/", (ServiceProfile descriptor) => Results.Ok(new
     utc = DateTimeOffset.UtcNow,
 }));
 
-app.Run();
+await app.RunAsync();
 
 public partial class Program;

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -13,32 +13,19 @@ using Urfu.Link.Services.Presence.Messaging;
 using Urfu.Link.Services.Presence.Realtime;
 using Urfu.Link.Services.Presence.Services;
 
-if (args.Any(a => string.Equals(a, "--migrate", StringComparison.OrdinalIgnoreCase)))
-{
-    try
-    {
-        var migrateBuilder = WebApplication.CreateBuilder(args);
-        migrateBuilder.Services.AddDbContextPool<PresenceDbContext>(options =>
-            options.UseNpgsql(migrateBuilder.Configuration.GetConnectionString("Primary")));
-        var migrateApp = migrateBuilder.Build();
-        await using var migrateScope = migrateApp.Services.CreateAsyncScope();
-        var migrateDb = migrateScope.ServiceProvider.GetRequiredService<PresenceDbContext>();
-        await migrateDb.Database.MigrateAsync();
-        await Console.Out.WriteLineAsync("PresenceService migrations applied successfully.");
-        return;
-    }
-#pragma warning disable CA1031 // Migration entry-point must catch any failure to surface it as a non-zero exit code for Helm.
-    catch (Exception ex)
-#pragma warning restore CA1031
-    {
-        await Console.Error.WriteLineAsync($"PresenceService migration failed: {ex.GetType().Name}: {ex.Message}");
-        await Console.Error.WriteLineAsync(ex.ToString());
-        Environment.ExitCode = 1;
-        return;
-    }
-}
-
 var builder = WebApplication.CreateBuilder(args);
+
+// Migration mode: invoked by the Helm pre-upgrade Job (or the docker-compose
+// `presence-migrations` sidecar in dev). When triggered, applies pending EF
+// migrations and exits — no web host is started, no HostedServices run.
+if (await MigrationCliRunner.TryRunMigrationsAsync<PresenceDbContext>(
+    args,
+    "PresenceService",
+    services => services.AddDbContext<PresenceDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("Primary")))))
+{
+    return;
+}
 
 builder.Services.AddGrpc();
 builder.Services

--- a/src/Services/User/UserService.Api/Program.cs
+++ b/src/Services/User/UserService.Api/Program.cs
@@ -18,6 +18,18 @@ using UserService.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Migration mode: invoked by the Helm pre-upgrade Job (or the docker-compose
+// `user-migrations` sidecar in dev). When triggered, applies pending EF
+// migrations and exits — no web host is started, no HostedServices run.
+if (await MigrationCliRunner.TryRunMigrationsAsync<UserDbContext>(
+    args,
+    "UserService",
+    services => services.AddDbContext<UserDbContext>(options =>
+        options.UseNpgsql(builder.Configuration.GetConnectionString("Primary")))))
+{
+    return;
+}
+
 builder.Services.AddGrpc();
 builder.Services.AddFastEndpoints();
 builder.Services.SwaggerDocument(o =>
@@ -49,13 +61,10 @@ builder.Services.AddUserModule(builder.Configuration);
 
 var app = builder.Build();
 
-await using (var scope = app.Services.CreateAsyncScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<UserDbContext>();
-    if (db.Database.IsRelational())
-        await db.Database.MigrateAsync();
-}
-
+// Schema is owned by the Helm pre-upgrade migrations Job (or the dev sidecar)
+// and applied via `dotnet UserService.Api.dll --migrate` exactly once per
+// release. Auto-migrating in startup raced replicas on the schema upgrade
+// at boot — moved out deliberately.
 app.MapServiceDefaults();
 app.UseFastEndpoints(c =>
 {

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="xunit" />

--- a/tests/unit/BuildingBlocks.UnitTests/ServiceDefaults/MigrationCliRunnerTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/ServiceDefaults/MigrationCliRunnerTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Urfu.Link.BuildingBlocks.ServiceDefaults;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.ServiceDefaults;
+
+/// <summary>
+/// <see cref="MigrationCliRunner"/> is the shared <c>--migrate</c> entry point for every
+/// EF-backed service. The Helm <c>migrations</c> Job spawns a container with this argument
+/// before the main app rolls out, so the helper must (a) honour the flag, (b) leave normal
+/// startup untouched when it's absent, and (c) surface a non-zero exit code when the
+/// migration itself fails so Helm aborts the upgrade.
+/// </summary>
+public sealed class MigrationCliRunnerTests : IDisposable
+{
+    private readonly int _originalExitCode;
+
+    public MigrationCliRunnerTests()
+    {
+        _originalExitCode = Environment.ExitCode;
+        Environment.ExitCode = 0;
+    }
+
+    public void Dispose()
+    {
+        Environment.ExitCode = _originalExitCode;
+    }
+
+    [Fact]
+    public async Task Returns_false_and_skips_migration_when_flag_absent()
+    {
+        var args = new[] { "--other-flag" };
+
+        var migrated = await MigrationCliRunner.TryRunMigrationsAsync<UnreachableDbContext>(
+            args,
+            "test-service",
+            ConfigureUnreachableDbContext,
+            CancellationToken.None);
+
+        migrated.Should().BeFalse("the caller must continue to normal app startup when --migrate isn't passed.");
+        Environment.ExitCode.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("--migrate")]
+    [InlineData("--MIGRATE")]
+    [InlineData("--Migrate")]
+    public async Task Recognises_flag_case_insensitively(string flag)
+    {
+        var args = new[] { flag };
+
+        var migrated = await MigrationCliRunner.TryRunMigrationsAsync<UnreachableDbContext>(
+            args,
+            "test-service",
+            ConfigureUnreachableDbContext,
+            CancellationToken.None);
+
+        // Migration mode was triggered (so caller should exit), even though the migration itself failed.
+        migrated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Sets_exit_code_to_one_when_migration_fails()
+    {
+        var args = new[] { "--migrate" };
+
+        var migrated = await MigrationCliRunner.TryRunMigrationsAsync<UnreachableDbContext>(
+            args,
+            "test-service",
+            ConfigureUnreachableDbContext,
+            CancellationToken.None);
+
+        migrated.Should().BeTrue();
+        Environment.ExitCode.Should().Be(1, "non-zero exit fails the Helm pre-upgrade Job and aborts the rollout.");
+    }
+
+    private static void ConfigureUnreachableDbContext(IServiceCollection services)
+    {
+        // Postgres at port 1 is guaranteed to refuse the connection — exercises the failure path
+        // without binding the test to a real container.
+        services.AddDbContext<UnreachableDbContext>(options =>
+            options.UseNpgsql("Host=localhost;Port=1;Database=missing;Username=u;Password=p;Timeout=2;Command Timeout=2"));
+    }
+
+    private sealed class UnreachableDbContext(DbContextOptions<UnreachableDbContext> options) : DbContext(options);
+}


### PR DESCRIPTION
Refs #234

PR 2 of 7 для EPIC #216 tech debt. Унификация миграций на единый Helm Job pattern для всех 5 EF-сервисов.

## Что сделано

### B0. MigrationCliRunner helper в ServiceDefaults
- ${'`'}src/BuildingBlocks/ServiceDefaults/MigrationCliRunner.cs${'`'} — единая точка входа для ${'`'}--migrate${'`'} флага
- Возвращает ${'`'}bool${'`'}: ${'`'}true${'`'} если миграция отработала (caller должен exit), ${'`'}false${'`'} если нормальный startup
- На ошибке ставит ${'`'}Environment.ExitCode = 1${'`'} → Helm pre-upgrade Job завершается non-zero → rollout abort
- 5 unit-тестов (case-insensitive flag detection, no-op path, exit code propagation)

### B1. NotificationService — добавлен ${'`'}--migrate${'`'}
Раньше не мигрировал вообще: на чистой БД контейнер падал. Теперь использует ${'`'}MigrationCliRunner${'`'}.

### B2-B3. DisciplineService + UserService — рефакторинг
Auto-migrate в startup (race на старте при N репликах) → ${'`'}--migrate${'`'} CLI через ${'`'}MigrationCliRunner${'`'}. Тестовый factory уже мигрирует руками до boot — coverage не пострадал.

### B4. MediaService + PresenceService — переход на helper
Раньше каждый имел свой inline ${'`'}try/catch${'`'} блок (~24 LOC дублирования). Заменено на один вызов helper. Поведение идентично.

### B5. Helm values
В values-{dev,prod}.yaml для notification, user, discipline:
\`\`\`yaml
migrations:
  enabled: true
  command: [\"dotnet\", \"<Service>.Api.dll\", \"--migrate\"]
\`\`\`
${'`'}helm template${'`'} проверен локально — Job рендерится с ${'`'}helm.sh/hook: pre-install,pre-upgrade${'`'} и ${'`'}helm.sh/hook-weight: -5${'`'}.

### B6. docker-compose dev
Добавлены 5 sidecar контейнеров (${'`'}user/media/presence/notification/discipline-migrations${'`'}). Main service ждёт ${'`'}service_completed_successfully${'`'} → schema готова до открытия первого connection. Зеркалит prod-flow.

## Прод-flow (закреплён в issue body)

\`\`\`
1. CI builds image → пушит в GHCR
2. CI обновляет values-prod.yaml image.tag
3. ArgoCD detects → Helm sync
4. Helm pre-upgrade hook (weight -5) запускает Job *-migrations:
   - dotnet *.Api.dll --migrate → MigrateAsync → exit 0
   - На ошибке → backoffLimit retries → Helm ABORT, новые поды НЕ запускаются
5. Argo Rollouts canary раскатывает новые поды (схема уже мигрирована)
6. TTL 600s → Job auto-deleted
\`\`\`

## Как проверить

- ${'`'}dotnet build Urfu.Link.slnx${'`'} — 0 errors
- ${'`'}dotnet test tests/unit/BuildingBlocks.UnitTests${'`'} — 26 passed (включая 5 новых для MigrationCliRunner)
- ${'`'}helm template deploy/helm/charts/urfu-service -f deploy/helm/services/<svc>/values-prod.yaml${'`'} — Job рендерится с правильными hook annotations и command
- ${'`'}docker compose -f platform/dev/docker-compose.dev.yml config${'`'} — валидный YAML, 5 ${'`'}*-migrations${'`'} сервисов
- Каждое EF-приложение: при запуске без ${'`'}--migrate${'`'} startup НЕ мигрирует (visual review Program.cs)