### PR TITLE
Bump dotAPNS from 4.4.0 to 4.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
 
     <PackageVersion Include="FirebaseAdmin" Version="3.5.0" />
-    <PackageVersion Include="dotAPNS" Version="4.4.0" />
+    <PackageVersion Include="dotAPNS" Version="4.6.0" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="RazorLight" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />


### PR DESCRIPTION
Replaces #246 (had merge conflict with develop after sibling bumps were merged).

Closes #246.