### PR TITLE
fix(infra): restore prod gateway routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
             media-service
             user-service
             chat-service
+            discipline-service
             presence-service
             notification-service
             call-service

--- a/deploy/k8s/platform/argocd/applicationset.yaml
+++ b/deploy/k8s/platform/argocd/applicationset.yaml
@@ -19,6 +19,9 @@ spec:
           - service: chat-service
             env: prod
             namespace: urfu-prod
+          - service: discipline-service
+            env: prod
+            namespace: urfu-prod
           - service: presence-service
             env: prod
             namespace: urfu-prod

--- a/deploy/k8s/platform/external-secrets/services-external-secrets.yaml
+++ b/deploy/k8s/platform/external-secrets/services-external-secrets.yaml
@@ -93,6 +93,26 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: discipline-service-secrets
+  namespace: urfu-prod
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    name: discipline-service-secrets
+  data:
+    - secretKey: ConnectionStrings__Primary
+      remoteRef:
+        key: urfu-link/prod/discipline-service
+        property: primary_connection
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: presence-service-secrets
   namespace: urfu-prod
   annotations:

--- a/deploy/k8s/platform/identity/pomerium-config.yaml
+++ b/deploy/k8s/platform/identity/pomerium-config.yaml
@@ -18,6 +18,18 @@ data:
         jwt_claims_headers:
           X-Session-Id: sid
 
+      # SignalR hubs: authenticated traffic goes through the same gateway as REST.
+      - from: https://urfu-link.ghjc.ru
+        to: http://api-gateway.urfu-prod.svc.cluster.local:8080
+        prefix: /hubs
+        policy:
+          - allow:
+              or:
+                - authenticated_user: true
+        pass_identity_headers: true
+        jwt_claims_headers:
+          X-Session-Id: sid
+
       # Static assets: allow unauthenticated access so app-config.js is loaded
       # before the auth flow starts. Without this Pomerium intercepts app-config.js
       # and the browser falls back to the default appEnv: "dev".

--- a/deploy/k8s/platform/linkerd/server-authentication.yaml
+++ b/deploy/k8s/platform/linkerd/server-authentication.yaml
@@ -91,6 +91,33 @@ spec:
 apiVersion: policy.linkerd.io/v1beta3
 kind: Server
 metadata:
+  name: discipline-service
+  namespace: urfu-prod
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: discipline-service
+  port: 8080
+  proxyProtocol: HTTP/1
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: discipline-service-allow-mtls
+  namespace: urfu-prod
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: discipline-service
+  requiredAuthenticationRefs:
+    - name: cluster-authenticated
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
+---
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
   name: presence-service
   namespace: urfu-prod
 spec:

--- a/deploy/k8s/platform/network/service-egress-policies-dev.yaml
+++ b/deploy/k8s/platform/network/service-egress-policies-dev.yaml
@@ -30,6 +30,7 @@ spec:
           - media-service
           - user-service
           - chat-service
+          - discipline-service
           - presence-service
           - notification-service
           - call-service

--- a/deploy/k8s/platform/network/service-egress-policies.yaml
+++ b/deploy/k8s/platform/network/service-egress-policies.yaml
@@ -61,6 +61,7 @@ spec:
           - media-service
           - user-service
           - chat-service
+          - discipline-service
           - presence-service
           - notification-service
           - call-service
@@ -110,6 +111,7 @@ spec:
           - media-service
           - user-service
           - chat-service
+          - discipline-service
           - presence-service
           - notification-service
           - call-service

--- a/deploy/k8s/platform/stateful/kafka-topics-job.yaml
+++ b/deploy/k8s/platform/stateful/kafka-topics-job.yaml
@@ -24,6 +24,7 @@ spec:
               echo "Kafka is ready. Creating topics..." &&
               /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.user.events.v1 --partitions 3 --replication-factor 1 &&
               /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.chat.events.v1 --partitions 3 --replication-factor 1 &&
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.discipline.events.v1 --partitions 3 --replication-factor 1 &&
               /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.media.events.v1 --partitions 3 --replication-factor 1 &&
               /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.notification.events.v1 --partitions 3 --replication-factor 1 &&
               /opt/kafka/bin/kafka-topics.sh --bootstrap-server urfu-kafka.urfu-platform.svc.cluster.local:9092 --create --if-not-exists --topic urfu.call.events.v1 --partitions 3 --replication-factor 1 &&

