### PR TITLE
fix(client): drop nip.io fallback, fail loud when EXPO_PUBLIC_API_URL is missing in prod

### DIFF
--- a/apps/client/app.config.ts
+++ b/apps/client/app.config.ts
@@ -2,11 +2,14 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 import { z } from "zod";
 const APP_ENVS = ["dev", "prod"] as const;
 const appEnvSchema = z.enum(APP_ENVS);
-const DEFAULT_API_URLS: Record<(typeof APP_ENVS)[number], string> = {
-    dev: "https://api.dev.127.0.0.1.nip.io",
-    prod: "https://api.ghjc.ru",
+// Defaults exist only for the local dev loop. prod must come from EXPO_PUBLIC_*
+// (eas.json sets them per profile, docker-entrypoint.sh sets them at container start).
+const DEFAULT_API_URLS: Partial<Record<(typeof APP_ENVS)[number], string>> = {
+    dev: "http://localhost:5080",
 };
-const DEFAULT_KEYCLOAK_URL = "http://localhost:8080";
+const DEFAULT_KEYCLOAK_URLS: Partial<Record<(typeof APP_ENVS)[number], string>> = {
+    dev: "http://localhost:8080",
+};
 const runtimeConfigSchema = z.object({
     appEnv: appEnvSchema,
     apiUrl: z.string().url(),
@@ -19,7 +22,19 @@ export default ({ config }: ConfigContext): AppExpoConfig => {
     const appEnvResult = appEnvSchema.safeParse(process.env.APP_ENV);
     const appEnv = appEnvResult.success ? appEnvResult.data : "dev";
     const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? DEFAULT_API_URLS[appEnv];
-    const keycloakUrl = process.env.EXPO_PUBLIC_KEYCLOAK_URL ?? DEFAULT_KEYCLOAK_URL;
+    const keycloakUrl = process.env.EXPO_PUBLIC_KEYCLOAK_URL ?? DEFAULT_KEYCLOAK_URLS[appEnv];
+    if (!apiUrl) {
+        throw new Error(
+            `EXPO_PUBLIC_API_URL is required for appEnv="${appEnv}". ` +
+            `For dev the default is http://localhost:5080; for prod set it via eas.json or container env.`,
+        );
+    }
+    if (!keycloakUrl) {
+        throw new Error(
+            `EXPO_PUBLIC_KEYCLOAK_URL is required for appEnv="${appEnv}". ` +
+            `For dev the default is http://localhost:8080; for prod set it via eas.json or container env.`,
+        );
+    }
     const buildConfig = { appEnv, apiUrl, keycloakUrl };
     const validated = runtimeConfigSchema.safeParse(buildConfig);
     if (!validated.success) {

--- a/apps/client/public/app-config.js
+++ b/apps/client/public/app-config.js
@@ -1,6 +1,4 @@
-window.__APP_CONFIG__ = {
-    appEnv: "dev",
-    apiUrl: "https://api.dev.127.0.0.1.nip.io",
-    oidcAuthority: "",
-    oidcClientId: ""
-};
+// Empty seed. In prod docker-entrypoint.sh overwrites this file with values
+// from container env at startup; in dev `app.config.ts` provides apiUrl/keycloakUrl
+// via Constants.expoConfig.extra and this file stays empty so it does not shadow them.
+window.__APP_CONFIG__ = {};

--- a/apps/client/src/shared/lib/README.md
+++ b/apps/client/src/shared/lib/README.md
@@ -2,12 +2,12 @@
 
 Всё, что касается runtime- и build-time конфига, живёт здесь.
 
-**`env.ts`** — типы `AppEnv` (dev/prod), `DEFAULT_API_URLS`, zod-схемы. Используется в `config.ts`. Чтобы Expo мог подхватить конфиг без резолва из `src/`, те же значения продублированы в `app.config.ts`.
+**`env.ts`** — типы `AppEnv` (dev/prod), `DEFAULT_API_URLS`/`DEFAULT_KEYCLOAK_URLS` (только dev — localhost), zod-схемы. Используется в `config.ts`. Чтобы Expo мог подхватить конфиг без резолва из `src/`, те же значения продублированы в `app.config.ts`.
 
-**`config.ts`** — то, что читает приложение в рантайме: `Constants.expoConfig.extra` (натив/build) и `window.__APP_CONFIG__` (web). Валидация через zod, при невалидных данных — throw. В коде приложения импортируй `appConfig` отсюда.
+**`config.ts`** — то, что читает приложение в рантайме: `Constants.expoConfig.extra` (build-time) и `window.__APP_CONFIG__` (runtime override). Валидация через zod, при невалидных данных — throw. В коде приложения импортируй `appConfig` отсюда.
 
-**Build-time:** в `app.config.ts` читаются `process.env.APP_ENV`, `process.env.EXPO_PUBLIC_API_URL`, проверяются и уходят в `extra`.
+**Build-time:** в `app.config.ts` читаются `process.env.APP_ENV`, `process.env.EXPO_PUBLIC_API_URL`, `process.env.EXPO_PUBLIC_KEYCLOAK_URL`, проверяются и уходят в `extra`. Для `appEnv=dev` есть localhost-дефолты, для `prod` env-переменные обязательны (иначе throw на старте expo).
 
-**Web:** в `app/+html.tsx` подгружается `/app-config.js`; в контейнере `docker-entrypoint.sh` пишет его из env. `config.ts` мержит и валидирует.
+**Web prod:** в Docker-контейнере `docker-entrypoint.sh` инжектит `<script src="/app-config.js">` в `index.html` и пишет файл из container env — `window.__APP_CONFIG__` перебивает build-time `extra`. В dev файл `public/app-config.js` пустой и не мешает build-time конфигу.
 
 Не читай `process.env` или `window.__APP_CONFIG__` напрямую — только через этот слой, т.е. импорт из `../lib/config` или `@/lib/config`.

--- a/apps/client/src/shared/lib/config.ts
+++ b/apps/client/src/shared/lib/config.ts
@@ -1,7 +1,7 @@
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 import type { AppEnv } from "./env";
-import { DEFAULT_API_URLS, DEFAULT_KEYCLOAK_URL, runtimeConfigSchema } from "./env";
+import { runtimeConfigSchema } from "./env";
 export type { AppEnv } from "./env";
 
 export type RuntimeConfig = {
@@ -14,18 +14,15 @@ declare global {
         __APP_CONFIG__?: Partial<RuntimeConfig>;
     }
 }
-const defaultConfig: RuntimeConfig = {
-    appEnv: "dev",
-    apiUrl: DEFAULT_API_URLS.dev,
-    keycloakUrl: DEFAULT_KEYCLOAK_URL,
-};
 function getRawConfig(): Partial<RuntimeConfig> {
     const extra = (Constants.expoConfig?.extra ?? {}) as Partial<RuntimeConfig>;
     const webConfig = Platform.OS === "web" && typeof window !== "undefined" ? window.__APP_CONFIG__ ?? {} : {};
+    // extra is populated at build time by app.config.ts (which already validates required env).
+    // webConfig wins in prod where docker-entrypoint.sh writes /app-config.js from container env.
     return {
-        appEnv: webConfig.appEnv || extra.appEnv || defaultConfig.appEnv,
-        apiUrl: webConfig.apiUrl || extra.apiUrl || defaultConfig.apiUrl,
-        keycloakUrl: webConfig.keycloakUrl || extra.keycloakUrl || defaultConfig.keycloakUrl,
+        appEnv: webConfig.appEnv || extra.appEnv,
+        apiUrl: webConfig.apiUrl || extra.apiUrl,
+        keycloakUrl: webConfig.keycloakUrl || extra.keycloakUrl,
     };
 }
 const raw = getRawConfig();

--- a/apps/client/src/shared/lib/env.ts
+++ b/apps/client/src/shared/lib/env.ts
@@ -8,11 +8,14 @@ export const runtimeConfigSchema = z.object({
     keycloakUrl: z.string().url(),
 });
 export type RuntimeConfigInput = z.infer<typeof runtimeConfigSchema>;
-export const DEFAULT_API_URLS: Record<AppEnv, string> = {
-    dev: "https://api.dev.127.0.0.1.nip.io",
-    prod: "https://api.urfu-link.ghjc.ru",
+// Defaults exist only for the local dev loop. prod must come from EXPO_PUBLIC_*
+// (eas.json sets them per profile, docker-entrypoint.sh sets them at container start).
+export const DEFAULT_API_URLS: Partial<Record<AppEnv, string>> = {
+    dev: "http://localhost:5080",
 };
-export const DEFAULT_KEYCLOAK_URL = "http://localhost:8080";
+export const DEFAULT_KEYCLOAK_URLS: Partial<Record<AppEnv, string>> = {
+    dev: "http://localhost:8080",
+};
 export const ENV_KEYS = {
     APP_ENV: "APP_ENV",
     EXPO_PUBLIC_API_URL: "EXPO_PUBLIC_API_URL",


### PR DESCRIPTION
## Что и зачем

Дефолт `https://api.dev.127.0.0.1.nip.io` в [apps/client/app.config.ts](apps/client/app.config.ts) и [src/shared/lib/env.ts](apps/client/src/shared/lib/env.ts) — мина: домен нигде не обслуживается (нет TLS на `127.0.0.1:443` локально, и в проде он не используется — там nginx через `docker-entrypoint.sh` пишет `app-config.js` из container env).

Поведение до фикса: если пакетировщик забывал запустить `web:local` или любой другой setter `EXPO_PUBLIC_API_URL`, клиент молча уезжал в этот мёртвый URL и фронтендер 5–10 минут разбирался почему `ERR_CONNECTION_REFUSED`.

## Что сделано

- `DEFAULT_API_URLS` / `DEFAULT_KEYCLOAK_URLS` теперь имеют только `dev`-ключ с localhost-значениями (`http://localhost:5080` / `http://localhost:8080`), которые совпадают с docker-compose маппингом.
- Для `appEnv=prod` env-переменные обязательны: `app.config.ts` бросает понятную ошибку (`EXPO_PUBLIC_API_URL is required for appEnv="prod". For dev the default is http://localhost:5080; for prod set it via eas.json or container env.`) вместо беззвучного падения в неправильный URL. eas.json и docker-entrypoint.sh всё равно их выставляют, так что прод-флоу не трогает.
- `public/app-config.js` теперь пустой сид (`window.__APP_CONFIG__ = {}`). В проде nginx через `docker-entrypoint.sh` его перезаписывает; в dev он перестал затенять build-time extra, и `EXPO_PUBLIC_API_URL` наконец-то реально работает.
- В `config.ts` убрал отдельный `defaultConfig` — после этого фикса `extra` всегда заполнен `app.config.ts` (либо валидно, либо throw).
- README в `src/shared/lib/` поправил — было устаревшее утверждение про `+html.tsx`, который ничего не подгружает.

## Test plan

Прогнал `pnpm exec expo config --type prebuild` для трёх кейсов:

- [x] dev без env → `apiUrl: http://localhost:5080`, `keycloakUrl: http://localhost:8080`
- [x] `APP_ENV=prod` без env → throw `EXPO_PUBLIC_API_URL is required for appEnv="prod"` (ожидаемо)
- [x] `APP_ENV=prod EXPO_PUBLIC_API_URL=https://api.example.com EXPO_PUBLIC_KEYCLOAK_URL=https://kc.example.com` → корректно резолвится
- [x] `pnpm --filter @urfu-link/client typecheck` — clean