### PR TITLE
fix(frontend): restore Pomerium login redirect

### DIFF
--- a/packages/api-client/src/__tests__/createApiClient.test.ts
+++ b/packages/api-client/src/__tests__/createApiClient.test.ts
@@ -19,13 +19,20 @@ function mockFetchWith(responseInit: Partial<Response>) {
 
 describe("createApiClient", () => {
   let originalLocation: Location;
+  let assignLocation: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     originalLocation = window.location;
+    assignLocation = vi.fn((url: string | URL) => {
+      window.location.href = url.toString();
+    });
     Object.defineProperty(window, "location", {
       configurable: true,
       writable: true,
-      value: { href: "https://urfu-link.ghjc.ru/chats?view=messages" },
+      value: {
+        href: "https://urfu-link.ghjc.ru/chats?view=messages",
+        assign: assignLocation,
+      },
     });
   });
 
@@ -57,7 +64,7 @@ describe("createApiClient", () => {
   });
 
   describe("handleUnauthorized — opaqueredirect (Pomerium → Keycloak redirect)", () => {
-    it("redirects to /.pomerium/sign_in on opaqueredirect response", async () => {
+    it("reloads the current route on opaqueredirect response", async () => {
       mockFetchWith({ type: "opaqueredirect", status: 0, ok: false });
 
       const client = createApiClient({ baseUrl: "" });
@@ -67,12 +74,10 @@ describe("createApiClient", () => {
         // expected: response.ok is false → throws
       }
 
-      expect(window.location.href).toBe(
-        "/.pomerium/sign_in?pomerium_redirect_uri=https%3A%2F%2Furfu-link.ghjc.ru%2Fchats%3Fview%3Dmessages"
-      );
+      expect(assignLocation).toHaveBeenCalledWith("https://urfu-link.ghjc.ru/chats?view=messages");
     });
 
-    it("redirects to /.pomerium/sign_in on 401 without X-Session-Revoked", async () => {
+    it("reloads the current route on 401 without X-Session-Revoked", async () => {
       mockFetchWith({ status: 401, ok: false });
 
       const client = createApiClient({ baseUrl: "" });
@@ -82,9 +87,7 @@ describe("createApiClient", () => {
         // expected
       }
 
-      expect(window.location.href).toBe(
-        "/.pomerium/sign_in?pomerium_redirect_uri=https%3A%2F%2Furfu-link.ghjc.ru%2Fchats%3Fview%3Dmessages"
-      );
+      expect(assignLocation).toHaveBeenCalledWith("https://urfu-link.ghjc.ru/chats?view=messages");
     });
 
     it("redirects to /.pomerium/sign_out on 401 with X-Session-Revoked: true", async () => {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -86,11 +86,16 @@ export function createApiClient({ baseUrl, getAccessToken, onUnauthorized }: Api
     }
     if (typeof window !== "undefined" && !redirecting) {
       redirecting = true;
-      const rd = encodeURIComponent(window.location.href);
       const isRevoked = !isAuthRedirect && response.headers.get("X-Session-Revoked") === "true";
-      window.location.href = isRevoked
-        ? `/.pomerium/sign_out?pomerium_redirect_uri=${rd}`
-        : `/.pomerium/sign_in?pomerium_redirect_uri=${rd}`;
+      if (isRevoked) {
+        const rd = encodeURIComponent(window.location.href);
+        window.location.href = `/.pomerium/sign_out?pomerium_redirect_uri=${rd}`;
+        return;
+      }
+
+      // Let Pomerium generate its signed sign-in URL instead of constructing
+      // /.pomerium/sign_in directly in the SPA.
+      window.location.assign(window.location.href);
     }
   }
 


### PR DESCRIPTION
## Что исправлено

- Убрана ручная сборка URL /.pomerium/sign_in во фронтовом API-клиенте.
- При потере Pomerium-сессии клиент перезагружает текущий защищенный маршрут, чтобы Pomerium сам сгенерировал signed login redirect.
- Поведение /.pomerium/sign_out для явно отозванной сессии сохранено.

## Проверки

- pnpm --filter @urfu-link/api-client test
- pnpm client:typecheck
- pnpm client:web:build
- pnpm client:test

## Диагностика

В прод-логах Pomerium request id 97ffa1c8-7d26-4a00-b3b1-4ef3aeb7b239 падал с internal/urlutil: malformed unix timestamp field, потому что SPA отправляла пользователя на неподписанный /.pomerium/sign_in.