--- a/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
+++ b/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
@@ -129,6 +129,7 @@ spec:
 
                 USER_DB_PASSWORD="$(secret_value "$GENERATED_JSON" user_db_password 2>/dev/null || true)"
                 MEDIA_DB_PASSWORD="$(secret_value "$GENERATED_JSON" media_db_password 2>/dev/null || true)"
+                DISCIPLINE_DB_PASSWORD="$(secret_value "$GENERATED_JSON" discipline_db_password 2>/dev/null || true)"
                 KEYCLOAK_DB_PASSWORD="$(secret_value "$GENERATED_JSON" keycloak_db_password 2>/dev/null || true)"
                 KEYCLOAK_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" keycloak_admin_password 2>/dev/null || true)"
                 API_GATEWAY_CLIENT_SECRET="$(secret_value "$GENERATED_JSON" api_gateway_client_secret 2>/dev/null || true)"
@@ -136,6 +137,7 @@ spec:
 
                 [ -n "$USER_DB_PASSWORD" ] || USER_DB_PASSWORD="$(rand 32)"
                 [ -n "$MEDIA_DB_PASSWORD" ] || MEDIA_DB_PASSWORD="$(rand 32)"
+                [ -n "$DISCIPLINE_DB_PASSWORD" ] || DISCIPLINE_DB_PASSWORD="$(rand 32)"
                 [ -n "$KEYCLOAK_DB_PASSWORD" ] || KEYCLOAK_DB_PASSWORD="$(rand 32)"
                 [ -n "$KEYCLOAK_ADMIN_PASSWORD" ] || KEYCLOAK_ADMIN_PASSWORD="$(rand 32)"
                 [ -n "$API_GATEWAY_CLIENT_SECRET" ] || API_GATEWAY_CLIENT_SECRET="$(rand 40)"
@@ -144,9 +146,10 @@ spec:
                 GRAFANA_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" grafana_admin_password 2>/dev/null || true)"
                 [ -n "$GRAFANA_ADMIN_PASSWORD" ] || GRAFANA_ADMIN_PASSWORD="$(rand 32)"
 
-                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
                   "$(b64 "$USER_DB_PASSWORD")" \
                   "$(b64 "$MEDIA_DB_PASSWORD")" \
+                  "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
                   "$(b64 "$KEYCLOAK_DB_PASSWORD")" \
                   "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                   "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
@@ -156,9 +159,10 @@ spec:
                 if [ "$GENERATED_EXISTS" = "true" ]; then
                   patch_secret_json platform-bootstrap-generated "$GENERATED_PATCH"
                 else
-                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
                     "$(b64 "$USER_DB_PASSWORD")" \
                     "$(b64 "$MEDIA_DB_PASSWORD")" \
+                    "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
                     "$(b64 "$KEYCLOAK_DB_PASSWORD")" \
                     "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                     "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
@@ -235,6 +239,7 @@ spec:
 
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'user') THEN CREATE ROLE \"user\" LOGIN PASSWORD '$USER_DB_PASSWORD'; ELSE ALTER ROLE \"user\" WITH LOGIN PASSWORD '$USER_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'media') THEN CREATE ROLE \"media\" LOGIN PASSWORD '$MEDIA_DB_PASSWORD'; ELSE ALTER ROLE \"media\" WITH LOGIN PASSWORD '$MEDIA_DB_PASSWORD'; END IF; END \$\$;"
+                pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'discipline') THEN CREATE ROLE discipline LOGIN PASSWORD '$DISCIPLINE_DB_PASSWORD'; ELSE ALTER ROLE discipline WITH LOGIN PASSWORD '$DISCIPLINE_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'keycloak') THEN CREATE ROLE keycloak LOGIN PASSWORD '$KEYCLOAK_DB_PASSWORD'; ELSE ALTER ROLE keycloak WITH LOGIN PASSWORD '$KEYCLOAK_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pomerium') THEN CREATE ROLE pomerium LOGIN PASSWORD '$POMERIUM_DB_PASSWORD'; ELSE ALTER ROLE pomerium WITH LOGIN PASSWORD '$POMERIUM_DB_PASSWORD'; END IF; END \$\$;"
 
