### PR TITLE
fix(#234): chat hub typing through Presence + @teachers/@students resolver

### DIFF
--- a/src/Services/Chat/ChatService.Api/Application/Disciplines/IDisciplineServiceClient.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Disciplines/IDisciplineServiceClient.cs
@@ -14,13 +14,30 @@ public sealed record UserDisciplineSnapshot(
     ParticipantRole Role);
 
 /// <summary>
-/// Inbound view of DisciplineService used by ChatService at SignalR connection time.
-/// Production implementation is a thin wrapper around the gRPC InternalApi client; tests
-/// substitute a fake without booting Kestrel.
+/// One member of a discipline (teacher or student). Returned by
+/// <see cref="IDisciplineServiceClient.ListMembersAsync"/> so the mention resolver can
+/// expand <c>@teachers</c> / <c>@students</c> into concrete user ids.
+/// </summary>
+public sealed record DisciplineMember(Guid UserId, ParticipantRole Role);
+
+/// <summary>
+/// Inbound view of DisciplineService used by ChatService at SignalR connection time and
+/// by the mention resolver. Production implementation is a thin wrapper around the gRPC
+/// InternalApi client; tests substitute a fake without booting Kestrel.
 /// </summary>
 public interface IDisciplineServiceClient
 {
     Task<IReadOnlyList<UserDisciplineSnapshot>> ListUserDisciplinesAsync(
         Guid userId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists every member of a discipline together with their role. Used by the
+    /// <c>@teachers</c> / <c>@students</c> mention resolver in discipline conversations.
+    /// Returns an empty list if the discipline does not exist (the gRPC <c>exists</c>
+    /// flag is collapsed into "no members").
+    /// </summary>
+    Task<IReadOnlyList<DisciplineMember>> ListMembersAsync(
+        Guid disciplineId,
         CancellationToken cancellationToken);
 }

--- a/src/Services/Chat/ChatService.Api/Application/Mentions/MentionResolver.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Mentions/MentionResolver.cs
@@ -1,0 +1,113 @@
+using System.Text.RegularExpressions;
+using Urfu.Link.Services.Chat.Application.Disciplines;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.Application.Mentions;
+
+/// <summary>
+/// Resolves the full mention set for a message body, including the discipline-only
+/// <c>@teachers</c> and <c>@students</c> tokens that <see cref="MentionsParser"/>
+/// alone cannot expand. Composes with <see cref="MentionsParser.Parse"/> for the
+/// participant-only tokens (<c>@&lt;guid&gt;</c>, <c>@everyone</c>) and adds an async
+/// roundtrip to <see cref="IDisciplineServiceClient.ListMembersAsync"/> when the
+/// conversation is a discipline group.
+/// </summary>
+/// <remarks>
+/// Direct conversations reject <c>@teachers</c> / <c>@students</c> by silently dropping
+/// the token — there is no role hierarchy in a 1:1 chat. The discipline gRPC call is
+/// uncached at this layer; PresenceService-style projection caching can be layered
+/// on later if the round-trip becomes a hot path.
+/// </remarks>
+public sealed partial class MentionResolver(IDisciplineServiceClient disciplineServiceClient)
+{
+    [GeneratedRegex(@"@(?<token>teachers|students)\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 500)]
+    private static partial Regex SpecialTokensRegex();
+
+    public async Task<IReadOnlyList<Guid>> ResolveAsync(
+        string? body,
+        Conversation conversation,
+        int maxMentions,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(conversation);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxMentions);
+
+        // Step 1: explicit user ids and @everyone — purely synchronous, no gRPC.
+        var explicitMentions = MentionsParser.Parse(body, conversation.Participants, maxMentions);
+
+        if (explicitMentions.Count >= maxMentions || string.IsNullOrEmpty(body))
+        {
+            return explicitMentions;
+        }
+
+        // Step 2: @teachers / @students — discipline-only, requires gRPC.
+        if (conversation.GroupSubtype != GroupSubtype.Discipline ||
+            conversation.DisciplineId is not Guid disciplineId)
+        {
+            return explicitMentions;
+        }
+
+        var (mentionsTeachers, mentionsStudents) = ScanSpecialTokens(body);
+        if (!mentionsTeachers && !mentionsStudents)
+        {
+            return explicitMentions;
+        }
+
+        var members = await disciplineServiceClient
+            .ListMembersAsync(disciplineId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var participantSet = new HashSet<Guid>(conversation.Participants);
+        var combined = new List<Guid>(explicitMentions);
+        var seen = new HashSet<Guid>(combined);
+
+        foreach (var member in members)
+        {
+            if (combined.Count >= maxMentions)
+            {
+                break;
+            }
+
+            // Skip if not actually in the conversation (the discipline roster and the chat
+            // roster can drift between an enrollment Kafka event and its projection).
+            if (!participantSet.Contains(member.UserId))
+            {
+                continue;
+            }
+
+            var roleMatches = (mentionsTeachers && member.Role == ParticipantRole.Teacher)
+                           || (mentionsStudents && member.Role == ParticipantRole.Student);
+
+            if (roleMatches && seen.Add(member.UserId))
+            {
+                combined.Add(member.UserId);
+            }
+        }
+
+        return combined;
+    }
+
+    /// <summary>Walks the body once to detect whether teachers/students tokens are present.</summary>
+    private static (bool teachers, bool students) ScanSpecialTokens(string body)
+    {
+        var teachers = false;
+        var students = false;
+        foreach (Match match in SpecialTokensRegex().Matches(body))
+        {
+            var token = match.Groups["token"].Value;
+            if (string.Equals(token, "teachers", StringComparison.OrdinalIgnoreCase))
+            {
+                teachers = true;
+            }
+            else if (string.Equals(token, "students", StringComparison.OrdinalIgnoreCase))
+            {
+                students = true;
+            }
+        }
+
+        return (teachers, students);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/EditMessageService.cs
@@ -19,6 +19,7 @@ public sealed class EditMessageService(
     IOptions<ChatOptions> options,
     ChatEventDispatcher dispatcher,
     IChatBroadcaster broadcaster,
+    MentionResolver mentionResolver,
     TimeProvider clock)
 {
     public async Task<MessageDto> EditAsync(EditMessageRequest request, CancellationToken cancellationToken)
@@ -63,7 +64,9 @@ public sealed class EditMessageService(
             throw ChatEditTtlExpiredException.For(message.Id, ttl);
         }
 
-        var mentions = MentionsParser.Parse(request.NewBody, conversation.Participants, opts.MaxMentionsPerMessage);
+        var mentions = await mentionResolver
+            .ResolveAsync(request.NewBody, conversation, opts.MaxMentionsPerMessage, cancellationToken)
+            .ConfigureAwait(false);
         var priorMentions = new HashSet<Guid>(message.Mentions);
         var newlyAddedMentions = mentions.Where(m => !priorMentions.Contains(m)).ToList();
         var historyEntry = new EditHistoryEntry(message.Body, message.EditedAtUtc ?? message.CreatedAtUtc);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -27,6 +27,7 @@ public sealed class SendMessageService(
     ChatEventDispatcher dispatcher,
     IChatBroadcaster broadcaster,
     IPresenceServiceClient presenceClient,
+    MentionResolver mentionResolver,
     TimeProvider clock,
     IOptions<ChatOptions> options)
 {
@@ -87,7 +88,9 @@ public sealed class SendMessageService(
             .ConfigureAwait(false);
 
         var opts = options.Value;
-        var mentions = MentionsParser.Parse(request.Body, conversation.Participants, opts.MaxMentionsPerMessage);
+        var mentions = await mentionResolver
+            .ResolveAsync(request.Body, conversation, opts.MaxMentionsPerMessage, cancellationToken)
+            .ConfigureAwait(false);
 
         var now = clock.GetUtcNow();
         var message = Message.Send(

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -3,6 +3,7 @@ using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Mentions;
+using Urfu.Link.Services.Chat.Application.Presence;
 using Urfu.Link.Services.Chat.Domain.Aggregates;
 using Urfu.Link.Services.Chat.Domain.Events;
 using Urfu.Link.Services.Chat.Domain.Interfaces;
@@ -25,6 +26,7 @@ public sealed class SendMessageService(
     IIdempotencyStore idempotencyStore,
     ChatEventDispatcher dispatcher,
     IChatBroadcaster broadcaster,
+    IPresenceServiceClient presenceClient,
     TimeProvider clock,
     IOptions<ChatOptions> options)
 {
@@ -147,6 +149,13 @@ public sealed class SendMessageService(
 
         var dto = MessageDto.FromDomain(message);
         await broadcaster.NotifyMessageReceivedAsync(recipients, dto, cancellationToken).ConfigureAwait(false);
+
+        // Auto-clear the sender's typing indicator on PresenceService — sending a message
+        // implies the user is no longer typing, even if their client did not fire the
+        // explicit StopTyping. Failures are swallowed by the client (fail-open contract).
+        await presenceClient
+            .SetTypingAsync(request.ConversationId, request.SenderId, isTyping: false, cancellationToken)
+            .ConfigureAwait(false);
 
         return dto;
     }

--- a/src/Services/Chat/ChatService.Api/Application/Presence/IPresenceServiceClient.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Presence/IPresenceServiceClient.cs
@@ -1,0 +1,19 @@
+namespace Urfu.Link.Services.Chat.Application.Presence;
+
+/// <summary>
+/// Outbound view of PresenceService used by ChatHub to flip the typing indicator
+/// after authorising the caller. Implemented in production by a thin gRPC wrapper
+/// (<c>Infrastructure/Grpc/PresenceServiceClient</c>); tests replace it with a fake
+/// so they don't need a live PresenceService.
+/// </summary>
+public interface IPresenceServiceClient
+{
+    /// <summary>
+    /// Marks <paramref name="userId"/> as currently typing in the conversation.
+    /// Idempotent: re-running while already typing just refreshes the TTL on the
+    /// indicator. Network failures fail open — chat-side authorization has already
+    /// passed at this point and dropping a typing indicator is preferable to
+    /// raising an exception that aborts the SignalR call.
+    /// </summary>
+    Task SetTypingAsync(string conversationId, Guid userId, bool isTyping, CancellationToken cancellationToken);
+}

--- a/src/Services/Chat/ChatService.Api/Application/Threads/ReplyInThreadService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Threads/ReplyInThreadService.cs
@@ -42,6 +42,7 @@ public sealed class ReplyInThreadService(
     IIdempotencyStore idempotencyStore,
     ChatEventDispatcher dispatcher,
     IChatBroadcaster broadcaster,
+    MentionResolver mentionResolver,
     TimeProvider clock,
     IOptions<ChatOptions> options)
 {
@@ -92,7 +93,9 @@ public sealed class ReplyInThreadService(
         var replyTo = await ResolveReplyToInThreadAsync(root, request.ReplyToMessageId, cancellationToken).ConfigureAwait(false);
 
         var opts = options.Value;
-        var mentions = MentionsParser.Parse(request.Body, conversation.Participants, opts.MaxMentionsPerMessage);
+        var mentions = await mentionResolver
+            .ResolveAsync(request.Body, conversation, opts.MaxMentionsPerMessage, cancellationToken)
+            .ConfigureAwait(false);
 
         var now = clock.GetUtcNow();
         var reply = Message.SendAsThreadReply(

--- a/src/Services/Chat/ChatService.Api/ChatService.Api.csproj
+++ b/src/Services/Chat/ChatService.Api/ChatService.Api.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\..\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\Discipline\DisciplineService.Api.Contracts\DisciplineService.Api.Contracts.csproj" />
     <ProjectReference Include="..\..\Media\MediaService.Api.Contracts\MediaService.Api.Contracts.csproj" />
+    <ProjectReference Include="..\..\Presence\PresenceService.Api.Contracts\PresenceService.Api.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -131,6 +131,45 @@ public static class ModuleRegistration
         });
         services.AddSingleton<IDisciplineServiceClient, DisciplineServiceClient>();
 
+        services.AddOptions<PresenceServiceClientOptions>()
+            .Bind(configuration.GetSection(PresenceServiceClientOptions.SectionName));
+        var presenceAddress = configuration[$"{PresenceServiceClientOptions.SectionName}:Address"];
+        if (!string.IsNullOrWhiteSpace(presenceAddress))
+        {
+            services.AddSingleton(sp =>
+            {
+                var opts = sp.GetRequiredService<IOptions<PresenceServiceClientOptions>>().Value;
+                var retryPolicy = new RetryPolicy
+                {
+                    MaxAttempts = 3,
+                    InitialBackoff = TimeSpan.FromMilliseconds(100),
+                    MaxBackoff = TimeSpan.FromSeconds(2),
+                    BackoffMultiplier = 2,
+                    RetryableStatusCodes = { StatusCode.Unavailable, StatusCode.DeadlineExceeded },
+                };
+
+                var channel = GrpcChannel.ForAddress(opts.Address, new GrpcChannelOptions
+                {
+                    ServiceConfig = new ServiceConfig
+                    {
+                        MethodConfigs =
+                        {
+                            new MethodConfig { Names = { MethodName.Default }, RetryPolicy = retryPolicy },
+                        },
+                    },
+                });
+                return new Urfu.Link.Services.Presence.Grpc.InternalApi.InternalApiClient(channel);
+            });
+            services.AddSingleton<Urfu.Link.Services.Chat.Application.Presence.IPresenceServiceClient,
+                PresenceServiceClient>();
+        }
+        else
+        {
+            // Stub for tests and on-prem deployments without PresenceService.
+            services.AddSingleton<Urfu.Link.Services.Chat.Application.Presence.IPresenceServiceClient,
+                NoopPresenceServiceClient>();
+        }
+
         services.TryAddSingleton(TimeProvider.System);
         services.AddScoped<ChatEventDispatcher>();
         services.AddScoped<OpenDirectConversationService>();

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -195,6 +195,7 @@ public static class ModuleRegistration
         services.AddScoped<GetUserActiveThreadsQuery>();
         services.AddScoped<SearchMessagesQuery>();
         services.AddScoped<DisciplineConversationService>();
+        services.AddScoped<Urfu.Link.Services.Chat.Application.Mentions.MentionResolver>();
         services.AddHostedService<DisciplineEventConsumer>();
 
         // Per-user fixed window for /chat/search (issue #213 — 30 req/min per user).

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/DisciplineServiceClient.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/DisciplineServiceClient.cs
@@ -36,6 +36,32 @@ internal sealed class DisciplineServiceClient(DisciplineGrpc.InternalApi.Interna
             .ToList();
     }
 
+    public async Task<IReadOnlyList<DisciplineMember>> ListMembersAsync(
+        Guid disciplineId,
+        CancellationToken cancellationToken)
+    {
+        var request = new DisciplineGrpc.ListMembersRequest
+        {
+            DisciplineId = disciplineId.ToString("D", CultureInfo.InvariantCulture),
+        };
+
+        var reply = await grpcClient
+            .ListMembersAsync(request, cancellationToken: cancellationToken)
+            .ResponseAsync
+            .ConfigureAwait(false);
+
+        if (!reply.Exists)
+        {
+            return [];
+        }
+
+        return reply.Members
+            .Select(m => new DisciplineMember(
+                UserId: Guid.Parse(m.UserId),
+                Role: MapRole(m.Role)))
+            .ToList();
+    }
+
     private static ParticipantRole MapRole(DisciplineGrpc.MembershipRole role) => role switch
     {
         DisciplineGrpc.MembershipRole.Teacher => ParticipantRole.Teacher,

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/NoopPresenceServiceClient.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/NoopPresenceServiceClient.cs
@@ -1,0 +1,15 @@
+using Urfu.Link.Services.Chat.Application.Presence;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Grpc;
+
+/// <summary>
+/// No-op fallback for the typing fan-out used when <c>GrpcClients:PresenceService:Address</c>
+/// is not configured (tests, on-prem profiles without presence). Lets ChatHub call
+/// <c>SetTypingAsync</c> unconditionally — the chat-side authorization still runs, the
+/// signal simply doesn't propagate.
+/// </summary>
+internal sealed class NoopPresenceServiceClient : IPresenceServiceClient
+{
+    public Task SetTypingAsync(string conversationId, Guid userId, bool isTyping, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/PresenceServiceClient.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/PresenceServiceClient.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Urfu.Link.Services.Chat.Application.Presence;
+using PresenceGrpc = Urfu.Link.Services.Presence.Grpc;
+
+namespace Urfu.Link.Services.Chat.Infrastructure.Grpc;
+
+/// <summary>
+/// Production gRPC implementation of <see cref="IPresenceServiceClient"/>. Wraps the
+/// <c>SetTyping</c> rpc on PresenceService so domain code never sees protobuf types.
+/// </summary>
+/// <remarks>
+/// Conversation ids in chat are deterministic strings (SHA1 for direct, <c>discipline:GUID</c>
+/// for groups). PresenceService stores typing per-conversation by GUID, so for direct chats
+/// we hash the deterministic string into a stable GUID before sending. Discipline
+/// conversation ids embed the GUID directly — extract it.
+/// </remarks>
+internal sealed class PresenceServiceClient(
+    PresenceGrpc.InternalApi.InternalApiClient grpcClient,
+    ILogger<PresenceServiceClient> logger) : IPresenceServiceClient
+{
+    private const string DisciplinePrefix = "discipline:";
+
+    public async Task SetTypingAsync(
+        string conversationId,
+        Guid userId,
+        bool isTyping,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+
+        var conversationGuid = MapToConversationGuid(conversationId);
+        var request = new PresenceGrpc.SetTypingRequest
+        {
+            ConversationId = conversationGuid.ToString("D", CultureInfo.InvariantCulture),
+            UserId = userId.ToString("D", CultureInfo.InvariantCulture),
+            IsTyping = isTyping,
+        };
+
+        try
+        {
+            await grpcClient
+                .SetTypingAsync(request, cancellationToken: cancellationToken)
+                .ResponseAsync
+                .ConfigureAwait(false);
+        }
+        catch (RpcException ex)
+        {
+            // Fail open: chat-side authorization already passed. Dropping the typing
+            // signal is preferable to surfacing the failure as a SignalR exception.
+            logger.LogWarning(
+                ex,
+                "PresenceService SetTyping failed for {ConversationId}/{UserId}; ignoring.",
+                conversationId,
+                userId);
+        }
+    }
+
+    /// <summary>
+    /// PresenceService keys typing by <see cref="Guid"/>. Direct conversation ids in chat are
+    /// deterministic SHA1 strings; map them to a stable GUID. Discipline conversation ids
+    /// already embed the GUID — extract it.
+    /// </summary>
+    internal static Guid MapToConversationGuid(string conversationId)
+    {
+        if (conversationId.StartsWith(DisciplinePrefix, StringComparison.Ordinal))
+        {
+            var guidPart = conversationId[DisciplinePrefix.Length..];
+            if (Guid.TryParse(guidPart, out var disciplineId))
+            {
+                return disciplineId;
+            }
+        }
+
+        // Direct conversation id — derive a stable Guid via SHA1 truncation. SHA1 is used
+        // here as a non-cryptographic deterministic hash (same justification as
+        // Conversation.OpenDirect): the same string maps to the same Guid every time so
+        // PresenceService keys remain stable. Collisions would only matter for identifier
+        // reuse, not security.
+#pragma warning disable CA5350
+        Span<byte> hash = stackalloc byte[20];
+        System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(conversationId), hash);
+#pragma warning restore CA5350
+        return new Guid(hash[..16]);
+    }
+}

--- a/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/PresenceServiceClientOptions.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/Grpc/PresenceServiceClientOptions.cs
@@ -1,0 +1,13 @@
+namespace Urfu.Link.Services.Chat.Infrastructure.Grpc;
+
+/// <summary>
+/// Configuration for the gRPC client that fans out typing signals to PresenceService.
+/// Empty address disables the client and falls back to the no-op stub registered in DI —
+/// appropriate for tests and on-prem profiles without presence.
+/// </summary>
+public sealed class PresenceServiceClientOptions
+{
+    public const string SectionName = "GrpcClients:PresenceService";
+
+    public string Address { get; set; } = string.Empty;
+}

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -3,6 +3,7 @@ using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using MongoDB.Driver;
+using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Application.Disciplines;
@@ -50,6 +51,7 @@ public sealed class ChatHub(
     GetThreadMessagesQuery getThreadMessages,
     IConversationRepository conversationRepository,
     IDisciplineServiceClient disciplineServiceClient,
+    Application.Presence.IPresenceServiceClient presenceServiceClient,
     ILogger<ChatHub> logger) : Hub<IChatClient>
 {
     /// <summary>
@@ -268,5 +270,46 @@ public sealed class ChatHub(
         var caller = Context.User!.GetUserId();
         return getThreadMessages.ExecuteAsync(
             rootMessageId, caller, cursor, limit, CursorDirection.Older, Context.ConnectionAborted);
+    }
+
+    /// <summary>
+    /// Marks the caller as currently typing in the conversation. Refreshes the per-user TTL
+    /// on PresenceService so the indicator stays alive while the user keeps typing. Verifies
+    /// chat-side participation first so a non-member cannot pollute another conversation's
+    /// typing state.
+    /// </summary>
+    public async Task StartTyping(string conversationId)
+    {
+        await SetTypingAsync(conversationId, isTyping: true).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Clears the caller's typing indicator in the conversation immediately, regardless of TTL.
+    /// Called when the user blurs the input or sends the message; SendMessageService also
+    /// fires this server-side after a successful send.
+    /// </summary>
+    public async Task StopTyping(string conversationId)
+    {
+        await SetTypingAsync(conversationId, isTyping: false).ConfigureAwait(false);
+    }
+
+    private async Task SetTypingAsync(string conversationId, bool isTyping)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        var caller = Context.User!.GetUserId();
+
+        var conversation = await conversationRepository
+            .GetByIdAsync(conversationId, Context.ConnectionAborted)
+            .ConfigureAwait(false);
+        if (conversation is null || !conversation.Participants.Contains(caller))
+        {
+            // Match the rest of the hub: typing in a conversation you're not in is a no-op,
+            // not a leak. The exception type aligns with PinMessage / DeleteMessage paths.
+            throw new ChatAccessDeniedException(conversationId, caller);
+        }
+
+        await presenceServiceClient
+            .SetTypingAsync(conversationId, caller, isTyping, Context.ConnectionAborted)
+            .ConfigureAwait(false);
     }
 }

--- a/src/Services/Presence/PresenceService.Api.Contracts/Protos/internal.proto
+++ b/src/Services/Presence/PresenceService.Api.Contracts/Protos/internal.proto
@@ -9,6 +9,11 @@ service InternalApi {
   rpc GetPresenceBatch(GetPresenceBatchRequest) returns (GetPresenceBatchReply);
   rpc IsOnline(IsOnlineRequest) returns (IsOnlineReply);
   rpc IsTyping(IsTypingRequest) returns (IsTypingReply);
+  // Server-to-server signal that a user started or stopped typing in a conversation.
+  // ChatHub.StartTyping/StopTyping fan out to this endpoint instead of clients calling
+  // PresenceHub directly, so chat-internal authorization (IsParticipant) is enforced
+  // before the typing indicator becomes visible.
+  rpc SetTyping(SetTypingRequest) returns (SetTypingReply);
 }
 
 message PingRequest {
@@ -72,4 +77,17 @@ message IsTypingRequest {
 
 message IsTypingReply {
   bool is_typing = 1;
+}
+
+message SetTypingRequest {
+  string conversation_id = 1;
+  string user_id = 2;
+  // true = StartTyping (refreshes the per-user TTL), false = StopTyping (deletes the key).
+  bool is_typing = 3;
+}
+
+message SetTypingReply {
+  // True when the underlying Redis state actually changed
+  // (a new typing entry was created, or a stale one was removed).
+  bool changed = 1;
 }

--- a/src/Services/Presence/PresenceService.Api/Services/InternalApiService.cs
+++ b/src/Services/Presence/PresenceService.Api/Services/InternalApiService.cs
@@ -69,6 +69,23 @@ public sealed class InternalApiService(
         return new IsTypingReply { IsTyping = typingNow };
     }
 
+    public override async Task<SetTypingReply> SetTyping(SetTypingRequest request, ServerCallContext context)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+        var conv = ParseConversationId(request.ConversationId);
+        var user = ParseUserId(request.UserId);
+
+        // The store reports `changed = true` when it actually mutated state (created a
+        // fresh entry on Start, or removed an existing one on Stop). Callers can use
+        // this to avoid emitting redundant typing broadcasts for keep-alive refreshes.
+        var changed = request.IsTyping
+            ? await typing.StartTypingAsync(conv, user, context.CancellationToken).ConfigureAwait(false)
+            : await typing.StopTypingAsync(conv, user, context.CancellationToken).ConfigureAwait(false);
+
+        return new SetTypingReply { Changed = changed };
+    }
+
     private async Task<Domain.ValueObjects.AggregatedPresence> BuildAggregatedAsync(
         Guid userId, CancellationToken ct)
     {

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubTypingTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubTypingTests.cs
@@ -1,0 +1,110 @@
+using ChatService.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Urfu.Link.Services.Chat.Application.Contracts;
+
+namespace ChatService.IntegrationTests.Hub;
+
+/// <summary>
+/// Integration coverage for ChatHub.StartTyping / StopTyping. Until this PR the
+/// only path to PresenceService was a direct PresenceHub call from clients,
+/// which bypassed chat-side <c>IsParticipant</c> authorization. ChatHub now
+/// fans out the signal via gRPC after verifying participation; SendMessage
+/// also fires StopTyping after a successful send so the indicator clears
+/// without the client having to remember.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+public sealed class ChatHubTypingTests(ChatServiceFactory factory) : IAsyncLifetime
+{
+    private readonly ChatServiceFactory _factory = factory;
+
+    public Task InitializeAsync() => _factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task StartTyping_fans_out_to_presence_service()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+
+        await aliceConn.InvokeAsync("StartTyping", conv.Id);
+
+        _factory.PresenceServiceClient.Records.Should()
+            .ContainSingle(r => r.UserId == alice && r.ConversationId == conv.Id && r.IsTyping,
+                "ChatHub.StartTyping must fan the signal out to PresenceService.SetTyping(isTyping=true).");
+    }
+
+    [Fact]
+    public async Task StopTyping_fans_out_to_presence_service_with_isTyping_false()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+
+        await aliceConn.InvokeAsync("StopTyping", conv.Id);
+
+        _factory.PresenceServiceClient.Records.Should()
+            .ContainSingle(r => r.UserId == alice && r.ConversationId == conv.Id && !r.IsTyping);
+    }
+
+    [Fact]
+    public async Task StartTyping_rejects_non_participant()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+        await using var strangerConn = await TestChatHubClient.ConnectAsync(_factory, stranger);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+
+        var act = async () => await strangerConn.InvokeAsync("StartTyping", conv.Id);
+
+        await act.Should().ThrowAsync<HubException>(
+            "typing in a conversation you cannot see is a security boundary, not a no-op.");
+
+        _factory.PresenceServiceClient.Records.Should().BeEmpty(
+            "PresenceService must not receive a typing signal for a non-participant.");
+    }
+
+    [Fact]
+    public async Task SendMessage_auto_clears_typing_indicator_for_sender()
+    {
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        await using var aliceConn = await TestChatHubClient.ConnectAsync(_factory, alice);
+        await using var bobConn = await TestChatHubClient.ConnectAsync(_factory, bob);
+
+        var conv = await aliceConn.InvokeAsync<ConversationDto>("OpenDirectConversation", bob);
+
+        // Alice starts typing, then sends — the explicit StopTyping should not be needed.
+        await aliceConn.InvokeAsync("StartTyping", conv.Id);
+        _factory.PresenceServiceClient.Reset();
+
+        await aliceConn.InvokeAsync<MessageDto>("SendMessage", new
+        {
+            ConversationId = conv.Id,
+            Body = "hello",
+            AttachmentAssetIds = Array.Empty<Guid>(),
+            ClientMessageId = $"c-{Guid.NewGuid():N}",
+        });
+
+        _factory.PresenceServiceClient.Records.Should()
+            .ContainSingle(r => r.UserId == alice && r.ConversationId == conv.Id && !r.IsTyping,
+                "SendMessageService must auto-stop the sender's typing indicator after a successful send.");
+    }
+}

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -14,6 +14,7 @@ using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application.Authorization;
 using Urfu.Link.Services.Chat.Application.Disciplines;
 using Urfu.Link.Services.Chat.Application.Messages;
+using Urfu.Link.Services.Chat.Application.Presence;
 using Urfu.Link.Services.Chat.Infrastructure.Persistence;
 using Urfu.Link.Services.Chat.Realtime;
 
@@ -45,6 +46,8 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
 
     public FakeDisciplineServiceClient DisciplineServiceClient { get; } = new();
 
+    public FakePresenceServiceClient PresenceServiceClient { get; } = new();
+
     public IIdempotencyStore IdempotencyStore { get; } = Substitute.For<IIdempotencyStore>();
 
     public string MongoConnectionString => _mongo.GetConnectionString();
@@ -73,6 +76,7 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
         DisciplineRoleResolver.Reset();
         ChatBroadcaster.Reset();
         DisciplineServiceClient.Reset();
+        PresenceServiceClient.Reset();
         TestAuthHandler.CurrentPrincipal = null;
     }
 
@@ -143,6 +147,9 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
             // Drop the gRPC channel + InternalApiClient registration so it doesn't try to dial
             // the production discipline-service address during tests.
             services.RemoveAll<Urfu.Link.Services.Disciplines.Grpc.InternalApi.InternalApiClient>();
+
+            services.RemoveAll<IPresenceServiceClient>();
+            services.AddSingleton<IPresenceServiceClient>(PresenceServiceClient);
 
             ReplaceAuthWithTestScheme(services);
         });

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeDisciplineServiceClient.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/FakeDisciplineServiceClient.cs
@@ -10,9 +10,13 @@ namespace ChatService.IntegrationTests.Infrastructure;
 public sealed class FakeDisciplineServiceClient : IDisciplineServiceClient
 {
     private readonly Dictionary<Guid, List<UserDisciplineSnapshot>> _disciplinesByUser = new();
+    private readonly Dictionary<Guid, List<DisciplineMember>> _membersByDiscipline = new();
     private readonly System.Collections.Concurrent.ConcurrentBag<Guid> _calledForUsers = new();
+    private readonly System.Collections.Concurrent.ConcurrentBag<Guid> _calledForDisciplines = new();
 
     public IReadOnlyCollection<Guid> CalledForUsers => _calledForUsers;
+
+    public IReadOnlyCollection<Guid> CalledForDisciplines => _calledForDisciplines;
 
     public void Seed(Guid userId, params UserDisciplineSnapshot[] disciplines)
     {
@@ -20,10 +24,18 @@ public sealed class FakeDisciplineServiceClient : IDisciplineServiceClient
         _disciplinesByUser[userId] = disciplines.ToList();
     }
 
+    public void SeedMembers(Guid disciplineId, params DisciplineMember[] members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+        _membersByDiscipline[disciplineId] = members.ToList();
+    }
+
     public void Reset()
     {
         _disciplinesByUser.Clear();
+        _membersByDiscipline.Clear();
         _calledForUsers.Clear();
+        _calledForDisciplines.Clear();
     }
 
     public Task<IReadOnlyList<UserDisciplineSnapshot>> ListUserDisciplinesAsync(
@@ -36,5 +48,17 @@ public sealed class FakeDisciplineServiceClient : IDisciplineServiceClient
             return Task.FromResult<IReadOnlyList<UserDisciplineSnapshot>>(list.ToList());
         }
         return Task.FromResult<IReadOnlyList<UserDisciplineSnapshot>>(Array.Empty<UserDisciplineSnapshot>());
+    }
+
+    public Task<IReadOnlyList<DisciplineMember>> ListMembersAsync(
+        Guid disciplineId,
+        CancellationToken cancellationToken)
+    {
+        _calledForDisciplines.Add(disciplineId);
+        if (_membersByDiscipline.TryGetValue(disciplineId, out var members))
+        {
+            return Task.FromResult<IReadOnlyList<DisciplineMember>>(members.ToList());
+        }
+        return Task.FromResult<IReadOnlyList<DisciplineMember>>(Array.Empty<DisciplineMember>());
     }
 }

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/FakePresenceServiceClient.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/FakePresenceServiceClient.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+using Urfu.Link.Services.Chat.Application.Presence;
+
+namespace ChatService.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Test stand-in for <see cref="IPresenceServiceClient"/>. Records every SetTyping invocation
+/// so tests can assert that ChatHub.StartTyping/StopTyping fanned out, and that
+/// SendMessageService also fired StopTyping after a successful send.
+/// </summary>
+public sealed record FakeSetTypingRecord(string ConversationId, Guid UserId, bool IsTyping);
+
+public sealed class FakePresenceServiceClient : IPresenceServiceClient
+{
+    private readonly ConcurrentBag<FakeSetTypingRecord> _records = new();
+
+    public IReadOnlyCollection<FakeSetTypingRecord> Records => _records;
+
+    public void Reset()
+    {
+        while (_records.TryTake(out _))
+        {
+            // drain
+        }
+    }
+
+    public Task SetTypingAsync(string conversationId, Guid userId, bool isTyping, CancellationToken cancellationToken)
+    {
+        _records.Add(new FakeSetTypingRecord(conversationId, userId, isTyping));
+        return Task.CompletedTask;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/EditMessageServiceTests.cs
@@ -36,7 +36,9 @@ public class EditMessageServiceTests
             _outbox,
             new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
         var options = Options.Create(new ChatOptions { EditTtlHours = 48, MaxMentionsPerMessage = 50 });
-        return new EditMessageService(_conversations, _messages, options, dispatcher, _broadcaster, _clock);
+        var disciplineClient = Substitute.For<Urfu.Link.Services.Chat.Application.Disciplines.IDisciplineServiceClient>();
+        var mentions = new Urfu.Link.Services.Chat.Application.Mentions.MentionResolver(disciplineClient);
+        return new EditMessageService(_conversations, _messages, options, dispatcher, _broadcaster, mentions, _clock);
     }
 
     private (Conversation conversation, Message message) Seed(Guid sender, DateTimeOffset createdAt)

--- a/tests/unit/ChatService.UnitTests/Application/MentionResolverTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/MentionResolverTests.cs
@@ -1,0 +1,157 @@
+using FluentAssertions;
+using NSubstitute;
+using Urfu.Link.Services.Chat.Application.Disciplines;
+using Urfu.Link.Services.Chat.Application.Mentions;
+using Urfu.Link.Services.Chat.Domain.Aggregates;
+using Urfu.Link.Services.Chat.Domain.Enums;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Application;
+
+/// <summary>
+/// Unit coverage for <see cref="MentionResolver"/>. Direct chats must reject the
+/// discipline-only <c>@teachers</c> / <c>@students</c> tokens (silent drop, no gRPC),
+/// while discipline group conversations must call out to DisciplineService and merge
+/// the role-filtered roster with explicit mentions, deduplicated and capped.
+/// </summary>
+public sealed class MentionResolverTests
+{
+    private static readonly Guid TeacherA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TeacherB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid StudentA = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid StudentB = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid DisciplineId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private readonly IDisciplineServiceClient _discipline = Substitute.For<IDisciplineServiceClient>();
+
+    [Fact]
+    public async Task Direct_chat_silently_drops_teachers_and_students_tokens_without_grpc_call()
+    {
+        var direct = Conversation.OpenDirect(TeacherA, StudentA, DateTimeOffset.UtcNow);
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("hi @teachers and @students", direct, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEmpty(
+            "direct chats have no role hierarchy; the special tokens have no expansion target.");
+
+        await _discipline.DidNotReceive().ListMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Discipline_chat_expands_teachers_token_via_grpc()
+    {
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA, TeacherB, StudentA]);
+        _discipline.ListMembersAsync(DisciplineId, Arg.Any<CancellationToken>()).Returns(new List<DisciplineMember>
+        {
+            new(TeacherA, ParticipantRole.Teacher),
+            new(TeacherB, ParticipantRole.Teacher),
+            new(StudentA, ParticipantRole.Student),
+        });
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("@teachers please review", conv, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEquivalentTo([TeacherA, TeacherB]);
+    }
+
+    [Fact]
+    public async Task Discipline_chat_expands_students_token_via_grpc()
+    {
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA, StudentA, StudentB]);
+        _discipline.ListMembersAsync(DisciplineId, Arg.Any<CancellationToken>()).Returns(new List<DisciplineMember>
+        {
+            new(TeacherA, ParticipantRole.Teacher),
+            new(StudentA, ParticipantRole.Student),
+            new(StudentB, ParticipantRole.Student),
+        });
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("@students homework!", conv, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEquivalentTo([StudentA, StudentB]);
+    }
+
+    [Fact]
+    public async Task Discipline_chat_dedupes_explicit_and_role_based_mentions()
+    {
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA, TeacherB, StudentA]);
+        _discipline.ListMembersAsync(DisciplineId, Arg.Any<CancellationToken>()).Returns(new List<DisciplineMember>
+        {
+            new(TeacherA, ParticipantRole.Teacher),
+            new(TeacherB, ParticipantRole.Teacher),
+        });
+        var resolver = new MentionResolver(_discipline);
+
+        var body = $"@{TeacherA:D} and @teachers";
+        var mentions = await resolver.ResolveAsync(body, conv, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEquivalentTo([TeacherA, TeacherB],
+            "TeacherA appears as both an explicit mention and as a member of @teachers; the result must dedupe.");
+    }
+
+    [Fact]
+    public async Task Filters_role_members_who_are_not_actually_in_the_conversation()
+    {
+        // The discipline roster (returned by gRPC) and the chat roster can drift between an
+        // enrollment Kafka event and its projection. Mentioning a teacher who hasn't been
+        // synced into the chat yet must not leak that user id back to the broadcast pipeline.
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA]);
+        _discipline.ListMembersAsync(DisciplineId, Arg.Any<CancellationToken>()).Returns(new List<DisciplineMember>
+        {
+            new(TeacherA, ParticipantRole.Teacher),
+            new(TeacherB, ParticipantRole.Teacher), // not yet in chat participants
+        });
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("@teachers", conv, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEquivalentTo([TeacherA]);
+    }
+
+    [Fact]
+    public async Task Skips_grpc_call_when_body_has_no_special_tokens()
+    {
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA, StudentA]);
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("plain message", conv, maxMentions: 50, CancellationToken.None);
+
+        mentions.Should().BeEmpty();
+        await _discipline.DidNotReceive().ListMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Caps_at_max_mentions()
+    {
+        var conv = OpenDisciplineConversation(TeacherA, [TeacherA, TeacherB, StudentA, StudentB]);
+        _discipline.ListMembersAsync(DisciplineId, Arg.Any<CancellationToken>()).Returns(new List<DisciplineMember>
+        {
+            new(TeacherA, ParticipantRole.Teacher),
+            new(TeacherB, ParticipantRole.Teacher),
+            new(StudentA, ParticipantRole.Student),
+            new(StudentB, ParticipantRole.Student),
+        });
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync("@teachers @students", conv, maxMentions: 2, CancellationToken.None);
+
+        mentions.Should().HaveCount(2, "the cap protects against amplification when @everyone-style tokens cover huge rosters.");
+    }
+
+    private static Conversation OpenDisciplineConversation(Guid ownerTeacher, IReadOnlyList<Guid> participants)
+    {
+        var conv = Conversation.OpenDiscipline(
+            DisciplineId,
+            ownerTeacher,
+            DateTimeOffset.UtcNow,
+            title: "Test discipline");
+        foreach (var participant in participants)
+        {
+            if (participant != ownerTeacher)
+            {
+                conv.AddParticipant(participant, ParticipantRole.Student);
+            }
+        }
+        return conv;
+    }
+}

--- a/tests/unit/ChatService.UnitTests/Application/ReplyInThreadServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/ReplyInThreadServiceTests.cs
@@ -53,9 +53,11 @@ public class ReplyInThreadServiceTests
             _outbox,
             new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
         var options = Options.Create(new ChatOptions { MaxMentionsPerMessage = 50 });
+        var disciplineClient = Substitute.For<Urfu.Link.Services.Chat.Application.Disciplines.IDisciplineServiceClient>();
+        var mentions = new Urfu.Link.Services.Chat.Application.Mentions.MentionResolver(disciplineClient);
         return new ReplyInThreadService(
             _conversations, _messages, _subscriptions, _media, _idempotency,
-            dispatcher, _broadcaster, _clock, options);
+            dispatcher, _broadcaster, mentions, _clock, options);
     }
 
     private (Conversation conv, Message root) SeedRoot(DateTimeOffset rootCreatedAt)

--- a/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
@@ -26,6 +26,8 @@ public class SendMessageServiceTests
     private readonly IMediaServiceClient _media = Substitute.For<IMediaServiceClient>();
     private readonly IIdempotencyStore _idempotency = Substitute.For<IIdempotencyStore>();
     private readonly IChatBroadcaster _broadcaster = Substitute.For<IChatBroadcaster>();
+    private readonly Urfu.Link.Services.Chat.Application.Presence.IPresenceServiceClient _presence
+        = Substitute.For<Urfu.Link.Services.Chat.Application.Presence.IPresenceServiceClient>();
     private readonly RecordingOutboxWriter _outbox = new();
 
     private SendMessageService Build()
@@ -34,7 +36,7 @@ public class SendMessageServiceTests
             _outbox,
             new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
         var options = Microsoft.Extensions.Options.Options.Create(new Urfu.Link.Services.Chat.Infrastructure.ChatOptions());
-        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, TimeProvider.System, options);
+        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, _presence, TimeProvider.System, options);
     }
 
     private Conversation SeedConversation()

--- a/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
@@ -36,7 +36,9 @@ public class SendMessageServiceTests
             _outbox,
             new ServiceProfile("chat-service", "mongodb", KafkaTopicNames.ChatEvents, "chat.message.sent.v1"));
         var options = Microsoft.Extensions.Options.Options.Create(new Urfu.Link.Services.Chat.Infrastructure.ChatOptions());
-        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, _presence, TimeProvider.System, options);
+        var disciplineClient = Substitute.For<Urfu.Link.Services.Chat.Application.Disciplines.IDisciplineServiceClient>();
+        var mentions = new Urfu.Link.Services.Chat.Application.Mentions.MentionResolver(disciplineClient);
+        return new SendMessageService(_conversations, _messages, _media, _idempotency, dispatcher, _broadcaster, _presence, mentions, TimeProvider.System, options);
     }
 
     private Conversation SeedConversation()


