### PR TITLE
fix(chat): handle direct draft links

### DIFF
--- a/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
+++ b/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
@@ -2,6 +2,13 @@ import { mapMessageToProps, useChatStore } from "../chat-store";
 import { createHubConnection } from "@/shared/lib/signalr";
 import { apiClient } from "@/shared/lib/api";
 
+const mockAuthState: { userId: string | null; setUserId: jest.Mock } = {
+    userId: "user-1",
+    setUserId: jest.fn((userId: string | null) => {
+        mockAuthState.userId = userId;
+    }),
+};
+
 jest.mock("@microsoft/signalr", () => ({
     HubConnectionState: {
         Connected: "Connected",
@@ -33,12 +40,15 @@ jest.mock("@/shared/lib/signalr", () => ({
 
 jest.mock("@/shared/store/auth-store", () => ({
     useAuthStore: {
-        getState: jest.fn(() => ({ userId: "user-1" })),
+        getState: jest.fn(() => mockAuthState),
     },
 }));
 
 jest.mock("@/shared/lib/api", () => ({
     apiClient: {
+        users: {
+            getMe: jest.fn(),
+        },
         chat: {
             editMessage: jest.fn(),
             deleteMessage: jest.fn(),
@@ -57,9 +67,37 @@ jest.mock("@/shared/lib/api", () => ({
 describe("chat store direct draft sending", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockAuthState.userId = "user-1";
         Object.keys(hubHandlers).forEach((key) => delete hubHandlers[key]);
         hubConnection.state = "Disconnected";
         (createHubConnection as jest.Mock).mockReturnValue(hubConnection);
+        (apiClient.users.getMe as jest.Mock).mockResolvedValue({
+            userId: "user-1",
+            identity: {
+                name: "Current User",
+                email: "current@example.com",
+                username: "current",
+            },
+            account: {
+                avatarUrl: null,
+                aboutMe: null,
+            },
+            privacy: {
+                showOnlineStatus: true,
+                showLastVisitTime: true,
+            },
+            notifications: {
+                newMessages: true,
+                notificationSound: true,
+                disciplineChatMessages: true,
+                mentions: true,
+            },
+            soundVideo: {
+                playbackDeviceId: null,
+                recordingDeviceId: null,
+                webcamDeviceId: null,
+            },
+        });
         useChatStore.setState({
             connection: null,
             isConnected: false,
@@ -140,6 +178,54 @@ describe("chat store direct draft sending", () => {
             }),
         );
         expect(conversation.lastMessageAtUtc).toBe("2026-05-24T10:00:00.000Z");
+    });
+
+    it("hydrates the current user before sending when the auth store has no jwt user", async () => {
+        mockAuthState.userId = null;
+        const invoke = jest.fn(async (_method: string, payload: { clientMessageId: string }) => ({
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "user-1",
+            body: "hello",
+            attachments: [],
+            state: "Sent",
+            createdAtUtc: "2026-05-24T10:00:00.000Z",
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            clientMessageId: payload.clientMessageId,
+            editedAtUtc: null,
+            replyTo: null,
+            reactionsSummary: {},
+            mentions: [],
+            forwardedFrom: null,
+        }));
+
+        useChatStore.setState({
+            connection: { state: "Connected", invoke } as never,
+            isConnected: true,
+            conversations: [
+                {
+                    id: "direct-1",
+                    type: "Direct",
+                    participants: ["peer-1", "user-1"],
+                    createdAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessageAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessagePreview: null,
+                },
+            ],
+        });
+
+        await useChatStore.getState().sendMessage("direct-1", "hello");
+
+        expect(apiClient.users.getMe).toHaveBeenCalledTimes(1);
+        expect(mockAuthState.setUserId).toHaveBeenCalledWith("user-1");
+        expect(invoke).toHaveBeenCalledWith(
+            "SendMessage",
+            expect.objectContaining({
+                conversationId: "direct-1",
+                peerUserId: "peer-1",
+            }),
+        );
     });
 
     it("keeps media asset ids in mapped message attachments", () => {

--- a/apps/client/src/entities/conversation/model/__tests__/direct-draft-cache.test.ts
+++ b/apps/client/src/entities/conversation/model/__tests__/direct-draft-cache.test.ts
@@ -1,0 +1,76 @@
+const mockStorage = new Map<string, string>();
+
+jest.mock("@/shared/lib/storage", () => ({
+    appStorage: {
+        getItem: jest.fn((name: string) => mockStorage.get(name) ?? null),
+        setItem: jest.fn((name: string, value: string) => {
+            mockStorage.set(name, value);
+        }),
+        removeItem: jest.fn((name: string) => {
+            mockStorage.delete(name);
+        }),
+    },
+}));
+
+const {
+    isDirectDraftId,
+    restoreDirectDraftConversation,
+    saveDirectDraftConversation,
+} = require("../direct-draft-cache") as typeof import("../direct-draft-cache");
+
+describe("direct draft cache", () => {
+    beforeEach(() => {
+        mockStorage.clear();
+    });
+
+    it("recognizes deterministic direct draft ids", () => {
+        expect(isDirectDraftId("8b52b1fc6ba59e5479e937392652af924b69a5e7")).toBe(true);
+        expect(isDirectDraftId("8b52b1fc6ba59e5479e93739")).toBe(false);
+        expect(isDirectDraftId("not-a-draft")).toBe(false);
+    });
+
+    it("stores and restores an unmaterialized direct conversation", () => {
+        const conversation = {
+            id: "8b52b1fc6ba59e5479e937392652af924b69a5e7",
+            type: "Direct" as const,
+            participants: ["current-user", "peer-user"],
+            createdAtUtc: "2026-05-24T10:00:00.000Z",
+            lastMessageAtUtc: "2026-05-24T10:00:00.000Z",
+            lastMessagePreview: null,
+        };
+        const participants = [
+            {
+                userId: "peer-user",
+                role: "Member" as const,
+                displayName: "Peer User",
+                avatarUrl: "",
+            },
+        ];
+
+        saveDirectDraftConversation(conversation, participants);
+
+        expect(restoreDirectDraftConversation(conversation.id)).toEqual({
+            conversation,
+            participants,
+        });
+    });
+
+    it("does not cache already materialized direct conversations", () => {
+        const conversation = {
+            id: "8b52b1fc6ba59e5479e937392652af924b69a5e7",
+            type: "Direct" as const,
+            participants: ["current-user", "peer-user"],
+            createdAtUtc: "2026-05-24T10:00:00.000Z",
+            lastMessageAtUtc: "2026-05-24T10:01:00.000Z",
+            lastMessagePreview: {
+                messageId: "message-1",
+                senderId: "current-user",
+                body: "hello",
+            },
+        };
+
+        saveDirectDraftConversation(conversation, []);
+
+        expect(restoreDirectDraftConversation(conversation.id)).toBeNull();
+    });
+});

--- a/apps/client/src/entities/conversation/model/chat-store.ts
+++ b/apps/client/src/entities/conversation/model/chat-store.ts
@@ -8,6 +8,7 @@ import {
 import { createHubConnection } from "@/shared/lib/signalr";
 import { HubConnection, HubConnectionState } from "@microsoft/signalr";
 import { apiClient } from "@/shared/lib/api";
+import { resolveCurrentUserId } from "@/shared/lib/current-user";
 import { useAuthStore } from "@/shared/store/auth-store";
 
 /** Локальный (только клиентский) статус сообщения, не приходящий с сервера. */
@@ -751,10 +752,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         if (connection?.state !== HubConnectionState.Connected) {
             throw new Error("ChatHub is not connected");
         }
-        const currentUserId = useAuthStore.getState().userId;
-        if (!currentUserId) {
-            throw new Error("Not authenticated");
-        }
+        const currentUserId = await resolveCurrentUserId();
 
         const clientMessageId =
             typeof crypto !== "undefined" && "randomUUID" in crypto

--- a/apps/client/src/entities/conversation/model/direct-draft-cache.ts
+++ b/apps/client/src/entities/conversation/model/direct-draft-cache.ts
@@ -1,0 +1,81 @@
+import type { ConversationParticipantDto, ConversationPreview } from "@urfu-link/api-client";
+import { appStorage } from "@/shared/lib/storage";
+
+const STORAGE_KEY = "chat.directDrafts.v1";
+const MAX_CACHED_DRAFTS = 20;
+const DIRECT_DRAFT_ID_PATTERN = /^[0-9a-f]{40}$/i;
+
+type DirectDraftCacheEntry = {
+    conversation: ConversationPreview;
+    participants: ConversationParticipantDto[];
+    savedAt: number;
+};
+
+type DirectDraftCache = Record<string, DirectDraftCacheEntry>;
+
+export const isDirectDraftId = (value: string | null | undefined): value is string =>
+    typeof value === "string" && DIRECT_DRAFT_ID_PATTERN.test(value);
+
+export const isDirectDraftConversation = (
+    conversation: Pick<ConversationPreview, "type" | "lastMessagePreview"> | null | undefined,
+) => conversation?.type === "Direct" && !conversation.lastMessagePreview;
+
+const readCache = (): DirectDraftCache => {
+    const raw = appStorage.getItem(STORAGE_KEY);
+    if (!raw || typeof raw !== "string") {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as DirectDraftCache;
+        return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+        return {};
+    }
+};
+
+const writeCache = (cache: DirectDraftCache) => {
+    appStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+};
+
+export const saveDirectDraftConversation = (
+    conversation: ConversationPreview,
+    participants: ConversationParticipantDto[],
+) => {
+    if (!isDirectDraftId(conversation.id) || !isDirectDraftConversation(conversation)) {
+        return;
+    }
+
+    const cache = readCache();
+    cache[conversation.id] = {
+        conversation,
+        participants,
+        savedAt: Date.now(),
+    };
+
+    const pruned = Object.fromEntries(
+        Object.entries(cache)
+            .sort(([, left], [, right]) => right.savedAt - left.savedAt)
+            .slice(0, MAX_CACHED_DRAFTS),
+    );
+
+    writeCache(pruned);
+};
+
+export const restoreDirectDraftConversation = (
+    conversationId: string,
+): Pick<DirectDraftCacheEntry, "conversation" | "participants"> | null => {
+    if (!isDirectDraftId(conversationId)) {
+        return null;
+    }
+
+    const entry = readCache()[conversationId];
+    if (!entry || !isDirectDraftConversation(entry.conversation)) {
+        return null;
+    }
+
+    return {
+        conversation: entry.conversation,
+        participants: entry.participants,
+    };
+};

--- a/apps/client/src/entities/presence/model/__tests__/presence-store.test.ts
+++ b/apps/client/src/entities/presence/model/__tests__/presence-store.test.ts
@@ -209,6 +209,27 @@ describe("presence store subscriptions", () => {
         expect(connection.invoke).toHaveBeenCalledWith("UnsubscribeFromUsers", [peerUserId]);
     });
 
+    it("does not warn when subscribe is canceled by a closing hub connection", async () => {
+        const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        await act(async () => {
+            await usePresenceStore.getState().connect();
+        });
+        connection.invoke.mockClear();
+        connection.invoke.mockRejectedValueOnce(
+            new Error("Invocation canceled due to the underlying connection being closed."),
+        );
+
+        await act(async () => {
+            await usePresenceStore.getState().watchUserPresence(peerUserId);
+        });
+
+        expect(connection.invoke).toHaveBeenCalledWith("SubscribeToUsers", [peerUserId]);
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+    });
+
     it("does not warn when unsubscribe is canceled by a closing hub connection", async () => {
         const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 

--- a/apps/client/src/entities/presence/model/presence-store.ts
+++ b/apps/client/src/entities/presence/model/presence-store.ts
@@ -49,6 +49,12 @@ const isConnectionClosingError = (error: unknown) =>
     error instanceof Error &&
     error.message.toLowerCase().includes("underlying connection being closed");
 
+const warnUnlessConnectionClosingError = (message: string, error: unknown) => {
+    if (!isConnectionClosingError(error)) {
+        console.warn(message, error);
+    }
+};
+
 const formatGuid = (hex: string) =>
     `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`.toLowerCase();
 
@@ -113,10 +119,16 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         const newConnection = createHubConnection("/hubs/presence");
         const subscribeWatchedUsers = async () => {
             const watched = get().watchedUserIds.filter(isUuid);
-            if (watched.length === 0) return;
+            if (
+                watched.length === 0 ||
+                newConnection.state !== HubConnectionState.Connected ||
+                get().connection !== newConnection
+            ) {
+                return;
+            }
 
-            await newConnection.invoke("SubscribeToUsers", watched).catch((e) =>
-                console.warn("Presence subscribe failed", e),
+            await newConnection.invoke("SubscribeToUsers", watched).catch((error) =>
+                warnUnlessConnectionClosingError("Presence subscribe failed", error),
             );
         };
 
@@ -177,11 +189,19 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         );
 
         newConnection.onreconnecting((err) => {
+            if (get().connection !== newConnection) {
+                return;
+            }
+
             console.warn("PresenceHub reconnecting", err);
             set({ isConnected: false });
         });
 
         newConnection.onreconnected(() => {
+            if (get().connection !== newConnection) {
+                return;
+            }
+
             set({ isConnected: true });
             void subscribeWatchedUsers();
         });
@@ -222,7 +242,7 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         const { connection } = get();
         if (shouldSubscribe && connection?.state === HubConnectionState.Connected) {
             await connection.invoke("SubscribeToUsers", [userId]).catch((error) =>
-                console.warn("Presence subscribe failed", error),
+                warnUnlessConnectionClosingError("Presence subscribe failed", error),
             );
         }
     },
@@ -249,11 +269,9 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
 
         const { connection } = get();
         if (shouldUnsubscribe && connection?.state === HubConnectionState.Connected) {
-            connection.invoke("UnsubscribeFromUsers", [userId]).catch((error) => {
-                if (!isConnectionClosingError(error)) {
-                    console.warn("Presence unsubscribe failed", error);
-                }
-            });
+            connection.invoke("UnsubscribeFromUsers", [userId]).catch((error) =>
+                warnUnlessConnectionClosingError("Presence unsubscribe failed", error),
+            );
         }
     },
 
@@ -302,7 +320,7 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         const { connection } = get();
         if (connection?.state === HubConnectionState.Connected) {
             connection.invoke("Heartbeat").catch((e) =>
-                console.warn("Heartbeat failed", e)
+                warnUnlessConnectionClosingError("Heartbeat failed", e)
             );
         }
     },
@@ -311,7 +329,7 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         const { connection } = get();
         if (connection?.state === HubConnectionState.Connected) {
             connection.invoke("StartTyping", conversationId).catch((e) =>
-                console.warn("StartTyping failed", e)
+                warnUnlessConnectionClosingError("StartTyping failed", e)
             );
         }
     },
@@ -320,7 +338,7 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
         const { connection } = get();
         if (connection?.state === HubConnectionState.Connected) {
             connection.invoke("StopTyping", conversationId).catch((e) =>
-                console.warn("StopTyping failed", e)
+                warnUnlessConnectionClosingError("StopTyping failed", e)
             );
         }
     },

--- a/apps/client/src/features/chat-search/model/__tests__/search-store.test.ts
+++ b/apps/client/src/features/chat-search/model/__tests__/search-store.test.ts
@@ -2,6 +2,7 @@ const mockOpenDirectConversation = jest.fn();
 const mockUpdateConversation = jest.fn();
 const mockPrimeParticipants = jest.fn();
 const mockLoadParticipants = jest.fn();
+const mockStorage = new Map<string, string>();
 
 jest.mock("@/shared/lib/api", () => ({
     apiClient: {
@@ -33,17 +34,30 @@ jest.mock("@/entities/conversation/model/participants-store", () => ({
     },
 }));
 
+jest.mock("@/shared/lib/storage", () => ({
+    appStorage: {
+        getItem: jest.fn((name: string) => mockStorage.get(name) ?? null),
+        setItem: jest.fn((name: string, value: string) => {
+            mockStorage.set(name, value);
+        }),
+        removeItem: jest.fn((name: string) => {
+            mockStorage.delete(name);
+        }),
+    },
+}));
+
 const { useSearchStore } = require("../search-store") as typeof import("../search-store");
 
 describe("search store direct chat drafts", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockStorage.clear();
         useSearchStore.setState({ pendingUserId: null });
     });
 
     it("primes participants without loading the draft participants endpoint", async () => {
         mockOpenDirectConversation.mockResolvedValue({
-            id: "direct-1",
+            id: "8b52b1fc6ba59e5479e937392652af924b69a5e7",
             type: "Direct",
             participants: ["user-1", "peer-1"],
             createdAtUtc: "2026-05-24T10:00:00.000Z",
@@ -58,9 +72,9 @@ describe("search store direct chat drafts", () => {
             avatarUrl: null,
         });
 
-        expect(result).toBe("direct-1");
+        expect(result).toBe("8b52b1fc6ba59e5479e937392652af924b69a5e7");
         expect(mockUpdateConversation).toHaveBeenCalled();
-        expect(mockPrimeParticipants).toHaveBeenCalledWith("direct-1", [
+        expect(mockPrimeParticipants).toHaveBeenCalledWith("8b52b1fc6ba59e5479e937392652af924b69a5e7", [
             {
                 userId: "peer-1",
                 role: "Member",
@@ -69,5 +83,8 @@ describe("search store direct chat drafts", () => {
             },
         ]);
         expect(mockLoadParticipants).not.toHaveBeenCalled();
+        expect(mockStorage.get("chat.directDrafts.v1")).toContain(
+            "8b52b1fc6ba59e5479e937392652af924b69a5e7",
+        );
     });
 });

--- a/apps/client/src/features/chat-search/model/search-store.ts
+++ b/apps/client/src/features/chat-search/model/search-store.ts
@@ -3,6 +3,7 @@ import { SearchFilters, SearchResultDto, SearchUserDto } from "@urfu-link/api-cl
 import { apiClient } from "@/shared/lib/api";
 import { useChatStore } from "@/entities/conversation/model/chat-store";
 import { useParticipantsStore } from "@/entities/conversation/model/participants-store";
+import { saveDirectDraftConversation } from "@/entities/conversation/model/direct-draft-cache";
 
 // Поля, которыми UI рулит из SearchFiltersBar. conversationId исключён —
 // он задаётся самим режимом поиска (global/local), а не пользователем.
@@ -283,14 +284,14 @@ export const useSearchStore = create<SearchState>((set, get) => ({
             // по id после router.push. Если SignalR-событие потом прилетит, оно
             // просто перезапишет ту же запись (updateConversation идемпотентен).
             useChatStore.getState().updateConversation(conversation);
-            useParticipantsStore.getState().prime(conversation.id, [
-                {
-                    userId,
-                    role: "Member",
-                    displayName: user.displayName || user.username,
-                    avatarUrl: user.avatarUrl ?? "",
-                },
-            ]);
+            const peerParticipant = {
+                userId,
+                role: "Member" as const,
+                displayName: user.displayName || user.username,
+                avatarUrl: user.avatarUrl ?? "",
+            };
+            useParticipantsStore.getState().prime(conversation.id, [peerParticipant]);
+            saveDirectDraftConversation(conversation, [peerParticipant]);
 
             // Для нового direct-чата backend возвращает draft без Mongo-документа, поэтому
             // /participants до первого сообщения ещё недоступен. Имя собеседника уже есть из

--- a/apps/client/src/providers/auth-provider.tsx
+++ b/apps/client/src/providers/auth-provider.tsx
@@ -1,4 +1,5 @@
 import { appConfig } from "@/shared/lib/config";
+import { resolveCurrentUserId } from "@/shared/lib/current-user";
 import { useAuthStore } from "@/shared/store/auth-store";
 import { useCallback, useEffect, useRef } from "react";
 import type { PropsWithChildren } from "react";
@@ -85,6 +86,14 @@ export default function AuthProvider({ children }: PropsWithChildren) {
             if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
         };
     }, [isDev, scheduleRefresh]);
+
+    useEffect(() => {
+        if (isDev) return;
+
+        void resolveCurrentUserId({ forceRefresh: true }).catch(() => {
+            useAuthStore.getState().setUserId(null);
+        });
+    }, [isDev]);
 
     // Dev-only: schedule refresh when AuthGate sets a new token.
     useEffect(() => {

--- a/apps/client/src/shared/lib/current-user.ts
+++ b/apps/client/src/shared/lib/current-user.ts
@@ -1,0 +1,34 @@
+import { apiClient } from "./api";
+import { useAuthStore } from "@/shared/store/auth-store";
+
+let currentUserIdPromise: Promise<string> | null = null;
+
+type ResolveCurrentUserIdOptions = {
+    forceRefresh?: boolean;
+};
+
+const loadCurrentUserId = () =>
+    apiClient.users.getMe()
+        .then((profile) => {
+            useAuthStore.getState().setUserId(profile.userId);
+            return profile.userId;
+        })
+        .finally(() => {
+            currentUserIdPromise = null;
+        });
+
+export const resolveCurrentUserId = async ({
+    forceRefresh = false,
+}: ResolveCurrentUserIdOptions = {}): Promise<string> => {
+    if (currentUserIdPromise) {
+        return currentUserIdPromise;
+    }
+
+    const { userId } = useAuthStore.getState();
+    if (!forceRefresh && userId) {
+        return userId;
+    }
+
+    currentUserIdPromise = loadCurrentUserId();
+    return currentUserIdPromise;
+};

--- a/apps/client/src/shared/store/auth-store.ts
+++ b/apps/client/src/shared/store/auth-store.ts
@@ -8,6 +8,7 @@ type AuthState = {
     expiresAt: number | null; // Unix ms
     userId: string | null;
     setTokens: (accessToken: string, refreshToken: string, expiresAt: number) => void;
+    setUserId: (userId: string | null) => void;
     clearTokens: () => void;
     isTokenValid: () => boolean;
 };
@@ -45,6 +46,7 @@ export const useAuthStore = create<AuthState>()(
                     expiresAt,
                     userId: extractUserId(accessToken),
                 }),
+            setUserId: (userId) => set({ userId }),
             clearTokens: () =>
                 set({
                     accessToken: null,

--- a/apps/client/src/widgets/chat/ui/ChatView.tsx
+++ b/apps/client/src/widgets/chat/ui/ChatView.tsx
@@ -7,6 +7,11 @@ import { MessagesList, type MessagesListHandle } from "./MessagesList";
 import { SubjectHeader } from "./subject-header/SubjectHeader";
 import { useChatStore } from "@/entities/conversation/model/chat-store";
 import { useParticipantsStore } from "@/entities/conversation/model/participants-store";
+import {
+    isDirectDraftConversation,
+    isDirectDraftId,
+    restoreDirectDraftConversation,
+} from "@/entities/conversation/model/direct-draft-cache";
 import { apiClient } from "@/shared/lib/api";
 import type { DocumentPickerAsset } from "expo-document-picker";
 import { LocalSearchPanel } from "@/features/chat-search";
@@ -45,7 +50,9 @@ export const ChatView = () => {
 
     const chatId = params.id as string;
     const type = currentTab === "chats" ? "chat" : "subject";
-    const isDirectDraft = conversation?.type === "Direct" && !conversation.lastMessagePreview;
+    const isDirectDraft = isDirectDraftConversation(conversation);
+    const isUnknownDirectDraft = type === "chat" && !conversation && isDirectDraftId(chatId);
+    const shouldSkipRemoteConversationLoads = isDirectDraft || isUnknownDirectDraft;
 
     const handleSend = useCallback(
         async (text: string, files: DocumentPickerAsset[], replyToMessageId?: string) => {
@@ -99,12 +106,26 @@ export const ChatView = () => {
         };
     }, [pendingScrollId, setPendingScrollToMessageId]);
 
+    useEffect(() => {
+        if (type !== "chat" || conversation || !isDirectDraftId(chatId)) {
+            return;
+        }
+
+        const restored = restoreDirectDraftConversation(chatId);
+        if (!restored) {
+            return;
+        }
+
+        useChatStore.getState().updateConversation(restored.conversation);
+        useParticipantsStore.getState().prime(chatId, restored.participants);
+    }, [chatId, conversation, type]);
+
     // Прогрев participants-store: нужен для @mentions autocomplete и для
     // resolve userId -> displayName в TypingIndicator. Кэш в сторе TTL 5 минут,
     // повторные load() для одного и того же chatId — no-op.
     useEffect(() => {
         if (!chatId) return;
-        if (isDirectDraft) {
+        if (shouldSkipRemoteConversationLoads) {
             return;
         }
 
@@ -114,7 +135,7 @@ export const ChatView = () => {
             .catch(() => {
                 /* fail-open: индикатор печати и mentions работают и без имён */
             });
-    }, [chatId, isDirectDraft]);
+    }, [chatId, shouldSkipRemoteConversationLoads]);
 
     const pinnedIds = conversation?.pinnedMessageIds ?? [];
     const isActionsTargetPinned = !!(
@@ -236,16 +257,18 @@ export const ChatView = () => {
                 ref={listRef}
                 chatId={chatId}
                 type={type}
-                skipInitialLoad={isDirectDraft}
+                skipInitialLoad={shouldSkipRemoteConversationLoads}
                 onMessageLongPress={(message) => openActionsMenu(message)}
                 onMessageContextMenu={openActionsMenu}
                 onThreadOpen={setOpenThreadRootId}
             />
-            <ChatInput
-                conversationId={chatId}
-                onSend={handleSend}
-                typingEnabled={!isDirectDraft}
-            />
+            {!isUnknownDirectDraft && (
+                <ChatInput
+                    conversationId={chatId}
+                    onSend={handleSend}
+                    typingEnabled={!isDirectDraft}
+                />
+            )}
         </View>
     );
 

--- a/src/Services/Chat/ChatService.Api/Endpoints/Conversations/GetConversationEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Conversations/GetConversationEndpoint.cs
@@ -1,4 +1,5 @@
 using FastEndpoints;
+using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
@@ -19,7 +20,18 @@ public sealed class GetConversationEndpoint(GetConversationQuery query)
     {
         var caller = User.GetUserId();
         var id = Route<string>("id")!;
-        var dto = await query.ExecuteAsync(id, caller, ct).ConfigureAwait(false);
-        await Send.OkAsync(dto, ct).ConfigureAwait(false);
+        try
+        {
+            var dto = await query.ExecuteAsync(id, caller, ct).ConfigureAwait(false);
+            await Send.OkAsync(dto, ct).ConfigureAwait(false);
+        }
+        catch (ConversationNotFoundException)
+        {
+            await Send.NotFoundAsync(ct).ConfigureAwait(false);
+        }
+        catch (ChatAccessDeniedException)
+        {
+            await Send.ForbiddenAsync(ct).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Services/Chat/ChatService.Api/Endpoints/Conversations/GetConversationParticipantsEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Conversations/GetConversationParticipantsEndpoint.cs
@@ -1,4 +1,5 @@
 using FastEndpoints;
+using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Conversations;
 using Urfu.Link.Services.Chat.Infrastructure.Auth;
 
@@ -21,9 +22,20 @@ public sealed class GetConversationParticipantsEndpoint(GetConversationParticipa
         var caller = User.GetUserId();
         var isAdmin = User.IsAdmin();
         var id = Route<string>("id")!;
-        var participants = await query
-            .ExecuteAsync(id, caller, isAdmin, ct)
-            .ConfigureAwait(false);
-        await Send.OkAsync(participants, ct).ConfigureAwait(false);
+        try
+        {
+            var participants = await query
+                .ExecuteAsync(id, caller, isAdmin, ct)
+                .ConfigureAwait(false);
+            await Send.OkAsync(participants, ct).ConfigureAwait(false);
+        }
+        catch (ConversationNotFoundException)
+        {
+            await Send.NotFoundAsync(ct).ConfigureAwait(false);
+        }
+        catch (ChatAccessDeniedException)
+        {
+            await Send.ForbiddenAsync(ct).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetConversationMessagesEndpoint.cs
+++ b/src/Services/Chat/ChatService.Api/Endpoints/Messages/GetConversationMessagesEndpoint.cs
@@ -1,4 +1,5 @@
 using FastEndpoints;
+using Urfu.Link.Services.Chat.Application;
 using Urfu.Link.Services.Chat.Application.Contracts;
 using Urfu.Link.Services.Chat.Application.Cursors;
 using Urfu.Link.Services.Chat.Application.Messages;
@@ -37,6 +38,14 @@ public sealed class GetConversationMessagesEndpoint(GetConversationMessagesQuery
         {
             AddError("cursor", "Invalid cursor.");
             await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+        }
+        catch (ConversationNotFoundException)
+        {
+            await Send.NotFoundAsync(ct).ConfigureAwait(false);
+        }
+        catch (ChatAccessDeniedException)
+        {
+            await Send.ForbiddenAsync(ct).ConfigureAwait(false);
         }
     }
 }

--- a/tests/integration/ChatService.IntegrationTests/Endpoints/ChatEndpointsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Endpoints/ChatEndpointsTests.cs
@@ -94,7 +94,18 @@ public class ChatEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Get_ConversationById_NotParticipant_ReturnsConflictOrForbidden()
+    public async Task Get_ConversationById_Missing_Returns404()
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/v1/chat/conversations/{Guid.NewGuid():N}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_ConversationById_NotParticipant_ReturnsForbidden()
     {
         // Open a conversation the caller is NOT part of.
         string convId;
@@ -119,10 +130,7 @@ public class ChatEndpointsTests : IAsyncLifetime
         using var client = _factory.CreateClient();
         var response = await client.GetAsync($"/api/v1/chat/conversations/{convId}");
 
-        // FastEndpoints maps unhandled exceptions to 500 by default, but ChatAccessDeniedException is
-        // not specifically mapped. We assert any non-success here to demonstrate the access path is
-        // wired; exception-to-status mapping will be tightened in a future iteration.
-        response.IsSuccessStatusCode.Should().BeFalse();
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -252,7 +260,18 @@ public class ChatEndpointsTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Get_ConversationParticipants_AsNonParticipant_NonSuccess()
+    public async Task Get_ConversationParticipants_Missing_Returns404()
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/v1/chat/conversations/{Guid.NewGuid():N}/participants");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_ConversationParticipants_AsNonParticipant_ReturnsForbidden()
     {
         var teacherId = Guid.NewGuid();
         var disciplineId = Guid.NewGuid();
@@ -273,7 +292,7 @@ public class ChatEndpointsTests : IAsyncLifetime
         using var client = _factory.CreateClient();
         var response = await client.GetAsync($"/api/v1/chat/conversations/{conversationId}/participants");
 
-        response.IsSuccessStatusCode.Should().BeFalse();
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -332,5 +351,16 @@ public class ChatEndpointsTests : IAsyncLifetime
             $"/api/v1/chat/conversations/{convId}/messages?limit=10&direction=older");
 
         page!.Items.Select(m => m.Body).Should().Equal("m2", "m1", "m0");
+    }
+
+    [Fact]
+    public async Task Get_ConversationMessages_Missing_Returns404()
+    {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.Authenticated(Guid.NewGuid());
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/v1/chat/conversations/{Guid.NewGuid():N}/messages?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }


### PR DESCRIPTION
## Что исправлено
- Восстановление пустых direct-чатов после перезагрузки ссылки.
- Остановка лишних запросов messages/participants для draft-чата без Mongo-документа.
- Корректные 404/403 для chat read endpoints вместо 500.

## Проверки
- pnpm --filter @urfu-link/client test
- pnpm --filter @urfu-link/client typecheck
- dotnet test tests/integration/ChatService.IntegrationTests/ChatService.IntegrationTests.csproj --filter FullyQualifiedName~ChatEndpointsTests --no-restore