@@ -252,6 +257,14 @@ spec:
                   -d postgres \
                   -c "SELECT 1 FROM pg_database WHERE datname = 'media_db'" | grep -q 1; then
                   pg_exec "CREATE DATABASE media_db OWNER \"media\""
+                fi
+
+                if ! PGPASSWORD="$POSTGRES_PASSWORD" psql -At \
+                  -h urfu-postgres-rw.urfu-platform.svc.cluster.local \
+                  -U "$POSTGRES_USER" \
+                  -d postgres \
+                  -c "SELECT 1 FROM pg_database WHERE datname = 'discipline_db'" | grep -q 1; then
+                  pg_exec "CREATE DATABASE discipline_db OWNER discipline"
                 fi
 
                 if ! PGPASSWORD="$POSTGRES_PASSWORD" psql -At \
@@ -329,6 +342,7 @@ spec:
                 USER_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=user_db;Username=user;Password=%s"}}' "$USER_DB_PASSWORD")"
               fi
               MEDIA_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=media_db;Username=media;Password=%s"}}' "$MEDIA_DB_PASSWORD")"
+              DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s"}}' "$DISCIPLINE_DB_PASSWORD")"
               CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
               PRESENCE_PAYLOAD='{"data":{"primary_connection":"urfu-redis.urfu-platform.svc.cluster.local:6379"}}'
               NOTIFICATION_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'
@@ -345,6 +359,7 @@ spec:
               vault_put urfu-link/prod/pomerium-db "$POMERIUM_DB_PAYLOAD"
               vault_put urfu-link/prod/user-service "$USER_PAYLOAD"
               vault_put urfu-link/prod/media-service "$MEDIA_PAYLOAD"
+              vault_put urfu-link/prod/discipline-service "$DISCIPLINE_PAYLOAD"
               vault_put urfu-link/prod/chat-service "$CHAT_PAYLOAD"
               vault_put urfu-link/prod/presence-service "$PRESENCE_PAYLOAD"
               vault_put urfu-link/prod/notification-service "$NOTIFICATION_PAYLOAD"

--- a/deploy/k8s/platform/vault/vault-auto-init-job.yaml
+++ b/deploy/k8s/platform/vault/vault-auto-init-job.yaml
@@ -141,6 +141,9 @@ spec:
               path "kv/data/urfu-link/prod/chat-service" {
                 capabilities = ["create", "update", "read"]
               }
+              path "kv/data/urfu-link/prod/discipline-service" {
+                capabilities = ["create", "update", "read"]
+              }
               path "kv/data/urfu-link/prod/presence-service" {
                 capabilities = ["create", "update", "read"]
               }

--- a/platform/dev/local-k8s/dependencies.yaml
+++ b/platform/dev/local-k8s/dependencies.yaml
@@ -269,7 +269,7 @@ spec:
                 sleep 2
               done
 
-              topics="urfu.user.events.v1 urfu.media.events.v1 urfu.chat.events.v1 urfu.presence.events.v1 urfu.notification.events.v1 urfu.call.events.v1 urfu.user.events.v1.dlq urfu.media.events.v1.dlq urfu.chat.events.v1.dlq urfu.presence.events.v1.dlq urfu.notification.events.v1.dlq urfu.call.events.v1.dlq"
+              topics="urfu.user.events.v1 urfu.media.events.v1 urfu.chat.events.v1 urfu.discipline.events.v1 urfu.presence.events.v1 urfu.notification.events.v1 urfu.call.events.v1 urfu.user.events.v1.dlq urfu.media.events.v1.dlq urfu.chat.events.v1.dlq urfu.discipline.events.v1.dlq urfu.presence.events.v1.dlq urfu.notification.events.v1.dlq urfu.call.events.v1.dlq"
               for topic in $topics; do
                 /opt/kafka/bin/kafka-topics.sh \
                   --bootstrap-server kafka.urfu-platform.svc.cluster.local:9092 \

--- a/platform/dev/local-k8s/dev-secrets.yaml
+++ b/platform/dev/local-k8s/dev-secrets.yaml
@@ -50,6 +50,19 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: discipline-service-secrets
+  namespace: urfu-dev
+type: Opaque
+stringData:
+  ConnectionStrings__Primary: Host=postgres.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=discipline;GSS Encryption Mode=Disable
+  Kafka__BootstrapServers: kafka.urfu-platform.svc.cluster.local:9092
+  Auth__Authority: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link
+  Observability__Otlp__Endpoint: http://otel-collector.observability.svc.cluster.local:4317
+  Infrastructure__Redis__Configuration: redis.urfu-platform.svc.cluster.local:6379
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: presence-service-secrets
   namespace: urfu-dev
 type: Opaque