### PR DESCRIPTION
Refs #234

PR 4 of 7. Закрывает D + E из issue: typing через ChatHub с фан-аутом в PresenceService и резолвинг discipline-only mention-токенов.

## Что сделано

### D1. PresenceService.SetTyping rpc (server-side)
ChatHub нужно flip typing state в PresenceService после chat-side IsParticipant check. Существующие PresenceHub методы — client-facing (chat-internal authz туда не повесить). Добавил `SetTyping(SetTypingRequest) returns (SetTypingReply)` rpc на InternalApi. Reply.changed позволяет skip redundant broadcasts на keep-alive refresh.

### D2. IDisciplineServiceClient.ListMembersAsync
DisciplineService gRPC `ListMembers` (из #207) уже был, ChatService-side wrapper отсутствовал. Добавил — вернёт пустой список при `exists=false` (resolver обрабатывает both "not found" и "no members" одинаково).

### D3. PresenceServiceClient в ChatService
- Wrapper в `ChatService.Api/Infrastructure/Grpc/PresenceServiceClient.cs`
- `MapToConversationGuid` маппит chat conversation id (deterministic SHA1 / `discipline:guid` префикс) → стабильный Guid для Presence keying
- Fail open на RpcException (chat authz уже прошёл, лучше потерять typing-сигнал чем уронить SignalR call)
- DI: условная регистрация по `GrpcClients:PresenceService:Address`. NoopPresenceServiceClient в фолбэке для тестов / on-prem без presence

### D4. ChatHub.StartTyping / StopTyping + auto-stop в SendMessage
- ChatHub получил `StartTyping(conversationId)` / `StopTyping(conversationId)` с access check (must be participant) → `ChatAccessDeniedException` для не-участников
- SendMessageService вызывает `presenceClient.SetTypingAsync(..., isTyping: false)` после успешного broadcast — клиент не должен вспоминать explicit transition

4 integration теста (`ChatHubTypingTests`) + FakePresenceServiceClient для проверки fan-out.

### E. @teachers / @students mention resolver
EPIC #211 специфицировал, legacy parser stubbed expansion в empty list (каждое discipline сообщение с @teachers тихо никого не пинговало).

`MentionResolver` композирует:
- `MentionsParser.Parse` (sync) для `@<guid>` и `@everyone`
- async gRPC roundtrip в `DisciplineServiceClient.ListMembersAsync` для `@teachers` / `@students` если conversation = Discipline group

Direct chats — тихо drop'аем спецтокены (нет иерархии ролей, не billing gRPC call). Role members не из chat roster фильтруются (drift между Kafka enrollment event и projection).

`SendMessageService`, `EditMessageService`, `ReplyInThreadService` переключены с `MentionsParser.Parse` на resolver. 7 unit-тестов покрывают direct-vs-discipline split, dedupe, фильтр participant, no-tokens-no-grpc shortcut, maxMentions cap.

## Как проверить

\`\`\`
dotnet build Urfu.Link.slnx                                              # 0 errors
dotnet test Urfu.Link.slnx --filter \"FullyQualifiedName~UnitTests\"       # 562 passed (+8 GrpcPresence + 7 Mention + 4 typing)
\`\`\`

ChatHub integration tests локально требуют Docker; CI должно пройти.

## Что дальше

- PR 5: Media voice 5min duration validator
- PR 6: Presence last_seen_history partitioning + privacy gRPC fallback
- PR 7: cleanup + docs (final, Closes #234)