### PR TITLE
fix(infra): provision notification postgres secret

### DIFF
--- a/deploy/k8s/platform/external-secrets/services-external-secrets.yaml
+++ b/deploy/k8s/platform/external-secrets/services-external-secrets.yaml
@@ -145,6 +145,10 @@ spec:
   target:
     name: notification-service-secrets
   data:
+    - secretKey: ConnectionStrings__Primary
+      remoteRef:
+        key: urfu-link/prod/notification-service
+        property: primary_connection
     - secretKey: Kafka__BootstrapServers
       remoteRef:
         key: urfu-link/prod/notification-service

--- a/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
+++ b/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
@@ -131,6 +131,7 @@ spec:
                 MEDIA_DB_PASSWORD="$(secret_value "$GENERATED_JSON" media_db_password 2>/dev/null || true)"
                 DISCIPLINE_DB_PASSWORD="$(secret_value "$GENERATED_JSON" discipline_db_password 2>/dev/null || true)"
                 PRESENCE_DB_PASSWORD="$(secret_value "$GENERATED_JSON" presence_db_password 2>/dev/null || true)"
+                NOTIFICATION_DB_PASSWORD="$(secret_value "$GENERATED_JSON" notification_db_password 2>/dev/null || true)"
                 KEYCLOAK_DB_PASSWORD="$(secret_value "$GENERATED_JSON" keycloak_db_password 2>/dev/null || true)"
                 KEYCLOAK_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" keycloak_admin_password 2>/dev/null || true)"
                 API_GATEWAY_CLIENT_SECRET="$(secret_value "$GENERATED_JSON" api_gateway_client_secret 2>/dev/null || true)"
@@ -140,6 +141,7 @@ spec:
                 [ -n "$MEDIA_DB_PASSWORD" ] || MEDIA_DB_PASSWORD="$(rand 32)"
                 [ -n "$DISCIPLINE_DB_PASSWORD" ] || DISCIPLINE_DB_PASSWORD="$(rand 32)"
                 [ -n "$PRESENCE_DB_PASSWORD" ] || PRESENCE_DB_PASSWORD="$(rand 32)"
+                [ -n "$NOTIFICATION_DB_PASSWORD" ] || NOTIFICATION_DB_PASSWORD="$(rand 32)"
                 [ -n "$KEYCLOAK_DB_PASSWORD" ] || KEYCLOAK_DB_PASSWORD="$(rand 32)"
                 [ -n "$KEYCLOAK_ADMIN_PASSWORD" ] || KEYCLOAK_ADMIN_PASSWORD="$(rand 32)"
                 [ -n "$API_GATEWAY_CLIENT_SECRET" ] || API_GATEWAY_CLIENT_SECRET="$(rand 40)"
@@ -148,11 +150,12 @@ spec:
                 GRAFANA_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" grafana_admin_password 2>/dev/null || true)"
                 [ -n "$GRAFANA_ADMIN_PASSWORD" ] || GRAFANA_ADMIN_PASSWORD="$(rand 32)"
 
-                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
                   "$(b64 "$USER_DB_PASSWORD")" \
                   "$(b64 "$MEDIA_DB_PASSWORD")" \
                   "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
                   "$(b64 "$PRESENCE_DB_PASSWORD")" \
+                  "$(b64 "$NOTIFICATION_DB_PASSWORD")" \
                   "$(b64 "$KEYCLOAK_DB_PASSWORD")" \
                   "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                   "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
@@ -162,11 +165,12 @@ spec:
                 if [ "$GENERATED_EXISTS" = "true" ]; then
                   patch_secret_json platform-bootstrap-generated "$GENERATED_PATCH"
                 else
-                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
                     "$(b64 "$USER_DB_PASSWORD")" \
                     "$(b64 "$MEDIA_DB_PASSWORD")" \
                     "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
                     "$(b64 "$PRESENCE_DB_PASSWORD")" \
+                    "$(b64 "$NOTIFICATION_DB_PASSWORD")" \
                     "$(b64 "$KEYCLOAK_DB_PASSWORD")" \
                     "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                     "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