--- a/platform/dev/local-k8s/postgres-init.sql
+++ b/platform/dev/local-k8s/postgres-init.sql
@@ -26,6 +26,19 @@ WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'media_db')
 
 DO $$
 BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'discipline') THEN
+        CREATE ROLE discipline LOGIN PASSWORD 'discipline';
+    ELSE
+        ALTER ROLE discipline WITH LOGIN PASSWORD 'discipline';
+    END IF;
+END $$;
+
+SELECT 'CREATE DATABASE discipline_db OWNER discipline'
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'discipline_db')
+\gexec
+
+DO $$
+BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'keycloak') THEN
         CREATE ROLE keycloak LOGIN PASSWORD 'keycloak';
     ELSE

--- a/scripts/deploy-service.ps1
+++ b/scripts/deploy-service.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("api-gateway", "media-service", "user-service", "chat-service", "presence-service", "notification-service", "call-service", "frontend-web")]
+    [ValidateSet("api-gateway", "media-service", "user-service", "chat-service", "discipline-service", "presence-service", "notification-service", "call-service", "frontend-web")]
     [string]$Service,
 
     [Parameter(Mandatory = $true)]

--- a/scripts/local-k8s-load-images.ps1
+++ b/scripts/local-k8s-load-images.ps1
@@ -14,6 +14,7 @@ $images = @(
     @{ Service = "media-service"; Dockerfile = "src/Services/Media/MediaService.Api/Dockerfile" },
     @{ Service = "user-service"; Dockerfile = "src/Services/User/UserService.Api/Dockerfile" },
     @{ Service = "chat-service"; Dockerfile = "src/Services/Chat/ChatService.Api/Dockerfile" },
+    @{ Service = "discipline-service"; Dockerfile = "src/Services/Discipline/DisciplineService.Api/Dockerfile" },
     @{ Service = "presence-service"; Dockerfile = "src/Services/Presence/PresenceService.Api/Dockerfile" },
     @{ Service = "notification-service"; Dockerfile = "src/Services/Notification/NotificationService.Api/Dockerfile" },
     @{ Service = "call-service"; Dockerfile = "src/Services/Call/CallService.Api/Dockerfile" },

--- a/scripts/local-k8s-smoke.ps1
+++ b/scripts/local-k8s-smoke.ps1
@@ -13,6 +13,7 @@ $services = @(
     "user-service",
     "media-service",
     "chat-service",
+    "discipline-service",
     "presence-service",
     "notification-service",
     "call-service",

--- a/scripts/local-k8s-up.ps1
+++ b/scripts/local-k8s-up.ps1
@@ -115,6 +115,7 @@ $services = @(
     "media-service",
     "user-service",
     "chat-service",
+    "discipline-service",
     "presence-service",
     "notification-service",
     "call-service",

--- a/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
+++ b/src/Gateway/ApiGateway/HealthChecks/YarpDestinationsHealthCheck.cs
@@ -5,7 +5,7 @@ namespace Urfu.Link.Gateway.ApiGateway.HealthChecks;
 
 /// <summary>
 /// Reads destination health populated by YARP active probes (configured per-cluster in
-/// <c>appsettings.json</c>) and aggregates it into a single readiness signal:
+/// <c>appsettings.json</c>) and aggregates it into a downstream dependency signal:
 /// <list type="bullet">
 ///   <item><description><see cref="HealthStatus.Healthy"/> — every cluster has at least one destination whose Active or Passive health is not <see cref="DestinationHealth.Unhealthy"/>.</description></item>
 ///   <item><description><see cref="HealthStatus.Unhealthy"/> — at least one cluster has no usable destinations.</description></item>

--- a/src/Gateway/ApiGateway/Middleware/HubAccessTokenPresenceMiddleware.cs
+++ b/src/Gateway/ApiGateway/Middleware/HubAccessTokenPresenceMiddleware.cs
@@ -1,25 +1,18 @@
 using System.Net.Http.Headers;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Net.Http.Headers;
 
 namespace Urfu.Link.Gateway.ApiGateway.Middleware;
 
 /// <summary>
-/// Defence-in-depth for SignalR hub routes (<c>/hubs/*</c>): the gateway cannot validate the JWT
-/// (downstream services accept it via <c>?access_token=</c> query parameter or via the
-/// <c>Authorization: Bearer</c> header), but it can require that a token be present in one of those
-/// two channels. Anonymous traffic that did not provide a token at all is rejected here with
-/// 401 Unauthorized, before it reaches downstream.
+/// Defence-in-depth for SignalR hub routes (<c>/hubs/*</c>): downstream services validate the JWT,
+/// but the gateway still requires a token in a known carrier before proxying hub traffic.
 /// </summary>
-/// <remarks>
-/// SignalR JS-клиент использует разные каналы передачи токена в зависимости от транспорта:
-/// на фазе HTTP-negotiate он шлёт <c>Authorization: Bearer</c>, при апгрейде в WebSocket
-/// токен переезжает в <c>?access_token=</c> query parameter. Middleware принимает оба варианта,
-/// чтобы валидный запрос не отвергался до того, как стандартный JWT-pipeline проверит подпись.
-/// </remarks>
-public sealed class HubAccessTokenPresenceMiddleware(RequestDelegate next)
+public sealed class HubAccessTokenPresenceMiddleware(RequestDelegate next, IConfiguration configuration)
 {
     private const string HubsPathSegment = "/hubs";
     private const string AccessTokenQueryKey = "access_token";
+    private readonly string? _configuredTokenHeader = GetConfiguredTokenHeader(configuration);
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -27,7 +20,9 @@ public sealed class HubAccessTokenPresenceMiddleware(RequestDelegate next)
 
         if (context.Request.Path.StartsWithSegments(HubsPathSegment, StringComparison.Ordinal))
         {
-            if (!HasAccessTokenInQuery(context) && !HasBearerAuthorizationHeader(context))
+            if (!HasAccessTokenInQuery(context)
+                && !HasBearerAuthorizationHeader(context)
+                && !HasConfiguredTokenHeader(context))
             {
                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 context.Response.Headers[HeaderNames.WWWAuthenticate] = "Bearer";
@@ -67,5 +62,34 @@ public sealed class HubAccessTokenPresenceMiddleware(RequestDelegate next)
         }
 
         return false;
+    }
+
+    private bool HasConfiguredTokenHeader(HttpContext context)
+    {
+        if (string.IsNullOrWhiteSpace(_configuredTokenHeader))
+        {
+            return false;
+        }
+
+        if (!context.Request.Headers.TryGetValue(_configuredTokenHeader, out var values))
+        {
+            return false;
+        }
+
+        foreach (var raw in values)
+        {
+            if (!string.IsNullOrWhiteSpace(raw))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? GetConfiguredTokenHeader(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        return configuration["Auth:TokenHeader"];
     }
 }

--- a/src/Gateway/ApiGateway/Program.cs
+++ b/src/Gateway/ApiGateway/Program.cs
@@ -96,7 +96,7 @@ builder.Services
         name: "yarp-destinations",
         factory: sp => sp.GetRequiredService<YarpDestinationsHealthCheck>(),
         failureStatus: HealthStatus.Unhealthy,
-        tags: ["ready"]));
+        tags: ["downstream"]));
 
 var app = builder.Build();
 
@@ -126,8 +126,8 @@ app.Use((context, next) =>
     return next();
 });
 
