### PR TITLE
fix(frontend): keep direct drafts local during first send

### DIFF
--- a/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
+++ b/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
@@ -117,6 +117,68 @@ describe("chat store direct draft sending", () => {
         });
     });
 
+    it("keeps a direct draft marked as draft while the first message is pending", async () => {
+        let resolveInvoke!: (value: unknown) => void;
+        let pendingClientMessageId = "";
+        const invoke = jest.fn(
+            (_method: string, payload: { clientMessageId: string }) => {
+                pendingClientMessageId = payload.clientMessageId;
+                return new Promise((resolve) => {
+                    resolveInvoke = resolve;
+                });
+            },
+        );
+
+        useChatStore.setState({
+            connection: { state: "Connected", invoke } as never,
+            isConnected: true,
+            conversations: [
+                {
+                    id: "direct-1",
+                    type: "Direct",
+                    participants: ["peer-1", "user-1"],
+                    createdAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessageAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessagePreview: null,
+                },
+            ],
+        });
+
+        const sendPromise = useChatStore.getState().sendMessage("direct-1", "hello");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const pendingConversation = useChatStore.getState().conversations[0];
+        expect(pendingConversation.lastMessagePreview).toEqual(
+            expect.objectContaining({ body: "hello" }),
+        );
+        expect((pendingConversation as { _localStatus?: string })._localStatus).toBe("draft");
+
+        expect(resolveInvoke).toBeDefined();
+        resolveInvoke({
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "user-1",
+            body: "hello",
+            attachments: [],
+            state: "Sent",
+            createdAtUtc: "2026-05-24T10:00:00.000Z",
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            clientMessageId: pendingClientMessageId,
+            editedAtUtc: null,
+            replyTo: null,
+            reactionsSummary: {},
+            mentions: [],
+            forwardedFrom: null,
+        });
+        await sendPromise;
+
+        expect(
+            (useChatStore.getState().conversations[0] as { _localStatus?: string })._localStatus,
+        ).toBeUndefined();
+    });
+
     it("passes peerUserId when sending the first message to a direct draft", async () => {
         const invoke = jest.fn(async (_method: string, payload: { clientMessageId: string }) => ({
             id: "message-1",

--- a/apps/client/src/entities/conversation/model/chat-store.ts
+++ b/apps/client/src/entities/conversation/model/chat-store.ts
@@ -10,6 +10,12 @@ import { HubConnection, HubConnectionState } from "@microsoft/signalr";
 import { apiClient } from "@/shared/lib/api";
 import { resolveCurrentUserId } from "@/shared/lib/current-user";
 import { useAuthStore } from "@/shared/store/auth-store";
+import {
+    isDirectDraftConversation,
+    normalizeConversationDraftStatus,
+    withDirectDraftStatus,
+    withoutDirectDraftStatus,
+} from "./direct-draft-status";
 
 /** Локальный (только клиентский) статус сообщения, не приходящий с сервера. */
 export type LocalMessageStatus = "sending" | "sent" | "failed";
@@ -170,7 +176,7 @@ const updateConversationPreviewFromMessage = (
     const next = [...conversations];
     const previous = next[index];
     const sentAtUtc = message.createdAt || undefined;
-    next[index] = {
+    const updated = {
         ...previous,
         lastMessageAtUtc: sentAtUtc ?? previous.lastMessageAtUtc,
         lastMessagePreview: {
@@ -183,6 +189,12 @@ const updateConversationPreviewFromMessage = (
             readAtUtc: message.readAt,
         },
     };
+    const isOptimistic = message.id.startsWith("optimistic:");
+    next[index] = isOptimistic
+        ? isDirectDraftConversation(previous)
+            ? withDirectDraftStatus(updated)
+            : updated
+        : withoutDirectDraftStatus(updated);
 
     next.sort(compareConversationActivity);
     return next;
@@ -627,7 +639,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 }
 
                 return {
-                    conversations: res.items,
+                    conversations: res.items.map(normalizeConversationDraftStatus),
                     unreadByConversation,
                     isConversationsLoading: false,
                 };
@@ -1017,15 +1029,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     updateConversation: (conversation) => {
         set((state) => {
-            const index = state.conversations.findIndex((c) => c.id === conversation.id);
+            const normalized = normalizeConversationDraftStatus(conversation);
+            const index = state.conversations.findIndex((c) => c.id === normalized.id);
             if (index === -1) {
-                return { conversations: [conversation, ...state.conversations] };
+                return { conversations: [normalized, ...state.conversations] };
             }
 
             const newConversations = [...state.conversations];
             newConversations[index] = mergeConversationUpdate(
                 newConversations[index],
-                conversation,
+                normalized,
             );
 
             newConversations.sort(compareConversationActivity);

--- a/apps/client/src/entities/conversation/model/direct-draft-cache.ts
+++ b/apps/client/src/entities/conversation/model/direct-draft-cache.ts
@@ -1,5 +1,7 @@
 import type { ConversationParticipantDto, ConversationPreview } from "@urfu-link/api-client";
 import { appStorage } from "@/shared/lib/storage";
+import { isDirectDraftConversation } from "./direct-draft-status";
+export { isDirectDraftConversation } from "./direct-draft-status";
 
 const STORAGE_KEY = "chat.directDrafts.v1";
 const MAX_CACHED_DRAFTS = 20;
@@ -15,10 +17,6 @@ type DirectDraftCache = Record<string, DirectDraftCacheEntry>;
 
 export const isDirectDraftId = (value: string | null | undefined): value is string =>
     typeof value === "string" && DIRECT_DRAFT_ID_PATTERN.test(value);
-
-export const isDirectDraftConversation = (
-    conversation: Pick<ConversationPreview, "type" | "lastMessagePreview"> | null | undefined,
-) => conversation?.type === "Direct" && !conversation.lastMessagePreview;
 
 const readCache = (): DirectDraftCache => {
     const raw = appStorage.getItem(STORAGE_KEY);

--- a/apps/client/src/entities/conversation/model/direct-draft-status.ts
+++ b/apps/client/src/entities/conversation/model/direct-draft-status.ts
@@ -1,0 +1,36 @@
+import type { ConversationPreview } from "@urfu-link/api-client";
+
+const DIRECT_DRAFT_LOCAL_STATUS = "draft";
+
+type DirectDraftAwareConversation = Pick<ConversationPreview, "type" | "lastMessagePreview"> & {
+    _localStatus?: typeof DIRECT_DRAFT_LOCAL_STATUS;
+};
+
+export const isDirectDraftConversation = (
+    conversation: DirectDraftAwareConversation | null | undefined,
+) =>
+    conversation?.type === "Direct" &&
+    (conversation._localStatus === DIRECT_DRAFT_LOCAL_STATUS || !conversation.lastMessagePreview);
+
+export const withDirectDraftStatus = (conversation: ConversationPreview): ConversationPreview =>
+    ({
+        ...conversation,
+        _localStatus: DIRECT_DRAFT_LOCAL_STATUS,
+    }) as ConversationPreview;
+
+export const normalizeConversationDraftStatus = (
+    conversation: ConversationPreview,
+): ConversationPreview => {
+    if (conversation.type === "Direct" && !conversation.lastMessagePreview) {
+        return withDirectDraftStatus(conversation);
+    }
+
+    return withoutDirectDraftStatus(conversation);
+};
+
+export const withoutDirectDraftStatus = (conversation: ConversationPreview): ConversationPreview => {
+    const { _localStatus: _ignored, ...rest } = conversation as ConversationPreview & {
+        _localStatus?: typeof DIRECT_DRAFT_LOCAL_STATUS;
+    };
+    return rest;
+};

--- a/apps/client/src/widgets/chat/ui/ChatView.tsx
+++ b/apps/client/src/widgets/chat/ui/ChatView.tsx
@@ -8,10 +8,10 @@ import { SubjectHeader } from "./subject-header/SubjectHeader";
 import { useChatStore } from "@/entities/conversation/model/chat-store";
 import { useParticipantsStore } from "@/entities/conversation/model/participants-store";
 import {
-    isDirectDraftConversation,
     isDirectDraftId,
     restoreDirectDraftConversation,
 } from "@/entities/conversation/model/direct-draft-cache";
+import { isDirectDraftConversation } from "@/entities/conversation/model/direct-draft-status";
 import { apiClient } from "@/shared/lib/api";
 import type { DocumentPickerAsset } from "expo-document-picker";
 import { LocalSearchPanel } from "@/features/chat-search";


### PR DESCRIPTION
## Что изменено
- Сохраняется локальный статус direct draft во время первой отправки сообщения, даже когда optimistic preview уже появился.
- Remote-load сообщений включается только после серверной материализации чата.
- Вынесена чистая проверка direct draft без зависимости от storage.

## Проверка
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test
- APP_ENV=prod EXPO_PUBLIC_API_URL=https://api.urfu-link.ghjc.ru EXPO_PUBLIC_KEYCLOAK_URL=https://id.ghjc.ru pnpm --filter @urfu-link/client web:build