### PR TITLE
fix(infra): stabilize prod chat routing

### DIFF
--- a/deploy/k8s/platform/argocd/apps/wave-5/platform-stateful.yaml
+++ b/deploy/k8s/platform/argocd/apps/wave-5/platform-stateful.yaml
@@ -18,6 +18,12 @@ spec:
       jsonPointers:
         - /data/password
         - /stringData
+    - kind: Secret
+      name: mongo-app-user-password
+      namespace: urfu-platform
+      jsonPointers:
+        - /data/password
+        - /stringData
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:

--- a/deploy/k8s/platform/identity/pomerium-config.yaml
+++ b/deploy/k8s/platform/identity/pomerium-config.yaml
@@ -22,6 +22,7 @@ data:
       - from: https://urfu-link.ghjc.ru
         to: http://api-gateway.urfu-prod.svc.cluster.local:8080
         prefix: /hubs
+        allow_websockets: true
         policy:
           - allow:
               or:

--- a/deploy/k8s/platform/stateful/mongodb-cluster.yaml
+++ b/deploy/k8s/platform/stateful/mongodb-cluster.yaml
@@ -27,6 +27,8 @@ kind: StatefulSet
 metadata:
   name: urfu-mongo
   namespace: urfu-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   serviceName: urfu-mongo-svc
   replicas: 1

--- a/deploy/k8s/platform/vault/vault-auto-init-job.yaml
+++ b/deploy/k8s/platform/vault/vault-auto-init-job.yaml
@@ -204,6 +204,9 @@ spec:
               path "kv/data/urfu-link/prod/user-service" {
                 capabilities = ["read", "update"]
               }
+              path "kv/data/urfu-link/prod/chat-service" {
+                capabilities = ["create", "update", "read"]
+              }
               path "kv/metadata/urfu-link/prod/*" {
                 capabilities = ["read", "list"]
               }

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -5,10 +5,8 @@ public sealed class DeploymentContractTests
     [Fact]
     public void HelmValuesShouldAlignWithPromotedImageTags()
     {
-        var prodValues = File.ReadAllText(Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "deploy", "helm", "services", "user-service", "values-prod.yaml")));
-        var devValues = File.ReadAllText(Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "deploy", "helm", "services", "user-service", "values-dev.yaml")));
+        var prodValues = ReadRepoFile("deploy", "helm", "services", "user-service", "values-prod.yaml");
+        var devValues = ReadRepoFile("deploy", "helm", "services", "user-service", "values-dev.yaml");
 
         Assert.Matches(@"tag:\s+sha-[0-9a-f]{7}", prodValues);
         Assert.Contains("tag: dev-local", devValues, StringComparison.Ordinal);
@@ -19,14 +17,64 @@ public sealed class DeploymentContractTests
     [Fact]
     public void LocalKubernetesOverlayShouldDefineClusterDependencies()
     {
-        var overlay = File.ReadAllText(Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "platform", "dev", "local-k8s", "kustomization.yaml")));
-        var dependencies = File.ReadAllText(Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "platform", "dev", "local-k8s", "dependencies.yaml")));
+        var overlay = ReadRepoFile("platform", "dev", "local-k8s", "kustomization.yaml");
+        var dependencies = ReadRepoFile("platform", "dev", "local-k8s", "dependencies.yaml");
 
         Assert.Contains("dependencies.yaml", overlay, StringComparison.Ordinal);
         Assert.Contains("kind: Deployment", dependencies, StringComparison.Ordinal);
         Assert.Contains("name: kafka", dependencies, StringComparison.Ordinal);
         Assert.Contains("name: keycloak", dependencies, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProductionPomeriumRoutesShouldProxyApiAndSignalRHubsToGateway()
+    {
+        var config = ReadRepoFile("deploy", "k8s", "platform", "identity", "pomerium-config.yaml");
+
+        Assert.Contains("prefix: /api", config, StringComparison.Ordinal);
+        Assert.Contains("prefix: /hubs", config, StringComparison.Ordinal);
+        Assert.Contains("allow_websockets: true", config, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void KeycloakBootstrapPolicyShouldAllowWritingChatServiceInternalSecret()
+    {
+        var config = ReadRepoFile("deploy", "k8s", "platform", "vault", "vault-auto-init-job.yaml");
+        var policyStart = config.IndexOf("vault policy write keycloak-bootstrap", StringComparison.Ordinal);
+        policyStart = config.IndexOf("<<EOF_POL", policyStart, StringComparison.Ordinal) + "<<EOF_POL".Length;
+        var policyEnd = config.IndexOf("EOF_POL", policyStart, StringComparison.Ordinal);
+        var keycloakBootstrapPolicy = config[policyStart..policyEnd];
+
+        Assert.Contains("path \"kv/data/urfu-link/prod/chat-service\"", keycloakBootstrapPolicy, StringComparison.Ordinal);
+        Assert.Contains("capabilities = [\"create\", \"update\", \"read\"]", keycloakBootstrapPolicy, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlatformStatefulShouldNotReconcileGeneratedMongoPassword()
+    {
+        var application = ReadRepoFile("deploy", "k8s", "platform", "argocd", "apps", "wave-5", "platform-stateful.yaml");
+
+        Assert.Contains("name: mongo-app-user-password", application, StringComparison.Ordinal);
+        Assert.Contains("/data/password", application, StringComparison.Ordinal);
+        Assert.Contains("/stringData", application, StringComparison.Ordinal);
+        Assert.Contains("RespectIgnoreDifferences=true", application, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MongoStatefulSetShouldStartAfterPlatformBootstrapGeneratesPassword()
+    {
+        var manifest = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-cluster.yaml");
+
+        Assert.Contains("name: mongo-app-user-password", manifest, StringComparison.Ordinal);
+        Assert.Contains("argocd.argoproj.io/sync-wave: \"-1\"", manifest, StringComparison.Ordinal);
+        Assert.Contains("name: urfu-mongo", manifest, StringComparison.Ordinal);
+        Assert.Contains("argocd.argoproj.io/sync-wave: \"3\"", manifest, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] pathSegments)
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
+
+        return File.ReadAllText(Path.Combine([repoRoot, .. pathSegments]));
     }
 }


### PR DESCRIPTION
## Что исправлено
- Проксирование SignalR `/hubs` через gateway с поддержкой WebSocket.
- Права `keycloak-bootstrap` на запись секрета ChatService в Vault.
- Защита сгенерированного MongoDB пароля от Argo self-heal.
- Порядок запуска MongoDB после bootstrap секрета.

## Проверка
- `dotnet test tests\contract\ContractTests\ContractTests.csproj`