### PR TITLE
ci(#271): rebuild services on patched runtime image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
               - 'Directory.Build.props'
               - 'Directory.Packages.props'
               - 'NuGet.Config'
+              - 'platform/dev/Dockerfile.service'
             api-gateway:
               - 'src/Gateway/ApiGateway/**'
             media-service:
@@ -106,6 +107,8 @@ jobs:
               - 'src/Services/User/**'
             chat-service:
               - 'src/Services/Chat/**'
+            discipline-service:
+              - 'src/Services/Discipline/**'
             presence-service:
               - 'src/Services/Presence/**'
             notification-service:
@@ -123,6 +126,7 @@ jobs:
           PROJECT_MAP[media-service]="src/Services/Media/MediaService.Api/MediaService.Api.csproj"
           PROJECT_MAP[user-service]="src/Services/User/UserService.Api/UserService.Api.csproj"
           PROJECT_MAP[chat-service]="src/Services/Chat/ChatService.Api/ChatService.Api.csproj"
+          PROJECT_MAP[discipline-service]="src/Services/Discipline/DisciplineService.Api/DisciplineService.Api.csproj"
           PROJECT_MAP[presence-service]="src/Services/Presence/PresenceService.Api/PresenceService.Api.csproj"
           PROJECT_MAP[notification-service]="src/Services/Notification/NotificationService.Api/NotificationService.Api.csproj"
           PROJECT_MAP[call-service]="src/Services/Call/CallService.Api/CallService.Api.csproj"
@@ -132,11 +136,12 @@ jobs:
           DLL_MAP[media-service]="MediaService.Api.dll"
           DLL_MAP[user-service]="UserService.Api.dll"
           DLL_MAP[chat-service]="ChatService.Api.dll"
+          DLL_MAP[discipline-service]="DisciplineService.Api.dll"
           DLL_MAP[presence-service]="PresenceService.Api.dll"
           DLL_MAP[notification-service]="NotificationService.Api.dll"
           DLL_MAP[call-service]="CallService.Api.dll"
 
-          ALL_SERVICES=(api-gateway media-service user-service chat-service presence-service notification-service call-service)
+          ALL_SERVICES=(api-gateway media-service user-service chat-service discipline-service presence-service notification-service call-service)
 
           FORCE_ALL="${{ inputs.force_all }}"
           SHARED_CHANGED="${{ steps.filter.outputs.shared }}"
@@ -168,6 +173,7 @@ jobs:
                 media-service) svc_changed="${{ steps.filter.outputs.media-service }}" ;;
                 user-service) svc_changed="${{ steps.filter.outputs.user-service }}" ;;
                 chat-service) svc_changed="${{ steps.filter.outputs.chat-service }}" ;;
+                discipline-service) svc_changed="${{ steps.filter.outputs.discipline-service }}" ;;
                 presence-service) svc_changed="${{ steps.filter.outputs.presence-service }}" ;;
                 notification-service) svc_changed="${{ steps.filter.outputs.notification-service }}" ;;
                 call-service) svc_changed="${{ steps.filter.outputs.call-service }}" ;;

--- a/.github/workflows/promote-app.yml
+++ b/.github/workflows/promote-app.yml
@@ -12,6 +12,7 @@ on:
           - media-service
           - user-service
           - chat-service
+          - discipline-service
           - presence-service
           - notification-service
           - call-service

--- a/platform/dev/Dockerfile.service
+++ b/platform/dev/Dockerfile.service
@@ -73,7 +73,7 @@ RUN dotnet publish "$SERVICE_PROJECT" \
     /p:UseAppHost=false
 
 # ── Runtime-стадия ──────────────────────────────────────────────────────────
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.8 AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080


### PR DESCRIPTION
## Что исправлено

- Обновлен runtime image для .NET сервисов: `mcr.microsoft.com/dotnet/aspnet:10.0.4` -> `10.0.8`, чтобы пройти Trivy после CVE-2026-42899.
- `platform/dev/Dockerfile.service` добавлен в shared paths CI: изменение Dockerfile теперь пересобирает все сервисные images.
- `discipline-service` добавлен в CI image matrix и ручной Promote App workflow.

## Проверки

- `git diff --check`
- Проверены project/values paths для `discipline-service`
- Локальный `docker manifest inspect` для MCR заблокирован сетью Microsoft, но ASP.NET Core Runtime 10.0.8 опубликован на официальной странице .NET 10.0.

После merge в `master` обычный push CI должен пересобрать все сервисы, просканировать, подписать и создать promote PR-ы для prod.