### PR TITLE
fix(#234): media voice 5min duration cap on initiate upload

### DIFF
--- a/src/Services/Media/MediaService.Api/Application/Contracts/Requests/InitiateUploadRequest.cs
+++ b/src/Services/Media/MediaService.Api/Application/Contracts/Requests/InitiateUploadRequest.cs
@@ -2,8 +2,15 @@ using MediaService.Api.Domain.Enums;
 
 namespace MediaService.Api.Application.Contracts.Requests;
 
+/// <summary>
+/// Asset metadata supplied by the recording client. <see cref="DurationSeconds"/> is
+/// declared by the client (the recorder UI knows the recording length); for voice it
+/// is mandatory and is enforced against <c>MediaLimits:Voice:MaxDurationSeconds</c>.
+/// Other kinds may set it to null.
+/// </summary>
 public sealed record InitiateUploadRequest(
     string FileName,
     long Size,
     string MimeType,
-    Visibility Visibility);
+    Visibility Visibility,
+    int? DurationSeconds = null);

--- a/src/Services/Media/MediaService.Api/Application/Limits/MediaLimitsOptions.cs
+++ b/src/Services/Media/MediaService.Api/Application/Limits/MediaLimitsOptions.cs
@@ -12,7 +12,12 @@ public sealed class MediaLimitsOptions
 
     public KindLimit Image { get; set; } = new(20L * 1024 * 1024);   // 20 MB
     public KindLimit Video { get; set; } = new(100L * 1024 * 1024);  // 100 MB
-    public KindLimit Voice { get; set; } = new(10L * 1024 * 1024);   // 10 MB
+    // Voice: 10 MB AND ≤5 minutes per EPIC #206. The size cap is enforced at
+    // /upload/init from the request payload; the duration cap is enforced via
+    // the client-declared `DurationSeconds` field which the recorder UI fills
+    // from the actual recording length. A stricter server-side ffmpeg probe
+    // can be layered on as a Worker post-CompleteUpload (TODO: tracked separately).
+    public KindLimit Voice { get; set; } = new(10L * 1024 * 1024, MaxDurationSeconds: 300);
     public KindLimit Audio { get; set; } = new(50L * 1024 * 1024);   // 50 MB
     public KindLimit Document { get; set; } = new(100L * 1024 * 1024); // 100 MB
 
@@ -27,4 +32,9 @@ public sealed class MediaLimitsOptions
     };
 }
 
-public sealed record KindLimit(long MaxSizeBytes);
+/// <summary>
+/// Per-asset-kind upload constraints. <see cref="MaxSizeBytes"/> is the universal cap;
+/// <see cref="MaxDurationSeconds"/> applies only to voice (and potentially video in the
+/// future). <c>null</c> means duration is not constrained for the kind.
+/// </summary>
+public sealed record KindLimit(long MaxSizeBytes, int? MaxDurationSeconds = null);

--- a/src/Services/Media/MediaService.Api/Application/Validators/InitiateUploadValidator.cs
+++ b/src/Services/Media/MediaService.Api/Application/Validators/InitiateUploadValidator.cs
@@ -30,12 +30,39 @@ public sealed class InitiateUploadValidator : Validator<InitiateUploadRequest>
             .Custom((req, context) =>
             {
                 if (!MimeTypeCatalog.TryResolve(req.MimeType, out var kind)) return;
-                var max = limits.For(kind).MaxSizeBytes;
-                if (req.Size > max)
+                var kindLimit = limits.For(kind);
+
+                if (req.Size > kindLimit.MaxSizeBytes)
                 {
                     context.AddFailure(
                         nameof(req.Size),
-                        $"File size {req.Size} exceeds the limit {max} for kind {kind}.");
+                        $"File size {req.Size} exceeds the limit {kindLimit.MaxSizeBytes} for kind {kind}.");
+                }
+
+                // Voice (and any future kind with MaxDurationSeconds set) requires the
+                // recorder to declare the recording length. The size cap alone allows a
+                // 30-minute high-bitrate recording to slip through (EPIC #206 caps voice
+                // at 5 minutes specifically because long voice messages are a chat anti-pattern).
+                if (kindLimit.MaxDurationSeconds is int maxDuration)
+                {
+                    if (req.DurationSeconds is null)
+                    {
+                        context.AddFailure(
+                            nameof(req.DurationSeconds),
+                            $"DurationSeconds is required for {kind}.");
+                    }
+                    else if (req.DurationSeconds < 1)
+                    {
+                        context.AddFailure(
+                            nameof(req.DurationSeconds),
+                            "DurationSeconds must be positive.");
+                    }
+                    else if (req.DurationSeconds > maxDuration)
+                    {
+                        context.AddFailure(
+                            nameof(req.DurationSeconds),
+                            $"Duration {req.DurationSeconds}s exceeds the {kind} limit of {maxDuration}s.");
+                    }
                 }
             });
     }