-// Defence in depth for SignalR hub routes: gateway does not validate the JWT (downstream does), but
-// it requires the access_token query parameter to be present so anonymous traffic is rejected here.
+// Defence in depth for SignalR hub routes: downstream services validate the JWT, while the gateway
+// rejects hub traffic that carries no token or edge identity assertion at all.
 app.UseMiddleware<HubAccessTokenPresenceMiddleware>();
 
 app.UseAuthentication();
@@ -158,7 +158,11 @@ app.MapHealthChecks("/health/live", new HealthCheckOptions
 });
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
-    Predicate = check => check.Tags.Contains("ready"),
+    Predicate = _ => false,
+});
+app.MapHealthChecks("/health/downstreams", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("downstream"),
     ResultStatusCodes = readinessStatusCodes,
 });
 

--- a/src/Gateway/ApiGateway/README.md
+++ b/src/Gateway/ApiGateway/README.md
@@ -1,16 +1,17 @@
 # ApiGateway
 
-YARP-based reverse proxy + edge concerns (auth, rate limiting, correlation, session revocation).
+YARP-based reverse proxy plus edge concerns: auth, rate limiting, correlation, and session revocation.
 
 ## Routing model (`appsettings.json`)
 
-REST routes carry `"AuthorizationPolicy": "default"`, which forces the gateway to validate the JWT (Keycloak realm via `Auth:Authority`) before forwarding. SignalR hub routes (`chat-hub`, `presence-hub`, `notification-hub`) intentionally **omit** the `AuthorizationPolicy` field. This is **by design**:
+REST routes carry `"AuthorizationPolicy": "default"`, which forces the gateway to validate the JWT before forwarding. SignalR hub routes (`chat-hub`, `presence-hub`, `notification-hub`) intentionally omit the `AuthorizationPolicy` field. This is by design:
 
