### PR TITLE
fix(infra): unblock migration hook service accounts

### DIFF
--- a/deploy/helm/charts/urfu-service/templates/_helpers.tpl
+++ b/deploy/helm/charts/urfu-service/templates/_helpers.tpl
@@ -17,3 +17,11 @@
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "urfu-service.migrationsServiceAccountName" -}}
+{{- if .Values.migrations.serviceAccount.create -}}
+{{- default (printf "%s-migrations" (include "urfu-service.fullname" .)) .Values.migrations.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.migrations.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/charts/urfu-service/templates/migrations-job.yaml
+++ b/deploy/helm/charts/urfu-service/templates/migrations-job.yaml
@@ -30,7 +30,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "urfu-service.serviceAccountName" . }}
+      serviceAccountName: {{ include "urfu-service.migrationsServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.migrations.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/charts/urfu-service/templates/migrations-serviceaccount.yaml
+++ b/deploy/helm/charts/urfu-service/templates/migrations-serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.migrations.enabled .Values.migrations.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "urfu-service.migrationsServiceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "urfu-service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: migrations
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.migrations.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.migrations.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/charts/urfu-service/values.yaml
+++ b/deploy/helm/charts/urfu-service/values.yaml
@@ -106,6 +106,11 @@ migrations:
   command: []
   backoffLimit: 2
   ttlSecondsAfterFinished: 600
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+    automountServiceAccountToken: false
   resources: {}
 
 nodeSelector: {}

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -51,6 +51,29 @@ public sealed class DeploymentContractTests
     }
 
     [Fact]
+    public void MigrationHookShouldNotDependOnWorkloadServiceAccount()
+    {
+        var migrationJob = ReadRepoFile("deploy", "helm", "charts", "urfu-service", "templates", "migrations-job.yaml");
+        var migrationServiceAccount = ReadRepoFile(
+            "deploy",
+            "helm",
+            "charts",
+            "urfu-service",
+            "templates",
+            "migrations-serviceaccount.yaml");
+        var chartValues = ReadRepoFile("deploy", "helm", "charts", "urfu-service", "values.yaml");
+
+        Assert.Contains("serviceAccountName: {{ include \"urfu-service.migrationsServiceAccountName\" . }}", migrationJob, StringComparison.Ordinal);
+        Assert.Contains("automountServiceAccountToken: {{ .Values.migrations.serviceAccount.automountServiceAccountToken }}", migrationJob, StringComparison.Ordinal);
+        Assert.Contains("kind: ServiceAccount", migrationServiceAccount, StringComparison.Ordinal);
+        Assert.Contains("helm.sh/hook", migrationServiceAccount, StringComparison.Ordinal);
+        Assert.Contains("pre-install,pre-upgrade", migrationServiceAccount, StringComparison.Ordinal);
+        Assert.Contains("\"helm.sh/hook-weight\": \"-10\"", migrationServiceAccount, StringComparison.Ordinal);
+        Assert.Contains("automountServiceAccountToken: {{ .Values.migrations.serviceAccount.automountServiceAccountToken }}", migrationServiceAccount, StringComparison.Ordinal);
+        Assert.Contains("automountServiceAccountToken: false", chartValues, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void KeycloakBootstrapPolicyShouldAllowWritingChatServiceInternalSecret()
     {
         var config = ReadRepoFile("deploy", "k8s", "platform", "vault", "vault-auto-init-job.yaml");


### PR DESCRIPTION
## Что изменено
- Добавлен отдельный Helm hook ServiceAccount для migration jobs (`*-migrations`) с hook weight `-10`.
- Migration Job теперь использует этот ServiceAccount, а не workload ServiceAccount, который создается только после PreSync hook.
- По умолчанию отключен automount service account token для migration hook.
- Добавлен contract test на этот порядок, чтобы Argo/Helm PreSync больше не зависал на fresh install.

## Почему
`discipline-service-prod` завис в Argo CD на PreSync migration Job: Job ссылался на `serviceAccountName: discipline-service`, но сам ServiceAccount был обычным ресурсом приложения и еще не был создан. Из-за этого `discipline-service` Missing, а gateway `/health/downstreams` отдавал 503 по `discipline-cluster`.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- docker run --rm -v <repo>:/work -w /work alpine/helm:3.19.0 lint deploy/helm/charts/urfu-service
- docker run --rm -v <repo>:/work -w /work alpine/helm:3.19.0 template ... for all service dev/prod values