### PR TITLE
fix(realtime): stabilize production presence

### DIFF
--- a/apps/client/eas.json
+++ b/apps/client/eas.json
@@ -26,7 +26,7 @@
       "channel": "production",
       "env": {
         "APP_ENV": "prod",
-        "EXPO_PUBLIC_API_URL": "https://api.ghjc.ru"
+        "EXPO_PUBLIC_API_URL": "https://api.urfu-link.ghjc.ru"
       }
     }
   },

--- a/apps/client/src/entities/presence/model/__tests__/presence-store.test.ts
+++ b/apps/client/src/entities/presence/model/__tests__/presence-store.test.ts
@@ -23,6 +23,9 @@ const connection = {
     onreconnected: jest.fn((handler: (...args: unknown[]) => void) => {
         handlers.reconnected = handler;
     }),
+    onclose: jest.fn((handler: (...args: unknown[]) => void) => {
+        handlers.close = handler;
+    }),
     start: jest.fn(async () => {
         connection.state = "Connected";
     }),
@@ -35,6 +38,7 @@ const connection = {
 jest.mock("@microsoft/signalr", () => ({
     HubConnectionState: {
         Connected: "Connected",
+        Connecting: "Connecting",
         Disconnected: "Disconnected",
     },
 }));
@@ -104,6 +108,45 @@ describe("presence store subscriptions", () => {
         });
 
         expect(connection.invoke).toHaveBeenCalledWith("SubscribeToUsers", [peerUserId]);
+    });
+
+    it("coalesces duplicate connect calls while the first hub start is pending", async () => {
+        let finishStart!: () => void;
+        const slowConnection = {
+            ...connection,
+            state: "Connecting",
+            on: jest.fn(),
+            onreconnecting: jest.fn(),
+            onreconnected: jest.fn(),
+            onclose: jest.fn(),
+            start: jest.fn(
+                () => new Promise<void>((resolve) => {
+                    finishStart = () => {
+                        slowConnection.state = "Connected";
+                        resolve();
+                    };
+                }),
+            ),
+            stop: jest.fn(async () => {
+                slowConnection.state = "Disconnected";
+            }),
+            invoke: jest.fn(async () => undefined),
+        };
+        (createHubConnection as jest.Mock).mockReturnValue(slowConnection);
+
+        const first = usePresenceStore.getState().connect();
+        const second = usePresenceStore.getState().connect();
+
+        expect(createHubConnection).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            finishStart();
+            await first;
+            await second;
+        });
+
+        expect(usePresenceStore.getState().connection).toBe(slowConnection);
+        expect(usePresenceStore.getState().isConnected).toBe(true);
     });
 
     it("ignores non-uuid presence ids without calling the api or hub", async () => {

--- a/apps/client/src/entities/presence/model/presence-store.ts
+++ b/apps/client/src/entities/presence/model/presence-store.ts
@@ -83,6 +83,9 @@ const normalizePlatforms = (platforms: Array<Platform | number | string>): Platf
         .map(normalizePlatform)
         .filter((platform): platform is Platform => platform !== null);
 
+const isActiveConnection = (connection: HubConnection | null) =>
+    connection !== null && connection.state !== HubConnectionState.Disconnected;
+
 export const toPresenceTypingConversationId = (conversationId: string) => {
     if (GUID_RE.test(conversationId)) {
         return conversationId.toLowerCase();
@@ -112,7 +115,7 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
 
     connect: async () => {
         const { connection, isConnected } = get();
-        if (isConnected || connection?.state === HubConnectionState.Connected) {
+        if (isConnected || isActiveConnection(connection)) {
             return;
         }
 
@@ -206,13 +209,31 @@ export const usePresenceStore = create<PresenceState>((set, get) => ({
             void subscribeWatchedUsers();
         });
 
+        newConnection.onclose((err) => {
+            if (get().connection !== newConnection) {
+                return;
+            }
+
+            if (err) {
+                console.warn("PresenceHub closed", err);
+            }
+            set({ connection: null, isConnected: false });
+        });
+
         try {
+            set({ connection: newConnection, isConnected: false });
             await newConnection.start();
+            if (get().connection !== newConnection) {
+                await newConnection.stop().catch(() => undefined);
+                return;
+            }
             set({ connection: newConnection, isConnected: true });
             await subscribeWatchedUsers();
         } catch (e) {
             console.error("Failed to connect to PresenceHub", e);
-            set({ isConnected: false });
+            if (get().connection === newConnection) {
+                set({ connection: null, isConnected: false });
+            }
         }
     },
 

--- a/apps/client/src/shared/lib/__tests__/usePresenceHub.test.tsx
+++ b/apps/client/src/shared/lib/__tests__/usePresenceHub.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react-native";
-import { AppState, type AppStateStatus } from "react-native";
+import { AppState, Platform, type AppStateStatus } from "react-native";
 
 import { notifyPresenceDisconnect } from "@/shared/lib/signalr";
 import { usePresenceHub } from "../usePresenceHub";
@@ -30,10 +30,17 @@ describe("usePresenceHub", () => {
         if (event === "beforeunload") beforeUnloadHandler = handler;
     });
     const removeWindowEventListener = jest.fn();
+    const setPlatformOS = (os: typeof Platform.OS) => {
+        Object.defineProperty(Platform, "OS", {
+            configurable: true,
+            get: () => os,
+        });
+    };
 
     beforeEach(() => {
         jest.useFakeTimers();
         jest.clearAllMocks();
+        setPlatformOS("ios");
         appStateHandler = null;
         pagehideHandler = null;
         beforeUnloadHandler = null;
@@ -69,6 +76,22 @@ describe("usePresenceHub", () => {
         });
 
         expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps web presence connected when the tab is merely hidden", async () => {
+        setPlatformOS("web");
+        renderHook(() => usePresenceHub());
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+        mockDisconnect.mockClear();
+
+        await act(async () => {
+            appStateHandler?.("background");
+        });
+
+        expect(mockDisconnect).not.toHaveBeenCalled();
     });
 
     it("reconnects and resumes heartbeat when the app returns to foreground", async () => {

--- a/apps/client/src/shared/lib/usePresenceHub.ts
+++ b/apps/client/src/shared/lib/usePresenceHub.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from "react";
-import { AppState, AppStateStatus } from "react-native";
+import { AppState, AppStateStatus, Platform } from "react-native";
 import { usePresenceStore } from "@/entities/presence";
 import { notifyPresenceDisconnect } from "@/shared/lib/signalr";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
+const shouldDisconnectForAppState = (nextState: AppStateStatus) =>
+    Platform.OS !== "web" && (nextState === "background" || nextState === "inactive");
 
 /**
  * Подключается к PresenceHub и поддерживает heartbeat раз в 15 секунд.
@@ -77,7 +79,7 @@ export function usePresenceHub() {
         const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
             if (nextState === "active") {
                 connectAndStartHeartbeat();
-            } else if (nextState === "background" || nextState === "inactive") {
+            } else if (shouldDisconnectForAppState(nextState)) {
                 disconnectAndStopHeartbeat();
             }
         });

--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -16,7 +16,16 @@ import React, {
     useRef,
     useState,
 } from "react";
-import { Animated, FlatList, StyleSheet, Text, View } from "react-native";
+import {
+    Animated,
+    FlatList,
+    Platform,
+    StyleSheet,
+    Text,
+    View,
+    type NativeScrollEvent,
+    type NativeSyntheticEvent,
+} from "react-native";
 import { ChatMessageSkeleton } from "@/entities/chat-message/ui/ChatMessageSkeleton";
 import type { MessageDto } from "@urfu-link/api-client";
 import { useCurrentUserId } from "@/shared/store/auth-store";
@@ -41,6 +50,8 @@ const HIGHLIGHT_HOLD_MS = 1500;
 const HIGHLIGHT_FADE_OUT_MS = 520;
 const HIGHLIGHT_TOTAL_MS = HIGHLIGHT_FADE_IN_MS + HIGHLIGHT_HOLD_MS + HIGHLIGHT_FADE_OUT_MS;
 const MAX_SCROLL_LOAD_ATTEMPTS = 30;
+const SCROLL_DIRECTION_EPSILON = 8;
+const NEWER_EDGE_OFFSET = 64;
 
 const waitForListUpdate = () => new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -99,6 +110,9 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const highlightOpacity = useRef(new Animated.Value(0)).current;
         const highlightAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
         const highlightClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+        const suppressEndReachedAfterScrollRef = useRef(false);
+        const userDraggingAfterProgrammaticScrollRef = useRef(false);
+        const lastScrollOffsetRef = useRef<number | null>(null);
 
         const currentUserId = useCurrentUserId();
         const readContextRef = useRef({ chatId, currentUserId, markRead });
@@ -122,6 +136,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         }, []);
 
         const highlightMessage = useCallback((messageId: string) => {
+            const useNativeAnimationDriver = Platform.OS !== "web";
             highlightAnimationRef.current?.stop();
             if (highlightClearTimerRef.current) {
                 clearTimeout(highlightClearTimerRef.current);
@@ -134,13 +149,13 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                 Animated.timing(highlightOpacity, {
                     toValue: 1,
                     duration: HIGHLIGHT_FADE_IN_MS,
-                    useNativeDriver: true,
+                    useNativeDriver: useNativeAnimationDriver,
                 }),
                 Animated.delay(HIGHLIGHT_HOLD_MS),
                 Animated.timing(highlightOpacity, {
                     toValue: 0,
                     duration: HIGHLIGHT_FADE_OUT_MS,
-                    useNativeDriver: true,
+                    useNativeDriver: useNativeAnimationDriver,
                 }),
             ]);
 
@@ -156,6 +171,9 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             (messageId: string, sourceMessages: MessageDto[]) => {
                 const idx = sourceMessages.findIndex((m) => m.id === messageId);
                 if (idx === -1) return false;
+                suppressEndReachedAfterScrollRef.current = true;
+                userDraggingAfterProgrammaticScrollRef.current = false;
+                lastScrollOffsetRef.current = null;
                 listRef.current?.scrollToIndex({ index: idx, animated: true, viewPosition: 0.5 });
                 highlightMessage(messageId);
                 return true;
@@ -239,6 +257,38 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const viewabilityConfig = React.useRef({ itemVisiblePercentThreshold: 50 }).current;
         const addReaction = useChatStore((s) => s.addReaction);
         const removeReaction = useChatStore((s) => s.removeReaction);
+
+        const handleScrollBeginDrag = useCallback(() => {
+            if (!suppressEndReachedAfterScrollRef.current) return;
+            userDraggingAfterProgrammaticScrollRef.current = true;
+            lastScrollOffsetRef.current = null;
+        }, []);
+
+        const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+            const offsetY = event.nativeEvent.contentOffset.y;
+            const previousOffset = lastScrollOffsetRef.current;
+            lastScrollOffsetRef.current = offsetY;
+
+            if (
+                !suppressEndReachedAfterScrollRef.current ||
+                !userDraggingAfterProgrammaticScrollRef.current ||
+                previousOffset === null
+            ) {
+                return;
+            }
+
+            const movedTowardOlderMessages = offsetY > previousOffset + SCROLL_DIRECTION_EPSILON;
+            const returnedToNewestEdge = offsetY <= NEWER_EDGE_OFFSET;
+            if (movedTowardOlderMessages || returnedToNewestEdge) {
+                suppressEndReachedAfterScrollRef.current = false;
+                userDraggingAfterProgrammaticScrollRef.current = false;
+            }
+        }, []);
+
+        const handleEndReached = useCallback(() => {
+            if (suppressEndReachedAfterScrollRef.current) return;
+            loadMore(chatId, type);
+        }, [chatId, loadMore, type]);
 
         const renderItem = useMemo(
             () =>
@@ -385,7 +435,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                     onViewableItemsChanged={handleViewableItemsChanged}
                     viewabilityConfig={viewabilityConfig}
                     renderItem={renderItem}
-                    onEndReached={() => loadMore(chatId, type)}
+                    onScroll={handleScroll}
+                    onScrollBeginDrag={handleScrollBeginDrag}
+                    scrollEventThrottle={16}
+                    onEndReached={handleEndReached}
                     onEndReachedThreshold={0.2}
                     ListHeaderComponent={() => (
                         <TypingIndicator

--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -96,7 +96,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const hasMore = hasMoreByConversation[chatId] || false;
         const listRef = useRef<FlatList<MessageDto>>(null);
         const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
-        const [visibleDateLabel, setVisibleDateLabel] = useState("");
         const highlightOpacity = useRef(new Animated.Value(0)).current;
         const highlightAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
         const highlightClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -112,10 +111,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             if (skipInitialLoad) return;
             loadMessages(chatId, type, true);
         }, [chatId, type, skipInitialLoad, loadMessages]);
-
-        useEffect(() => {
-            setVisibleDateLabel(messages[0] ? formatMessageDateLabel(messages[0].createdAt) : "");
-        }, [messages]);
 
         useEffect(() => {
             return () => {
@@ -222,16 +217,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             }: {
                 viewableItems: Array<{ item: MessageDto; index: number | null }>;
             }) => {
-                const topVisible = viewableItems.reduce<
-                    { item: MessageDto; index: number | null } | null
-                >((current, next) => {
-                    if (!current) return next;
-                    return (next.index ?? -1) > (current.index ?? -1) ? next : current;
-                }, null);
-                if (topVisible?.item.createdAt) {
-                    setVisibleDateLabel(formatMessageDateLabel(topVisible.item.createdAt));
-                }
-
                 const {
                     chatId: activeChatId,
                     currentUserId: activeCurrentUserId,
@@ -429,18 +414,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                         ) : null
                     }
                 />
-                {visibleDateLabel ? (
-                    <View
-                        className="absolute top-3 left-0 right-0 items-center"
-                        style={{ pointerEvents: "none" }}
-                    >
-                        <View className="px-3 py-1.5 rounded-full bg-app-panel border border-white/10">
-                            <Text className="text-[12px] font-semibold text-text-subtle">
-                                {visibleDateLabel}
-                            </Text>
-                        </View>
-                    </View>
-                ) : null}
             </View>
         );
     },

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react-native";
+import { Animated, FlatList, Platform } from "react-native";
 
 import { MessagesList, type MessagesListHandle } from "../MessagesList";
 
@@ -9,6 +10,7 @@ const mockMarkRead = jest.fn();
 const mockAddReaction = jest.fn();
 const mockRemoveReaction = jest.fn();
 const mockTypingIndicator = jest.fn();
+const originalPlatformOS = Platform.OS;
 
 let mockChatState = {
     messagesByConversation: {},
@@ -110,6 +112,7 @@ jest.mock("@/entities/presence", () => ({
 describe("MessagesList loading state", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatformOS });
         mockChatState = {
             messagesByConversation: {},
             messagesLoadingByConversation: {},
@@ -265,6 +268,98 @@ describe("MessagesList loading state", () => {
         ]);
         expect(screen.queryByTestId("message-highlight-message-1")).toBeNull();
         jest.useRealTimers();
+    });
+
+    it("uses the JS animation driver for highlighted messages on web", async () => {
+        jest.useFakeTimers();
+        Object.defineProperty(Platform, "OS", { configurable: true, value: "web" });
+        const timingSpy = jest.spyOn(Animated, "timing");
+        mockChatState = {
+            ...mockChatState,
+            messagesByConversation: {
+                "chat-web": [
+                    {
+                        id: "message-web",
+                        body: "web",
+                        senderId: "peer-user",
+                        readAt: null,
+                    },
+                ],
+            },
+            messagesLoadedByConversation: { "chat-web": true },
+        };
+
+        const ref = React.createRef<MessagesListHandle>();
+        render(<MessagesList ref={ref} chatId="chat-web" type="chat" />);
+
+        await act(async () => {
+            await expect(ref.current!.scrollToMessage("message-web")).resolves.toBe(true);
+        });
+
+        expect(timingSpy).toHaveBeenCalled();
+        expect(timingSpy.mock.calls).toEqual(
+            expect.arrayContaining([
+                expect.arrayContaining([
+                    expect.anything(),
+                    expect.objectContaining({ useNativeDriver: false }),
+                ]),
+            ]),
+        );
+        expect(
+            timingSpy.mock.calls.every(([, config]) => config.useNativeDriver === false),
+        ).toBe(true);
+
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+        timingSpy.mockRestore();
+        jest.useRealTimers();
+    });
+
+    it("does not auto-load older pages immediately after an imperative scroll", async () => {
+        mockChatState = {
+            ...mockChatState,
+            messagesByConversation: {
+                "chat-pinned": [
+                    {
+                        id: "message-new",
+                        body: "new",
+                        senderId: "peer-user",
+                        readAt: null,
+                    },
+                    {
+                        id: "message-old",
+                        body: "old",
+                        senderId: "peer-user",
+                        readAt: null,
+                    },
+                ],
+            },
+            messagesLoadedByConversation: { "chat-pinned": true },
+            hasMoreByConversation: { "chat-pinned": true },
+        };
+
+        const ref = React.createRef<MessagesListHandle>();
+        render(<MessagesList ref={ref} chatId="chat-pinned" type="chat" />);
+
+        await act(async () => {
+            await expect(ref.current!.scrollToMessage("message-old")).resolves.toBe(true);
+        });
+
+        const list = screen.UNSAFE_getByType(FlatList);
+        act(() => {
+            list.props.onEndReached?.({ distanceFromEnd: 0 });
+        });
+        expect(mockLoadMore).not.toHaveBeenCalled();
+
+        act(() => {
+            list.props.onScrollBeginDrag?.();
+            list.props.onScroll?.({ nativeEvent: { contentOffset: { y: 128 } } });
+            list.props.onScroll?.({ nativeEvent: { contentOffset: { y: 176 } } });
+            list.props.onEndReached?.({ distanceFromEnd: 0 });
+        });
+
+        expect(mockLoadMore).toHaveBeenCalledWith("chat-pinned", "chat");
     });
 
     it("scrolls to and highlights the original message from a reply preview", async () => {

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -187,7 +187,7 @@ describe("MessagesList loading state", () => {
         });
     });
 
-    it("renders the sticky date label and inline date separators", () => {
+    it("renders a single inline date separator per message day", () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date("2026-05-24T12:00:00.000Z"));
         mockChatState = {
@@ -215,7 +215,7 @@ describe("MessagesList loading state", () => {
 
         render(<MessagesList chatId="chat-dates" type="chat" />);
 
-        expect(screen.getAllByText("Сегодня").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Сегодня")).toHaveLength(1);
         expect(screen.getByText(/мая/)).toBeTruthy();
         jest.useRealTimers();
     });

--- a/deploy/helm/services/api-gateway/values-prod.yaml
+++ b/deploy/helm/services/api-gateway/values-prod.yaml
@@ -40,6 +40,7 @@ serviceMonitor:
 networkPolicy:
   allowedIngressNamespaces:
     - urfu-platform
+    - ingress-nginx
 
 resources:
   requests:

--- a/deploy/k8s/platform/kustomization.yaml
+++ b/deploy/k8s/platform/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - cert-manager/cluster-issuer.yaml
   - ingress/argocd-ingress.yaml
+  - ingress/api-gateway-ingress.yaml
   - ingress/frontend-web-ingress.yaml
   - ingress/pomerium-auth-ingress.yaml
   - ingress/vault-ingress.yaml

--- a/src/Services/Presence/PresenceService.Api/Domain/Interfaces/IPresenceSessionStore.cs
+++ b/src/Services/Presence/PresenceService.Api/Domain/Interfaces/IPresenceSessionStore.cs
@@ -20,6 +20,18 @@ public interface IPresenceSessionStore
     /// </summary>
     Task<(bool Removed, bool WasLast)> RemoveSessionAsync(Guid userId, string deviceId, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Removes a session only when the currently stored connection still belongs
+    /// to the disconnecting hub connection. This protects a quick reconnect with
+    /// the same device id from being deleted by the stale connection's
+    /// <c>OnDisconnectedAsync</c>.
+    /// </summary>
+    Task<(bool Removed, bool WasLast)> RemoveSessionForConnectionAsync(
+        Guid userId,
+        string deviceId,
+        string connectionId,
+        CancellationToken cancellationToken);
+
     Task RefreshHeartbeatAsync(Guid userId, string deviceId, DateTimeOffset utcNow, CancellationToken cancellationToken);
 
     Task UpdateSessionStatusAsync(

--- a/src/Services/Presence/PresenceService.Api/Domain/ValueObjects/PresenceSession.cs
+++ b/src/Services/Presence/PresenceService.Api/Domain/ValueObjects/PresenceSession.cs
@@ -9,4 +9,5 @@ public sealed record PresenceSession(
     PresenceStatus Status,
     string? CustomActivity,
     DateTimeOffset ConnectedAt,
-    DateTimeOffset LastHeartbeatAt);
+    DateTimeOffset LastHeartbeatAt,
+    string? ConnectionId = null);

--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Redis/RedisPresenceSessionStore.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Redis/RedisPresenceSessionStore.cs
@@ -10,6 +10,7 @@ namespace Urfu.Link.Services.Presence.Infrastructure.Redis;
 
 internal sealed record StoredSession(
     string DeviceId,
+    string? ConnectionId,
     Platform Platform,
     PresenceStatus Status,
     string? CustomActivity,
@@ -27,6 +28,27 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
         """;
 
     private const string RemoveScript = """
+        local removed = redis.call('HDEL', KEYS[1], ARGV[1])
+        redis.call('ZREM', KEYS[2], ARGV[2])
+        local remaining = redis.call('HLEN', KEYS[1])
+        if remaining == 0 then redis.call('DEL', KEYS[1]) end
+        return {removed, remaining}
+        """;
+
+    private const string RemoveForConnectionScript = """
+        local raw = redis.call('HGET', KEYS[1], ARGV[1])
+        if not raw then
+            return {0, redis.call('HLEN', KEYS[1])}
+        end
+
+        local ok, stored = pcall(cjson.decode, raw)
+        if ok and stored then
+            local storedConnectionId = stored['connectionId']
+            if storedConnectionId and storedConnectionId ~= cjson.null and storedConnectionId ~= ARGV[3] then
+                return {0, redis.call('HLEN', KEYS[1])}
+            end
+        end
+
         local removed = redis.call('HDEL', KEYS[1], ARGV[1])
         redis.call('ZREM', KEYS[2], ARGV[2])
         local remaining = redis.call('HLEN', KEYS[1])
@@ -63,6 +85,7 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
         var sessionsKey = RedisKeys.UserSessions(session.UserId);
         var stored = new StoredSession(
             session.DeviceId,
+            session.ConnectionId,
             session.Platform,
             session.Status,
             session.CustomActivity,
@@ -101,6 +124,30 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
             RemoveScript,
             keys: [sessionsKey, RedisKeys.Heartbeats],
             values: [deviceId, member]).ConfigureAwait(false))!;
+
+        var removed = (long)result[0] == 1;
+        var remaining = (long)result[1];
+        return (removed, removed && remaining == 0);
+    }
+
+    public async Task<(bool Removed, bool WasLast)> RemoveSessionForConnectionAsync(
+        Guid userId,
+        string deviceId,
+        string connectionId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(deviceId);
+        ArgumentException.ThrowIfNullOrEmpty(connectionId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var db = _redis.GetDatabase();
+        var sessionsKey = RedisKeys.UserSessions(userId);
+        var member = RedisKeys.HeartbeatMember(userId, deviceId);
+
+        var result = (RedisResult[])(await db.ScriptEvaluateAsync(
+            RemoveForConnectionScript,
+            keys: [sessionsKey, RedisKeys.Heartbeats],
+            values: [deviceId, member, connectionId]).ConfigureAwait(false))!;
 
         var removed = (long)result[0] == 1;
         var remaining = (long)result[1];
@@ -179,7 +226,8 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
                 stored.Status,
                 stored.CustomActivity,
                 stored.ConnectedAt,
-                stored.LastHeartbeatAt));
+                stored.LastHeartbeatAt,
+                stored.ConnectionId));
         }
         return sessions;
     }

--- a/src/Services/Presence/PresenceService.Api/Realtime/PresenceHub.cs
+++ b/src/Services/Presence/PresenceService.Api/Realtime/PresenceHub.cs
@@ -45,7 +45,10 @@ public sealed class PresenceHub(
         Context.Items[PlatformItemKey] = platform;
 
         var session = new PresenceSession(userId, deviceId, platform, PresenceStatus.Online,
-            CustomActivity: null, ConnectedAt: now, LastHeartbeatAt: now);
+            CustomActivity: null,
+            ConnectedAt: now,
+            LastHeartbeatAt: now,
+            ConnectionId: Context.ConnectionId);
         var wasFirst = await sessions.AddSessionAsync(session, ct).ConfigureAwait(false);
 
         await Groups.AddToGroupAsync(Context.ConnectionId, GroupForUser(userId), ct).ConfigureAwait(false);
@@ -66,7 +69,9 @@ public sealed class PresenceHub(
             && Context.Items.TryGetValue(PlatformItemKey, out var platformObj) && platformObj is Platform platform)
         {
             var ct = CancellationToken.None;
-            var (removed, wasLast) = await sessions.RemoveSessionAsync(userId, deviceId, ct).ConfigureAwait(false);
+            var (removed, wasLast) = await sessions
+                .RemoveSessionForConnectionAsync(userId, deviceId, Context.ConnectionId, ct)
+                .ConfigureAwait(false);
 
             if (removed && wasLast)
             {

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -37,6 +37,20 @@ public sealed class DeploymentContractTests
     }
 
     [Fact]
+    public void ProductionApiHostShouldResolveToGateway()
+    {
+        var frontendValues = ReadRepoFile("deploy", "helm", "services", "frontend-web", "values-prod.yaml");
+        var easConfig = ReadRepoFile("apps", "client", "eas.json");
+        var platformKustomization = ReadRepoFile("deploy", "k8s", "platform", "kustomization.yaml");
+        var gatewayValues = ReadRepoFile("deploy", "helm", "services", "api-gateway", "values-prod.yaml");
+
+        Assert.Contains("EXPO_PUBLIC_API_URL: https://api.urfu-link.ghjc.ru", frontendValues, StringComparison.Ordinal);
+        Assert.Contains("\"EXPO_PUBLIC_API_URL\": \"https://api.urfu-link.ghjc.ru\"", easConfig, StringComparison.Ordinal);
+        Assert.Contains("ingress/api-gateway-ingress.yaml", platformKustomization, StringComparison.Ordinal);
+        Assert.Contains("- ingress-nginx", gatewayValues, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void KeycloakBootstrapPolicyShouldAllowWritingChatServiceInternalSecret()
     {
         var config = ReadRepoFile("deploy", "k8s", "platform", "vault", "vault-auto-init-job.yaml");

--- a/tests/integration/ApiGateway.IntegrationTests/RoutingIntegrationTests.cs
+++ b/tests/integration/ApiGateway.IntegrationTests/RoutingIntegrationTests.cs
@@ -10,6 +10,11 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
 {
     private StubDownstreamServer _userStub = null!;
     private StubDownstreamServer _chatStub = null!;
+    private StubDownstreamServer _mediaStub = null!;
+    private StubDownstreamServer _presenceStub = null!;
+    private StubDownstreamServer _notificationStub = null!;
+    private StubDownstreamServer _callStub = null!;
+    private StubDownstreamServer _disciplineStub = null!;
     private GatewayTestFactory _factory = null!;
     private HttpClient _client = null!;
 
@@ -17,11 +22,21 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
     {
         _userStub = await StubDownstreamServer.StartAsync();
         _chatStub = await StubDownstreamServer.StartAsync();
+        _mediaStub = await StubDownstreamServer.StartAsync();
+        _presenceStub = await StubDownstreamServer.StartAsync();
+        _notificationStub = await StubDownstreamServer.StartAsync();
+        _callStub = await StubDownstreamServer.StartAsync();
+        _disciplineStub = await StubDownstreamServer.StartAsync();
 
         _factory = new GatewayTestFactory(new Dictionary<string, string>
         {
             ["user-cluster"] = _userStub.BaseUrl,
             ["chat-cluster"] = _chatStub.BaseUrl,
+            ["media-cluster"] = _mediaStub.BaseUrl,
+            ["presence-cluster"] = _presenceStub.BaseUrl,
+            ["notification-cluster"] = _notificationStub.BaseUrl,
+            ["call-cluster"] = _callStub.BaseUrl,
+            ["discipline-cluster"] = _disciplineStub.BaseUrl,
         });
 
         _client = _factory.CreateClient();
@@ -31,6 +46,11 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
     {
         _client.Dispose();
         await _factory.DisposeAsync();
+        await _disciplineStub.DisposeAsync();
+        await _callStub.DisposeAsync();
+        await _notificationStub.DisposeAsync();
+        await _presenceStub.DisposeAsync();
+        await _mediaStub.DisposeAsync();
         await _chatStub.DisposeAsync();
         await _userStub.DisposeAsync();
     }
@@ -71,6 +91,50 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
         recorded.Headers.Should().ContainKey("X-Correlation-Id");
         recorded.Headers["X-Correlation-Id"].Should().NotBeNullOrWhiteSpace();
         response.Headers.GetValues("X-Correlation-Id").Should().NotBeNullOrEmpty();
+    }
+
+    public static TheoryData<HttpMethod, string, string, string> RestRouteCases => new()
+    {
+        { HttpMethod.Get, "/api/users/me", "user-cluster", "/api/v1/me" },
+        { HttpMethod.Get, "/api/users/search?q=nik", "user-cluster", "/api/v1/search" },
+        { HttpMethod.Post, "/api/media/upload/init", "media-cluster", "/api/v1/media/upload/init" },
+        { HttpMethod.Post, "/api/media/upload/complete", "media-cluster", "/api/v1/media/upload/complete" },
+        { HttpMethod.Get, "/api/media/asset-1/download-url", "media-cluster", "/api/v1/media/asset-1/download-url" },
+        { HttpMethod.Get, "/api/media/asset-1/metadata", "media-cluster", "/api/v1/media/asset-1/metadata" },
+        { HttpMethod.Delete, "/api/media/asset-1", "media-cluster", "/api/v1/media/asset-1" },
+        { HttpMethod.Get, "/api/chat/conversations", "chat-cluster", "/api/v1/chat/conversations" },
+        { HttpMethod.Get, "/api/chat/conversations/conversation-1/pinned", "chat-cluster", "/api/v1/chat/conversations/conversation-1/pinned" },
+        { HttpMethod.Post, "/api/chat/conversations/conversation-1/messages", "chat-cluster", "/api/v1/chat/conversations/conversation-1/messages" },
+        { HttpMethod.Get, "/api/presence/users/user-1", "presence-cluster", "/api/v1/presence/users/user-1" },
+        { HttpMethod.Post, "/api/presence/users/batch", "presence-cluster", "/api/v1/presence/users/batch" },
+        { HttpMethod.Post, "/api/presence/sessions/device-1/disconnect", "presence-cluster", "/api/v1/presence/sessions/device-1/disconnect" },
+        { HttpMethod.Get, "/api/notifications/badge", "notification-cluster", "/api/v1/badge" },
+        { HttpMethod.Post, "/api/calls/rooms", "call-cluster", "/api/v1/rooms" },
+        { HttpMethod.Get, "/api/disciplines", "discipline-cluster", "/api/v1/disciplines" },
+    };
+
+    [Theory]
+    [MemberData(nameof(RestRouteCases))]
+    public async Task RestRoutes_ProxyPublicApiPrefixes_ToVersionedDownstreamPaths(
+        HttpMethod method,
+        string publicPath,
+        string clusterId,
+        string expectedDownstreamPath)
+    {
+        using var request = new HttpRequestMessage(method, publicPath);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "user-42");
+        if (method == HttpMethod.Post || method == HttpMethod.Put || method == HttpMethod.Patch)
+        {
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        }
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var downstream = GetStub(clusterId);
+        downstream.Requests.Should().ContainSingle();
+        var recorded = downstream.Requests.Single();
+        recorded.Path.Should().Be(expectedDownstreamPath);
     }
 
     [Fact]
@@ -177,13 +241,25 @@ public sealed class RoutingIntegrationTests : IAsyncLifetime
 
         await using var presenceFactory = new GatewayTestFactory(new Dictionary<string, string>
         {
-            ["presence-cluster"] = _chatStub.BaseUrl,
+            ["presence-cluster"] = _presenceStub.BaseUrl,
         });
         using var presenceClient = presenceFactory.CreateClient();
 
         var response = await presenceClient.SendAsync(request);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        _chatStub.Requests.Should().Contain(r => r.Path == "/hubs/presence/negotiate");
+        _presenceStub.Requests.Should().Contain(r => r.Path == "/hubs/presence/negotiate");
     }
+
+    private StubDownstreamServer GetStub(string clusterId) => clusterId switch
+    {
+        "user-cluster" => _userStub,
+        "chat-cluster" => _chatStub,
+        "media-cluster" => _mediaStub,
+        "presence-cluster" => _presenceStub,
+        "notification-cluster" => _notificationStub,
+        "call-cluster" => _callStub,
+        "discipline-cluster" => _disciplineStub,
+        _ => throw new ArgumentOutOfRangeException(nameof(clusterId), clusterId, null),
+    };
 }

--- a/tests/integration/PresenceService.IntegrationTests/Hub/MultiDeviceTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Hub/MultiDeviceTests.cs
@@ -67,6 +67,35 @@ public class MultiDeviceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SameDevice_ReconnectBeforeOldDisconnect_OldDisconnectDoesNotRemoveReplacementSession()
+    {
+        var userId = Guid.NewGuid();
+        var c1 = await TestPresenceHubClient.ConnectAsync(_factory, userId, Platform.Web, "d1");
+        var c2 = await TestPresenceHubClient.ConnectAsync(_factory, userId, Platform.Web, "d1");
+
+        _factory.OutboxWriter.Clear();
+
+        await c1.StopAsync();
+        await c1.DisposeAsync();
+
+        await Task.Delay(500);
+
+        _factory.OutboxWriter.Published
+            .Select(p => p.Payload).OfType<UserWentOfflineEvent>()
+            .Where(e => e.UserId == userId)
+            .Should().BeEmpty();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var sessions = scope.ServiceProvider.GetRequiredService<IPresenceSessionStore>();
+        var remaining = await sessions.GetSessionsAsync(userId, CancellationToken.None);
+        remaining.Should().ContainSingle(s => s.DeviceId == "d1");
+        remaining.Single().ConnectionId.Should().NotBeNullOrWhiteSpace();
+
+        await c2.StopAsync();
+        await c2.DisposeAsync();
+    }
+
+    [Fact]
     public async Task TwoDevices_BothDisconnect_PublishesOfflineEventOnce()
     {
         var userId = Guid.NewGuid();

--- a/tests/integration/PresenceService.IntegrationTests/Redis/RedisPresenceSessionStoreTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Redis/RedisPresenceSessionStoreTests.cs
@@ -23,9 +23,16 @@ public class RedisPresenceSessionStoreTests : IAsyncLifetime
     private IPresenceSessionStore Resolve() =>
         _factory.Services.GetRequiredService<IPresenceSessionStore>();
 
-    private static PresenceSession Session(Guid userId, string deviceId, Platform platform = Platform.Web)
+    private static PresenceSession Session(
+        Guid userId,
+        string deviceId,
+        Platform platform = Platform.Web,
+        string? connectionId = null)
         => new(userId, deviceId, platform, PresenceStatus.Online,
-            CustomActivity: null, ConnectedAt: DateTimeOffset.UtcNow, LastHeartbeatAt: DateTimeOffset.UtcNow);
+            CustomActivity: null,
+            ConnectedAt: DateTimeOffset.UtcNow,
+            LastHeartbeatAt: DateTimeOffset.UtcNow,
+            ConnectionId: connectionId);
 
     [Fact]
     public async Task AddSession_FirstSession_ReturnsTrue()
@@ -87,6 +94,36 @@ public class RedisPresenceSessionStoreTests : IAsyncLifetime
 
         removed.Should().BeTrue();
         wasLast.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemoveSessionForConnection_StaleConnection_DoesNotRemoveReplacementSession()
+    {
+        var sut = Resolve();
+        var userId = Guid.NewGuid();
+        await sut.AddSessionAsync(Session(userId, "d1", connectionId: "old-connection"), CancellationToken.None);
+        await sut.AddSessionAsync(Session(userId, "d1", connectionId: "new-connection"), CancellationToken.None);
+
+        var stale = await sut.RemoveSessionForConnectionAsync(
+            userId,
+            "d1",
+            "old-connection",
+            CancellationToken.None);
+
+        stale.Removed.Should().BeFalse();
+        stale.WasLast.Should().BeFalse();
+        var sessions = await sut.GetSessionsAsync(userId, CancellationToken.None);
+        sessions.Should().ContainSingle();
+        sessions.Single().ConnectionId.Should().Be("new-connection");
+
+        var current = await sut.RemoveSessionForConnectionAsync(
+            userId,
+            "d1",
+            "new-connection",
+            CancellationToken.None);
+
+        current.Removed.Should().BeTrue();
+        current.WasLast.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Что изменено
- Защитил Presence от гонки reconnect/disconnect: старая SignalR-сессия больше не удаляет новую Redis-сессию того же deviceId.
- На клиенте убрал параллельные старты PresenceHub и оставил web-подключение живым при скрытии вкладки; отключение остается на pagehide/beforeunload.
- Исправил production API host для мобильного EAS, вернул api-gateway ingress в platform kustomization и разрешил ingress-nginx до gateway.
- Добавил контрактные и интеграционные проверки production gateway/API маршрутов.
- Дотянул фикс списка сообщений: web highlight использует JS animation driver, а программный scroll к сообщению не триггерит лишнюю подгрузку старых страниц.

## Проверки
- dotnet test Urfu.Link.slnx
- dotnet test tests/integration/ApiGateway.IntegrationTests/ApiGateway.IntegrationTests.csproj
- dotnet test tests/integration/PresenceService.IntegrationTests/PresenceService.IntegrationTests.csproj
- dotnet test tests/unit/PresenceService.UnitTests/PresenceService.UnitTests.csproj
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test
- pnpm --filter @urfu-link/client web:build