### PR TITLE
fix(#234): final architecture documentation pass

### DIFF
--- a/docs/architecture/c4-container.md
+++ b/docs/architecture/c4-container.md
@@ -7,11 +7,11 @@
   - Correlation and edge rate limiting
 
 ## Logic containers
-- `MediaService` (PostgreSQL)
-- `UserService` (PostgreSQL)
-- `ChatService` (MongoDB)
-- `PresenceService` (Redis)
-- `NotificationService` (stateless workers)
+- `MediaService` (PostgreSQL + MinIO) — asset metadata; presigned upload/download to MinIO
+- `UserService` (PostgreSQL) — profile, JSONB notification settings, gRPC for downstream services
+- `ChatService` (MongoDB + Redis) — conversations and messages in Mongo, idempotency + outbox in Redis
+- `PresenceService` (Redis + PostgreSQL with `last_seen_history`) — Redis is the hot session/typing/projection store; PG keeps the partitioned long-term last-seen history for analytics
+- `NotificationService` (PostgreSQL partitioned + Redis) — notifications/deliveries in PG with monthly partitions (90-day retention), badge counters in Redis
 - `CallService` (signaling + media orchestration)
 - `DisciplineService` (PostgreSQL) — disciplines, enrollments, gRPC for ChatService
 

--- a/docs/architecture/domain-boundaries.md
+++ b/docs/architecture/domain-boundaries.md
@@ -11,6 +11,17 @@
 
 ## Presence Service
 - Online status, heartbeat, short-lived activity state
+- Owns the typing indicator: `InternalApi.SetTyping` is the server-to-server seam used by ChatHub.StartTyping/StopTyping after chat-side `IsParticipant` authorization, so PresenceHub clients can never poison another conversation's typing state.
+
+### Privacy projection vs gRPC pull (design choice)
+
+The MVP shipped a Kafka projection: UserService publishes `urfu.user.events.v1` with privacy changes, PresenceService consumes them into a Redis projection (`RedisPrivacyProjectionStore`) keyed by user id. Reads against the projection are O(1) and survive a UserService outage — the trade-off is eventual consistency between the moment a user toggles privacy and the moment the projection observes it (Kafka lag).
+
+A gRPC pull from UserService on every request would be strongly consistent at the cost of latency and a hard runtime dependency. The `IPrivacyResolver` interface is shaped to support a hybrid (Redis-projection primary, gRPC fallback on cache-miss / stale data) but the gRPC fallback is intentionally deferred: the projection's TTL is short (60s) and a cache miss simply falls back to a permissive default, which is acceptable for the privacy contract today.
+
+### last_seen snapshot vs last_seen_history
+
+`presence.last_seen` is a one-row-per-user snapshot updated on every disconnect — fast PK lookups for the "show me a user's last_seen now" query. `presence.last_seen_history` is the append-only audit record of every snapshot transition, partitioned monthly on `recorded_at_utc`, retained 12 months. Analytics queries ("when was this user online during March?") run against the history table without joining Kafka logs. The write-through is atomic with the snapshot mutation (single `SaveChangesAsync`, single transaction), so the history can never lag behind.
 
 ## Notification Service
 - Delivery orchestration and notification fan-out

--- a/docs/architecture/redis-topology.md
+++ b/docs/architecture/redis-topology.md
@@ -1,0 +1,24 @@
+# Redis Topology
+
+A single Redis instance backs every Redis-using concern in dev and staging:
+
+- **SignalR backplane** (`urfu:signalr:chat`, `urfu:signalr:presence`, `urfu:signalr:notifications` channel prefixes) — required so a broadcast issued on one replica reaches connections held by other replicas
+- **Idempotency** (`urfu:idempotency:*` via `BuildingBlocks.Idempotency`) — used by every Kafka consumer for envelope-MessageId deduplication
+- **Outbox** (`urfu:outbox` via `BuildingBlocks.Outbox`) — Redis-backed pending-events queue between the EF outbox writer and the Kafka publisher
+- **Session revocation** (`urfu:session:*` via `BuildingBlocks.SessionRevocation`) — deny/allow lists consumed by ApiGateway and UserService
+- **DataProtection keys** (`urfu:dp:*`) — survives pod restart and supports horizontal scaling
+- **Presence sessions / typing / privacy projection** (`presence:*`, `typing:*`)
+- **NotificationService badge counters** (`notif:badge:{userId}`)
+
+This is intentional in dev/staging — the same instance keeps the local-up footprint small. **Production needs Redis Sentinel (or Redis Cluster).** A single instance is a hard SPOF: if Redis goes down,
+
+- SignalR broadcasts cannot propagate cross-replica → users on different pods stop seeing each other's messages
+- Idempotency reads fail → Kafka consumers can't decide whether an envelope is a duplicate; depending on policy they either reject (lose work) or replay (duplicate side effects)
+- Outbox consumers stall → integration events accumulate in the writer side until Redis is back
+- SessionRevocation reads fail → either every request is denied (hard fail-closed) or every request is allowed (silent fail-open)
+
+## Plan
+
+The Helm chart for the platform exposes a single `redis` Service. For prod, swap it to a Sentinel-backed StatefulSet (`bitnami/redis` with `architecture: replication` + `sentinel.enabled: true` is the standard route). Application configuration changes amount to passing the Sentinel master name as the connection string — the StackExchange.Redis client transparently follows failovers — so no service code change is required.
+
+Tracking issue: separate infra task; this document captures the design intent. The plumbing inside the application (every concern reads from `Infrastructure:Redis:Configuration`) already supports multi-host connection strings without code changes.

--- a/src/Gateway/ApiGateway/README.md
+++ b/src/Gateway/ApiGateway/README.md
@@ -1,0 +1,28 @@
+# ApiGateway
+
+YARP-based reverse proxy + edge concerns (auth, rate limiting, correlation, session revocation).
+
+## Routing model (`appsettings.json`)
+
+REST routes carry `"AuthorizationPolicy": "default"`, which forces the gateway to validate the JWT (Keycloak realm via `Auth:Authority`) before forwarding. SignalR hub routes (`chat-hub`, `presence-hub`, `notification-hub`) intentionally **omit** the `AuthorizationPolicy` field. This is **by design**:
+
+- SignalR clients cannot set the `Authorization` HTTP header during the WebSocket upgrade handshake (browsers strip custom headers from the upgrade), so the JWT travels via the `?access_token=...` query parameter.
+- Each downstream SignalR service has a `JwtBearerEvents.OnMessageReceived` hook that promotes that query parameter into the bearer token before the auth middleware runs.
+- The gateway therefore relies on **two layers of defence-in-depth** for hub traffic: `HubAccessTokenPresenceMiddleware` rejects connections that omit `?access_token=` (so anonymous WebSocket attempts fail at the edge), and the downstream service still validates the JWT before letting the connection complete the handshake.
+
+If you need to add a new hub route, follow the same pattern: drop `AuthorizationPolicy`, leave the path under `/hubs/`, and ensure the downstream service's `Program.cs` configures `JwtBearerEvents.OnMessageReceived` to read `access_token` from the query string.
+
+## Rate limiting
+
+| Policy | Scope | Limit |
+|---|---|---|
+| Global | All routes | 200 rps per partition (Keycloak `sub` or remote IP) |
+| `chat-send` | `POST /api/chat/conversations/{id}/messages` | 60 / minute / partition |
+| `media-upload` | `POST /api/media/upload/init` | 30 / minute / partition |
+
+Search endpoints implement their own per-user limit at the service level (see `ChatSearchRateLimiterPolicy` in ChatService).
+
+## Health checks
+
+- `/health/live` — always 200 unless the process is dead. Wired to kubelet liveness; do **not** chain it to YARP destinations.
+- `/health/ready` — aggregates the `yarp-destinations` check (active YARP probes against each cluster's `/health/ready`). Wired to kubelet readiness so a degraded downstream takes the gateway pod out of rotation without restarting it.

--- a/src/Services/Chat/README.md
+++ b/src/Services/Chat/README.md
@@ -121,9 +121,16 @@ just queries subscribers on each call).
 
 ### Typing indicators
 
-ChatService does **not** track typing. Clients should call `PresenceHub.StartTyping` /
-`PresenceHub.StopTyping` from #208 directly. Auto-stop on `SendMessage` is the client's
-responsibility for now.
+`ChatHub.StartTyping(conversationId)` / `ChatHub.StopTyping(conversationId)` are the
+chat-side façade for the typing indicator. They authorise the caller (must be a
+participant of the conversation; non-participants get `ChatAccessDeniedException`)
+and fan the signal out to PresenceService over gRPC (`InternalApi.SetTyping`). The
+chat-side authorization is the reason this lives on ChatHub instead of clients
+calling PresenceHub directly — typing in a conversation you cannot see is a
+security boundary, not a no-op.
+
+`SendMessageService` also fires `SetTyping(isTyping=false)` after a successful send,
+so clients no longer need to remember the explicit `StopTyping` transition.
 
 ## REST endpoints (`/api/v1/chat/*`)
 


### PR DESCRIPTION
Closes #234

Финальный PR (7 of 7) для tech-debt EPIC #216. Это полностью документация — фиксы кода уже в master через PR 1-6.

## Что сделано

**c4-container.md** — точные storage descriptions: Notification = PG partitioned + Redis, Presence = Redis + PG with last_seen_history, Chat = Mongo + Redis, Media = PG + MinIO.

**domain-boundaries.md** — design rationale, который трудно восстановить из кода:
- Chat → Presence typing идёт через `InternalApi.SetTyping` (не прямо в PresenceHub) потому что chat-side IsParticipant authz должна сработать первой
- Privacy = Kafka projection (eventually consistent, Redis-backed). IPrivacyResolver открыт для гибридной стратегии но gRPC fallback не реализован — 60s TTL projection + permissive default делают это non-blocking
- last_seen snapshot vs last_seen_history split — fast reads vs analytics

**redis-topology.md** (новый) — единый Redis backs всё (backplane × 3, Idempotency × 7, Outbox × 7, SessionRevocation, DataProtection, Presence, Notifications) и это SPOF. Production план — Sentinel. Migration configuration-only потому что все consumers читают `Infrastructure:Redis:Configuration` которая принимает multi-host string.

**ApiGateway/README.md** (новый) — почему SignalR hub routes без YARP AuthorizationPolicy (браузеры strip custom headers из WS upgrade, JWT едет через `?access_token`; defence-in-depth = `HubAccessTokenPresenceMiddleware` + downstream validation). Чтобы future maintainer не "исправил" этот gap случайно.

**Chat README** — заменил note "PresenceHub directly" на новый контракт после PR 4 (ChatHub.StartTyping authorize + fan-out через gRPC + SendMessageService auto-stop).

## Что не вошло (документировано)

- **H1 ApiGateway tests consolidation** — оставил две папки. Test infrastructure setup имеет local-Docker quirks (см. PR 3 детали); risk/reward плохой для финального PR.
- **G2 Privacy gRPC fallback** — требует extension UserService.InternalApi с новым rpc + richer resolver strategy. Документировано в domain-boundaries.md как "intentionally deferred". Можно сделать отдельной issue или включить в next iteration.

## Итоги по issue #234

7 PR, ~22 коммитов, ~3500 LOC, 574 unit-теста (+12 новых) + integration-расширение в Notification (5 новых файлов) и Chat (1 новый файл typing).

Закрытые блокеры:
- 🔴 NotificationService presence-aware routing — реальный gRPC client заменил OfflinePresenceClient stub
- 🔴 NotificationService миграции — `--migrate` flag через MigrationCliRunner + Helm Job
- 🔴 ChatService typing — StartTyping/StopTyping в ChatHub с gRPC fan-out
- 🔴 NotificationService integration coverage — поднята с 1 до 6 тестов с TestContainers

Закрытые major:
- 🟡 Kafka tracing → Confluent.Kafka source в Observability
- 🟡 SignalR backplane HC → auto-register в ServiceDefaults
- 🟡 Chat events → BuildingBlocks/Contracts
- 🟡 Migrations standardization → 5 EF сервисов на едином Helm pattern
- 🟡 Voice 5min duration → DurationSeconds field в InitiateUploadRequest
- 🟡 last_seen_history → partitioned PG table с monthly write-through
- 🟡 @teachers / @students mentions → MentionResolver через DisciplineService gRPC

## Как проверить

\`\`\`
dotnet build Urfu.Link.slnx                                              # 0 errors
dotnet test Urfu.Link.slnx --filter \"FullyQualifiedName~UnitTests\"       # 574 passed
helm template deploy/helm/charts/urfu-service \
  -f deploy/helm/services/notification-service/values-prod.yaml          # Job рендерится
docker compose -f platform/dev/docker-compose.dev.yml config --quiet     # валидно
\`\`\`