### PR TITLE
fix(infra): handle legacy Pomerium sign-in redirects

### DIFF
--- a/deploy/k8s/platform/argocd/apps/wave-minus5/ingress-nginx.yaml
+++ b/deploy/k8s/platform/argocd/apps/wave-minus5/ingress-nginx.yaml
@@ -29,6 +29,20 @@ spec:
           config:
             server-snippet: |
               location = /.pomerium/sign_in {
+                set $legacy_pomerium_sign_in "";
+
+                if ($arg_pomerium_signature = "") {
+                  set $legacy_pomerium_sign_in "missing-signature";
+                }
+
+                if ($arg_pomerium_redirect_uri != "") {
+                  set $legacy_pomerium_sign_in "${legacy_pomerium_sign_in}-with-redirect";
+                }
+
+                if ($legacy_pomerium_sign_in = "missing-signature-with-redirect") {
+                  return 302 https://urfu-link.ghjc.ru/;
+                }
+
                 proxy_pass http://pomerium.urfu-platform.svc.cluster.local:80;
                 proxy_http_version 1.1;
                 proxy_set_header Host auth.ghjc.ru;


### PR DESCRIPTION
## Что исправлено

- Добавлен защитный обработчик для старых неподписанных /.pomerium/sign_in?pomerium_redirect_uri=... запросов.
- Такие запросы возвращаются на защищенный frontend route, чтобы Pomerium сам выпустил корректный signed login redirect.
- Валидные signed Pomerium sign-in URL с pomerium_signature продолжают проксироваться в Pomerium.

## Проверки

- kubectl apply --dry-run=server -f deploy/k8s/platform/argocd/apps/wave-minus5/ingress-nginx.yaml

## Диагностика

После PR #286 новые pod'ы уже на sha-a084729, но браузеры со старой вкладкой/URL продолжали слать legacy bare sign-in. Прямой patch ConfigMap откатывался Argo self-heal'ом, поэтому фикс закрепляется в Git.