@@ -245,6 +249,7 @@ spec:
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'media') THEN CREATE ROLE \"media\" LOGIN PASSWORD '$MEDIA_DB_PASSWORD'; ELSE ALTER ROLE \"media\" WITH LOGIN PASSWORD '$MEDIA_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'discipline') THEN CREATE ROLE discipline LOGIN PASSWORD '$DISCIPLINE_DB_PASSWORD'; ELSE ALTER ROLE discipline WITH LOGIN PASSWORD '$DISCIPLINE_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'presence') THEN CREATE ROLE presence LOGIN PASSWORD '$PRESENCE_DB_PASSWORD'; ELSE ALTER ROLE presence WITH LOGIN PASSWORD '$PRESENCE_DB_PASSWORD'; END IF; END \$\$;"
+                pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'notification') THEN CREATE ROLE notification LOGIN PASSWORD '$NOTIFICATION_DB_PASSWORD'; ELSE ALTER ROLE notification WITH LOGIN PASSWORD '$NOTIFICATION_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'keycloak') THEN CREATE ROLE keycloak LOGIN PASSWORD '$KEYCLOAK_DB_PASSWORD'; ELSE ALTER ROLE keycloak WITH LOGIN PASSWORD '$KEYCLOAK_DB_PASSWORD'; END IF; END \$\$;"
                 pg_exec "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pomerium') THEN CREATE ROLE pomerium LOGIN PASSWORD '$POMERIUM_DB_PASSWORD'; ELSE ALTER ROLE pomerium WITH LOGIN PASSWORD '$POMERIUM_DB_PASSWORD'; END IF; END \$\$;"
 
@@ -278,6 +283,14 @@ spec:
                   -d postgres \
                   -c "SELECT 1 FROM pg_database WHERE datname = 'presence_db'" | grep -q 1; then
                   pg_exec "CREATE DATABASE presence_db OWNER presence"
+                fi
+
+                if ! PGPASSWORD="$POSTGRES_PASSWORD" psql -At \
+                  -h urfu-postgres-rw.urfu-platform.svc.cluster.local \
+                  -U "$POSTGRES_USER" \
+                  -d postgres \
+                  -c "SELECT 1 FROM pg_database WHERE datname = 'notification_db'" | grep -q 1; then
+                  pg_exec "CREATE DATABASE notification_db OWNER notification"
                 fi
 
                 if ! PGPASSWORD="$POSTGRES_PASSWORD" psql -At \
@@ -358,7 +371,7 @@ spec:
               DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s"}}' "$DISCIPLINE_DB_PASSWORD")"
               CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
               PRESENCE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s"}}' "$PRESENCE_DB_PASSWORD")"
-              NOTIFICATION_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'
+              NOTIFICATION_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s","kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}' "$NOTIFICATION_DB_PASSWORD")"
               CALL_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'
               GRAFANA_PAYLOAD="$(printf '{"data":{"admin_password":"%s"}}' "$GRAFANA_ADMIN_PASSWORD")"
               KAFKA_PAYLOAD='{"data":{"bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -126,6 +126,29 @@ public sealed class DeploymentContractTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PlatformBootstrapShouldProvisionNotificationPostgresConnection()
+    {
+        var bootstrap = ReadRepoFile("deploy", "k8s", "platform", "stateful", "platform-bootstrap-job.yaml");
+        var externalSecrets = ReadRepoFile("deploy", "k8s", "platform", "external-secrets", "services-external-secrets.yaml");
+
+        Assert.Contains("notification_db_password", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("CREATE ROLE notification LOGIN PASSWORD '$NOTIFICATION_DB_PASSWORD'", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("CREATE DATABASE notification_db OWNER notification", bootstrap, StringComparison.Ordinal);
+        Assert.Contains(
+            "primary_connection\":\"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s",
+            bootstrap,
+            StringComparison.Ordinal);
+
+        var notificationSecretStart = externalSecrets.IndexOf("name: notification-service-secrets", StringComparison.Ordinal);
+        var notificationSecretEnd = externalSecrets.IndexOf("---", notificationSecretStart, StringComparison.Ordinal);
+        var notificationSecret = externalSecrets[notificationSecretStart..notificationSecretEnd];
+
+        Assert.Contains("secretKey: ConnectionStrings__Primary", notificationSecret, StringComparison.Ordinal);
+        Assert.Contains("key: urfu-link/prod/notification-service", notificationSecret, StringComparison.Ordinal);
+        Assert.Contains("property: primary_connection", notificationSecret, StringComparison.Ordinal);
+    }
+
     private static string ReadRepoFile(params string[] pathSegments)
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));


### PR DESCRIPTION
## Что изменено
- Добавлен production PostgreSQL bootstrap для NotificationService: пароль, роль `notification`, база `notification_db`.
- Vault payload `urfu-link/prod/notification-service` теперь содержит `primary_connection` вместе с Kafka bootstrap.
- `notification-service-secrets` теперь прокидывает `ConnectionStrings__Primary` в pod и migration job.
- Добавлен contract test, чтобы NotificationService больше не уходил в prod с дефолтным `Host=postgres`.

## Почему
После исправления Helm migration hook job реально стартовал и показал скрытую проблему: notification migrations падали с `NpgsqlException: Name or service not known`, потому что production secret не содержал `ConnectionStrings__Primary`.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- kubectl kustomize deploy/k8s/platform