### PR TITLE
fix(#234): wire Redis config for api-gateway and core services in dev compose

### DIFF
--- a/platform/dev/docker-compose.dev.yml
+++ b/platform/dev/docker-compose.dev.yml
@@ -250,6 +250,7 @@ services:
       Keycloak__ClientSecret: user-service-admin-dev-secret
       Auth__ValidIssuer: http://localhost:8080/realms/urfu-link
       Storage__PublicEndpoint: http://localhost:9000
+      Infrastructure__Redis__Configuration: redis:6379
     depends_on:
       user-migrations:
         condition: service_completed_successfully
@@ -274,6 +275,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       Kafka__BootstrapServers: kafka:29092
       Auth__ValidIssuer: http://localhost:8080/realms/urfu-link
+      Infrastructure__Redis__Configuration: redis:6379
     depends_on:
       mongo:
         condition: service_healthy
@@ -317,6 +319,7 @@ services:
       Storage__SecretKey: minio123
       Storage__PrivateBucket: media-private
       Storage__PublicBucket: media-public
+      Infrastructure__Redis__Configuration: redis:6379
     depends_on:
       media-migrations:
         condition: service_completed_successfully
@@ -506,9 +509,12 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       Cors__AllowedOrigins__0: http://localhost:3000
       Auth__ValidIssuer: http://localhost:8080/realms/urfu-link
+      Infrastructure__Redis__Configuration: redis:6379
     ports:
       - "5080:8080"
     depends_on:
+      redis:
+        condition: service_healthy
       keycloak:
         condition: service_healthy
       user-service:


### PR DESCRIPTION
## Что и зачем

`api-gateway`, `user-service`, `chat-service`, `media-service` все используют `SessionRevocation` (и другие Redis-backed штуки), но в dev compose у них не было `Infrastructure__Redis__Configuration`. Fallback в `SessionRevocationExtensions` бьётся в `localhost:6379` — внутри контейнера это сам контейнер, а не Redis. Любой аутентифицированный запрос через gateway падал в 500 на SISMEMBER timeout.

## Что сделано

Добавил `Infrastructure__Redis__Configuration=redis:6379` четырём сервисам и `depends_on: redis` для gateway, чтобы Redis был healthy до старта.

## Test plan

- [x] `docker compose ... up -d --no-build` — gateway стартует без ошибок Redis
- [x] `GET /api/users/me` через фронт — запрос проксируется в user-service (не падает на Redis)