--- a/tests/unit/MediaService.UnitTests/Unit/InitiateUploadValidatorTests.cs
+++ b/tests/unit/MediaService.UnitTests/Unit/InitiateUploadValidatorTests.cs
@@ -67,4 +67,74 @@ public class InitiateUploadValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(InitiateUploadRequest.MimeType));
     }
+
+    [Fact]
+    public void RejectsVoiceUploadWithoutDeclaredDuration()
+    {
+        // EPIC #206 caps voice at 5 minutes. The size cap alone allows a 30-minute
+        // high-bitrate recording to slip through, so DurationSeconds is mandatory.
+        var sut = CreateValidator();
+        var request = new InitiateUploadRequest("note.ogg", 1024, "audio/ogg", Visibility.Private);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(InitiateUploadRequest.DurationSeconds)
+            && e.ErrorMessage.Contains("required", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void RejectsVoiceUploadExceedingMaxDuration()
+    {
+        var sut = CreateValidator();
+        var request = new InitiateUploadRequest(
+            "note.ogg", 1024, "audio/ogg", Visibility.Private, DurationSeconds: 301);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(InitiateUploadRequest.DurationSeconds)
+            && e.ErrorMessage.Contains("exceeds", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void RejectsVoiceUploadWithNonPositiveDuration()
+    {
+        var sut = CreateValidator();
+        var request = new InitiateUploadRequest(
+            "note.ogg", 1024, "audio/ogg", Visibility.Private, DurationSeconds: 0);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(InitiateUploadRequest.DurationSeconds));
+    }
+
+    [Fact]
+    public void AcceptsVoiceUploadAtMaxDurationBoundary()
+    {
+        var sut = CreateValidator();
+        var request = new InitiateUploadRequest(
+            "note.ogg", 1024, "audio/ogg", Visibility.Private, DurationSeconds: 300);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IgnoresDurationForKindsWithoutMaxDuration()
+    {
+        // Image / document have no MaxDurationSeconds — the field is optional and ignored
+        // even if a malformed client sends a value.
+        var sut = CreateValidator();
+        var request = new InitiateUploadRequest(
+            "photo.png", 1024, "image/png", Visibility.Private, DurationSeconds: 9999);
+
+        var result = sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
Refs #234

PR 5 of 7. Закрывает F (voice 5min duration limit) из issue.

## Что сделано

EPIC #206 ограничивал voice одновременно по размеру (10MB) и длительности (5 мин). Раньше валидировался только размер — высокобитрейтная 30-минутная запись могла пройти 10 MB, но не должна была.

- `KindLimit` расширен опциональным `MaxDurationSeconds` (Voice = 300s, остальные = null)
- `InitiateUploadRequest` получил optional `DurationSeconds` поле — recorder UIs уже знают длительность записи
- `InitiateUploadValidator`: для kind с `MaxDurationSeconds` поле обязательно, должно быть positive и не превышать лимит

Server-side ffprobe verification — follow-up. Требует ffmpeg в runtime image (~80MB) и поэтому отложено: client-declared value ловит обычный случай (UI-баг с длинной записью) без operational overhead. Поле также служит будущим хуком для `VoiceDurationValidator` worker'а post-CompleteUpload.

5 новых unit-тестов в `InitiateUploadValidatorTests`: missing duration = 400, exceeds cap = 400, non-positive = 400, exact boundary = OK, ignored for non-duration kinds.

## Как проверить

\`\`\`
dotnet test tests/unit/MediaService.UnitTests/    # 77 passed (+5 new)
\`\`\`

Manual: попытаться залить voice без `DurationSeconds` через `POST /api/media/upload/init` → 400 с пояснением.

## Что дальше

- PR 6: Presence last_seen_history partitioning + privacy gRPC fallback
- PR 7: cleanup + docs (final, Closes #234)