-- SignalR clients cannot set the `Authorization` HTTP header during the WebSocket upgrade handshake (browsers strip custom headers from the upgrade), so the JWT travels via the `?access_token=...` query parameter.
-- Each downstream SignalR service has a `JwtBearerEvents.OnMessageReceived` hook that promotes that query parameter into the bearer token before the auth middleware runs.
-- The gateway therefore relies on **two layers of defence-in-depth** for hub traffic: `HubAccessTokenPresenceMiddleware` rejects connections that omit `?access_token=` (so anonymous WebSocket attempts fail at the edge), and the downstream service still validates the JWT before letting the connection complete the handshake.
+- SignalR clients cannot set the `Authorization` HTTP header during the WebSocket upgrade handshake, so browser WebSocket traffic may carry the JWT via the `?access_token=...` query parameter.
+- HTTP negotiate requests may carry `Authorization: Bearer ...`.
+- Pomerium-protected production traffic carries the signed identity assertion in the configured edge header, `X-Pomerium-Jwt-Assertion`.
+- The gateway therefore relies on two layers of defence-in-depth for hub traffic: `HubAccessTokenPresenceMiddleware` rejects connections that omit all accepted token carriers, and the downstream service still validates the JWT before letting the connection complete the handshake.
 
-If you need to add a new hub route, follow the same pattern: drop `AuthorizationPolicy`, leave the path under `/hubs/`, and ensure the downstream service's `Program.cs` configures `JwtBearerEvents.OnMessageReceived` to read `access_token` from the query string.
+If you need to add a new hub route, follow the same pattern: drop `AuthorizationPolicy`, leave the path under `/hubs/`, and ensure the downstream service can read the same token carriers used by the deployed edge.
 
 ## Rate limiting
 
