### PR TITLE
fix(#234): presence — sync model snapshot with LastSeenHistoryEntry

### DIFF
--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Persistence/Migrations/20260428070316_AddLastSeenHistoryPartitioned.Designer.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Persistence/Migrations/20260428070316_AddLastSeenHistoryPartitioned.Designer.cs
@@ -50,6 +50,36 @@ namespace PresenceService.Api.Infrastructure.Persistence.Migrations
 
                     b.ToTable("last_seen", "presence");
                 });
+
+            modelBuilder.Entity("Urfu.Link.Services.Presence.Domain.Aggregates.LastSeenHistoryEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<DateTimeOffset>("RecordedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("recorded_at_utc");
+
+                    b.Property<int>("LastPlatform")
+                        .HasColumnType("integer")
+                        .HasColumnName("last_platform");
+
+                    b.Property<DateTimeOffset>("LastSeenAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("last_seen_at_utc");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("user_id");
+
+                    b.HasKey("Id", "RecordedAtUtc");
+
+                    b.HasIndex("UserId")
+                        .HasDatabaseName("ix_last_seen_history_user_id");
+
+                    b.ToTable("last_seen_history", "presence");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Persistence/Migrations/PresenceDbContextModelSnapshot.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Persistence/Migrations/PresenceDbContextModelSnapshot.cs
@@ -47,6 +47,36 @@ namespace PresenceService.Api.Infrastructure.Persistence.Migrations
 
                     b.ToTable("last_seen", "presence");
                 });
+
+            modelBuilder.Entity("Urfu.Link.Services.Presence.Domain.Aggregates.LastSeenHistoryEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid")
+                        .HasColumnName("id");
+
+                    b.Property<DateTimeOffset>("RecordedAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("recorded_at_utc");
+
+                    b.Property<int>("LastPlatform")
+                        .HasColumnType("integer")
+                        .HasColumnName("last_platform");
+
+                    b.Property<DateTimeOffset>("LastSeenAtUtc")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("last_seen_at_utc");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("user_id");
+
+                    b.HasKey("Id", "RecordedAtUtc");
+
+                    b.HasIndex("UserId")
+                        .HasDatabaseName("ix_last_seen_history_user_id");
+
+                    b.ToTable("last_seen_history", "presence");
+                });
 #pragma warning restore 612, 618
         }
     }


### PR DESCRIPTION
## Что и зачем

Миграция `AddLastSeenHistoryPartitioned` (#240) была написана через `migrationBuilder.Sql(...)` (партиционирование `PARTITION BY RANGE` нельзя сгенерить кодом EF), но при её создании не обновили `PresenceDbContextModelSnapshot` и Designer — там не появился `LastSeenHistoryEntry`.

В результате `Database.MigrateAsync()` на старте валил `Microsoft.EntityFrameworkCore.Migrations.PendingModelChangesWarning`, и `presence-migrations` падал на свежей БД (как только Hyper-V перестал съедать порты LiveKit и стек реально доходил до миграций).

## Что сделано

Перегенерил миграцию через `dotnet ef migrations add` — это правильно обновило snapshot и Designer (включили `LastSeenHistoryEntry`). После этого восстановил оригинальный raw SQL в `Up`/`Down`, привёл namespace новых файлов к `PresenceService.Api.Infrastructure.Persistence.Migrations` (как в `Initial`), сохранил оригинальный timestamp `20260428070316`.

## Test plan

- [x] `dotnet build src/Services/Presence/PresenceService.Api/PresenceService.Api.csproj` — 0 warnings, 0 errors
- [x] `make up` на свежем postgres volume — `presence-migrations` exit 0, `presence-service` стартует, `__EFMigrationsHistory` содержит обе миграции
- [ ] `presence-integration-tests` (если есть в CI)