### PR TITLE
ci(#271): use package manager pnpm version in workflows

### DIFF
--- a/.github/workflows/frontend-mobile-release.yml
+++ b/.github/workflows/frontend-mobile-release.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.18.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/frontend-mobile-update.yml
+++ b/.github/workflows/frontend-mobile-update.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.18.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/frontend-validate.yml
+++ b/.github/workflows/frontend-validate.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.18.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/frontend-web-image.yml
+++ b/.github/workflows/frontend-web-image.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.18.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Что исправлено

- Убран явный `version: 10.18.0` из `pnpm/action-setup@v6` в frontend workflows.
- Теперь pnpm берётся из `packageManager` в `package.json`: `pnpm@11.0.9`.
- Это исправляет падение `Frontend Validate` и `Frontend Web Image` на setup-шаге после релиза #271.

## Проверки

- `pnpm install --frozen-lockfile`
- `pnpm client:typecheck`
- `APP_ENV=prod EXPO_PUBLIC_API_URL=https://api.urfu-link.ghjc.ru EXPO_PUBLIC_KEYCLOAK_URL=https://id.ghjc.ru pnpm client:web:build`