### PR TITLE
fix(frontend): remove duplicate chat date badge

### DIFF
--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -96,7 +96,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const hasMore = hasMoreByConversation[chatId] || false;
         const listRef = useRef<FlatList<MessageDto>>(null);
         const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
-        const [visibleDateLabel, setVisibleDateLabel] = useState("");
         const highlightOpacity = useRef(new Animated.Value(0)).current;
         const highlightAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
         const highlightClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -112,10 +111,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             if (skipInitialLoad) return;
             loadMessages(chatId, type, true);
         }, [chatId, type, skipInitialLoad, loadMessages]);
-
-        useEffect(() => {
-            setVisibleDateLabel(messages[0] ? formatMessageDateLabel(messages[0].createdAt) : "");
-        }, [messages]);
 
         useEffect(() => {
             return () => {
@@ -222,16 +217,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             }: {
                 viewableItems: Array<{ item: MessageDto; index: number | null }>;
             }) => {
-                const topVisible = viewableItems.reduce<
-                    { item: MessageDto; index: number | null } | null
-                >((current, next) => {
-                    if (!current) return next;
-                    return (next.index ?? -1) > (current.index ?? -1) ? next : current;
-                }, null);
-                if (topVisible?.item.createdAt) {
-                    setVisibleDateLabel(formatMessageDateLabel(topVisible.item.createdAt));
-                }
-
                 const {
                     chatId: activeChatId,
                     currentUserId: activeCurrentUserId,
@@ -429,18 +414,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                         ) : null
                     }
                 />
-                {visibleDateLabel ? (
-                    <View
-                        className="absolute top-3 left-0 right-0 items-center"
-                        style={{ pointerEvents: "none" }}
-                    >
-                        <View className="px-3 py-1.5 rounded-full bg-app-panel border border-white/10">
-                            <Text className="text-[12px] font-semibold text-text-subtle">
-                                {visibleDateLabel}
-                            </Text>
-                        </View>
-                    </View>
-                ) : null}
             </View>
         );
     },

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -187,7 +187,7 @@ describe("MessagesList loading state", () => {
         });
     });
 
-    it("renders the sticky date label and inline date separators", () => {
+    it("renders a single inline date separator per message day", () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date("2026-05-24T12:00:00.000Z"));
         mockChatState = {
@@ -215,7 +215,7 @@ describe("MessagesList loading state", () => {
 
         render(<MessagesList chatId="chat-dates" type="chat" />);
 
-        expect(screen.getAllByText("Сегодня").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Сегодня")).toHaveLength(1);
         expect(screen.getByText(/мая/)).toBeTruthy();
         jest.useRealTimers();
     });


### PR DESCRIPTION
## Что изменено
- Убран постоянный overlay даты над списком сообщений.
- В чате остаются только inline-разделители дней, поэтому на initial render не появляется вторая плашка Сегодня.

## Проверка
- pnpm --filter @urfu-link/client test -- MessagesList.test.tsx
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test
- APP_ENV=prod EXPO_PUBLIC_API_URL=https://api.urfu-link.ghjc.ru EXPO_PUBLIC_KEYCLOAK_URL=https://id.ghjc.ru pnpm --filter @urfu-link/client web:build