@@ -24,5 +25,6 @@ Search endpoints implement their own per-user limit at the service level (see `C
 
 ## Health checks
 
-- `/health/live` — always 200 unless the process is dead. Wired to kubelet liveness; do **not** chain it to YARP destinations.
-- `/health/ready` — aggregates the `yarp-destinations` check (active YARP probes against each cluster's `/health/ready`). Wired to kubelet readiness so a degraded downstream takes the gateway pod out of rotation without restarting it.
+- `/health/live` - always 200 unless the process is dead. Wired to kubelet liveness; do not chain it to YARP destinations.
+- `/health/ready` - process readiness for kubelet. It intentionally does not aggregate downstream service health, so one broken service does not remove every gateway route from Kubernetes endpoints.
+- `/health/downstreams` - aggregates the `yarp-destinations` check (active YARP probes against each cluster's `/health/ready`) for operational diagnostics.

--- a/tests/integration/ApiGateway.IntegrationTests/HealthCheckIntegrationTests.cs
+++ b/tests/integration/ApiGateway.IntegrationTests/HealthCheckIntegrationTests.cs
@@ -64,7 +64,38 @@ public sealed class HealthCheckIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Ready_ReturnsServiceUnavailable_WhenAnyClusterHasNoUsableDestinations()
+    public async Task Ready_ReturnsHealthy_WhenAnyDownstreamClusterHasNoUsableDestinations()
+    {
+        var unreachableFactory = new GatewayTestFactory(
+            new Dictionary<string, string>
+            {
+                ["user-cluster"] = "http://127.0.0.1:1",
+                ["chat-cluster"] = _chatStub.BaseUrl,
+                ["media-cluster"] = _chatStub.BaseUrl,
+                ["presence-cluster"] = _chatStub.BaseUrl,
+                ["notification-cluster"] = _chatStub.BaseUrl,
+                ["call-cluster"] = _chatStub.BaseUrl,
+                ["discipline-cluster"] = _chatStub.BaseUrl,
+            },
+            extraConfiguration: new Dictionary<string, string?>
+            {
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Enabled"] = "true",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Interval"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Timeout"] = "00:00:01",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Path"] = "/health/ready",
+                ["ReverseProxy:Clusters:user-cluster:HealthCheck:Active:Policy"] = "ConsecutiveFailures",
+            });
+        await using var _ = unreachableFactory;
+        using var unreachableClient = unreachableFactory.CreateClient();
+
+        using var response = await unreachableClient.GetAsync("/health/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "gateway readiness must not remove every API route from Kubernetes endpoints when one downstream fails");
+    }
+
+    [Fact]
+    public async Task Downstreams_ReturnsServiceUnavailable_WhenAnyClusterHasNoUsableDestinations()
     {
         // Active YARP probes mark the destination Unhealthy after one failure round-trip.
         // We point user-cluster at an unreachable endpoint, then wait until a probe round runs.
@@ -96,7 +127,7 @@ public sealed class HealthCheckIntegrationTests : IAsyncLifetime
             for (var attempt = 0; attempt < 10; attempt++)
             {
                 response?.Dispose();
-                response = await unreachableClient.GetAsync("/health/ready");
+                response = await unreachableClient.GetAsync("/health/downstreams");
                 if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
                 {
                     break;
@@ -105,7 +136,7 @@ public sealed class HealthCheckIntegrationTests : IAsyncLifetime
             }
 
             response!.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
-                "active probes mark unreachable user-cluster Unhealthy and the readiness check aggregates that into 503");
+                "the dedicated downstream health endpoint should still expose broken YARP destinations");
         }
         finally
         {

--- a/tests/integration/ApiGateway.IntegrationTests/RoutingIntegrationTests.cs
+++ b/tests/integration/ApiGateway.IntegrationTests/RoutingIntegrationTests.cs
@@ -140,6 +140,34 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HubRoute_WithConfiguredTokenHeader_ProxiesToDownstream()
+    {
+        await using var pomeriumFactory = new GatewayTestFactory(
+            new Dictionary<string, string>
+            {
+                ["chat-cluster"] = _chatStub.BaseUrl,
+            },
+            extraConfiguration: new Dictionary<string, string?>
+            {
+                ["Auth:TokenHeader"] = "X-Pomerium-Jwt-Assertion",
+            });
+        using var pomeriumClient = pomeriumFactory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/chat/negotiate")
+        {
+            Content = new StringContent(string.Empty),
+        };
+        request.Headers.Add("X-Pomerium-Jwt-Assertion", "signed-pomerium-jwt");
+
+        var response = await pomeriumClient.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _chatStub.Requests.Should().ContainSingle(r => r.Path == "/hubs/chat/negotiate")
+            .Which.Headers.Should().ContainKey("X-Pomerium-Jwt-Assertion")
+            .WhoseValue.Should().Be("signed-pomerium-jwt");
+    }
+
+    [Fact]
     public async Task DirectHubRoute_PresenceConnect_ProxiesWebSocketHandshake()
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, "/hubs/presence/negotiate?access_token=user-42")


### PR DESCRIPTION
## Summary
- route Pomerium /hubs/* traffic through the API Gateway and accept the configured Pomerium identity header for hub requests
- keep gateway readiness independent from downstream cluster health while exposing /health/downstreams for diagnostics
- add DisciplineService to prod/dev deployment plumbing, secrets bootstrap, Kafka topics, network policies, and Helm validation

## Validation
- dotnet build Urfu.Link.slnx -c Release
- dotnet test tests/integration/ApiGateway.IntegrationTests/ApiGateway.IntegrationTests.csproj
- kubectl kustomize deploy/k8s/platform
- kubectl kustomize deploy/k8s/platform/stateful
- kubectl kustomize platform/dev/local-k8s
- helm template for all services/environments via argocd-repo-server

Note: full dotnet test Urfu.Link.slnx -c Release --no-build is blocked locally because Docker/Testcontainers is unavailable on this machine.