### PR TITLE
fix: stabilize chat date separators and media storage

### DIFF
--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -53,9 +53,58 @@ const MAX_SCROLL_LOAD_ATTEMPTS = 30;
 const SCROLL_DIRECTION_EPSILON = 8;
 const NEWER_EDGE_OFFSET = 64;
 
+type MessageListMessageItem = {
+    type: "message";
+    id: string;
+    message: MessageDto;
+};
+
+type MessageListDateItem = {
+    type: "date";
+    id: string;
+    dayKey: string;
+    createdAt: string;
+};
+
+type MessageListItem = MessageListMessageItem | MessageListDateItem;
+
+const buildMessageListItems = (messages: MessageDto[]): MessageListItem[] => {
+    const items: MessageListItem[] = [];
+
+    messages.forEach((message, index) => {
+        items.push({
+            type: "message",
+            id: message.id,
+            message,
+        });
+
+        const currentDay = getMessageDayKey(message.createdAt);
+        const nextDay = getMessageDayKey(messages[index + 1]?.createdAt);
+        if (currentDay === "" || currentDay === nextDay) return;
+
+        items.push({
+            type: "date",
+            id: `date-${currentDay}-${index}`,
+            dayKey: currentDay,
+            createdAt: message.createdAt,
+        });
+    });
+
+    return items;
+};
+
+const getMessageListItemKey = (item: MessageListItem) => item.id;
+
 const waitForListUpdate = () => new Promise((resolve) => setTimeout(resolve, 50));
 
 const styles = StyleSheet.create({
+    dateSeparator: {
+        marginTop: 24,
+        marginBottom: 4,
+    },
+    firstDateSeparator: {
+        marginTop: 0,
+    },
     highlightOutline: {
         position: "absolute",
         top: 0,
@@ -77,6 +126,9 @@ const styles = StyleSheet.create({
         borderRadius: 999,
         backgroundColor: "#51A2FF",
         pointerEvents: "none",
+    },
+    messageAfterMessage: {
+        marginTop: 24,
     },
 });
 
@@ -105,7 +157,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const isLoading = messagesLoadingByConversation[chatId] || false;
         const isLoaded = messagesLoadedByConversation[chatId] || false;
         const hasMore = hasMoreByConversation[chatId] || false;
-        const listRef = useRef<FlatList<MessageDto>>(null);
+        const listItems = useMemo(() => buildMessageListItems(messages), [messages]);
+        const listRef = useRef<FlatList<MessageListItem>>(null);
         const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
         const highlightOpacity = useRef(new Animated.Value(0)).current;
         const highlightAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
@@ -169,7 +222,9 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
 
         const scrollLoadedMessageIntoView = useCallback(
             (messageId: string, sourceMessages: MessageDto[]) => {
-                const idx = sourceMessages.findIndex((m) => m.id === messageId);
+                const idx = buildMessageListItems(sourceMessages).findIndex(
+                    (item) => item.type === "message" && item.message.id === messageId,
+                );
                 if (idx === -1) return false;
                 suppressEndReachedAfterScrollRef.current = true;
                 userDraggingAfterProgrammaticScrollRef.current = false;
@@ -233,7 +288,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             ({
                 viewableItems,
             }: {
-                viewableItems: Array<{ item: MessageDto; index: number | null }>;
+                viewableItems: Array<{ item: MessageListItem; index: number | null }>;
             }) => {
                 const {
                     chatId: activeChatId,
@@ -243,13 +298,16 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                 if (!activeCurrentUserId) return;
 
                 const unreadItems = viewableItems.filter(
-                    (v) => v.item.senderId !== activeCurrentUserId && v.item.readAt === null,
+                    (v): v is { item: MessageListMessageItem; index: number | null } =>
+                        v.item.type === "message" &&
+                        v.item.message.senderId !== activeCurrentUserId &&
+                        v.item.message.readAt === null,
                 );
                 if (unreadItems.length > 0) {
                     const newestUnread = unreadItems.reduce((prev, curr) =>
                         (curr.index ?? 0) < (prev.index ?? 0) ? curr : prev,
                     );
-                    activeMarkRead(activeChatId, newestUnread.item.id);
+                    activeMarkRead(activeChatId, newestUnread.item.message.id);
                 }
             },
         ).current;
@@ -292,26 +350,38 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
 
         const renderItem = useMemo(
             () =>
-                ({ item, index }: { item: MessageDto; index: number }) => {
-                    const view = mapMessageToProps(item, currentUserId);
-                    const localStatus = (item as LocalMessageDto)._localStatus;
+                ({ item, index }: { item: MessageListItem; index: number }) => {
+                    if (item.type === "date") {
+                        const isFirstVisualItem = index === listItems.length - 1;
+
+                        return (
+                            <View
+                                testID={`message-date-separator-${item.dayKey}`}
+                                className="items-center py-1"
+                                style={[
+                                    styles.dateSeparator,
+                                    isFirstVisualItem ? styles.firstDateSeparator : null,
+                                ]}
+                            >
+                                <View className="px-3 py-1.5 rounded-full bg-app-panel border border-white/10">
+                                    <Text className="text-[12px] font-semibold text-text-subtle">
+                                        {formatMessageDateLabel(item.createdAt)}
+                                    </Text>
+                                </View>
+                            </View>
+                        );
+                    }
+
+                    const message = item.message;
+                    const view = mapMessageToProps(message, currentUserId);
+                    const localStatus = (message as LocalMessageDto)._localStatus;
                     const isHighlighted = view.id === highlightedMessageId;
-                    const next = messages[index + 1];
-                    const currentDay = getMessageDayKey(item.createdAt);
-                    const nextDay = getMessageDayKey(next?.createdAt);
-                    const showDateSeparator = currentDay !== "" && currentDay !== nextDay;
+                    const itemAbove = listItems[index + 1];
+                    const messageSpacing =
+                        itemAbove?.type === "message" ? styles.messageAfterMessage : null;
 
                     return (
-                        <View>
-                            {showDateSeparator && (
-                                <View className="items-center py-1">
-                                    <View className="px-3 py-1.5 rounded-full bg-app-panel border border-white/10">
-                                        <Text className="text-[12px] font-semibold text-text-subtle">
-                                            {formatMessageDateLabel(item.createdAt)}
-                                        </Text>
-                                    </View>
-                                </View>
-                            )}
+                        <View style={messageSpacing}>
                             <View
                                 testID={`message-row-${view.id}`}
                                 className="-mx-2 rounded-2xl px-2 py-1 overflow-hidden"
@@ -342,38 +412,40 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                                     avatarUrl={view.avatarUrl}
                                     showAvatar={shouldShowAvatars}
                                     attachments={view.attachments}
-                                    replyTo={item.replyTo ?? null}
-                                    reactions={item.reactions}
-                                    editedAtUtc={item.editedAtUtc}
-                                    forwardedFrom={item.forwardedFrom ?? null}
-                                    isDeleted={item.state === "Deleted"}
+                                    replyTo={message.replyTo ?? null}
+                                    reactions={message.reactions}
+                                    editedAtUtc={message.editedAtUtc}
+                                    forwardedFrom={message.forwardedFrom ?? null}
+                                    isDeleted={message.state === "Deleted"}
                                     isHighlighted={isHighlighted}
-                                    threadReplyCount={item.threadReplyCount ?? 0}
+                                    threadReplyCount={message.threadReplyCount ?? 0}
                                     localStatus={localStatus}
-                                    onLongPress={() => onMessageLongPress?.(item)}
-                                    onContextMenu={(anchor) => onMessageContextMenu?.(item, anchor)}
+                                    onLongPress={() => onMessageLongPress?.(message)}
+                                    onContextMenu={(anchor) =>
+                                        onMessageContextMenu?.(message, anchor)
+                                    }
                                     onReplyPress={
-                                        item.replyTo?.messageId
+                                        message.replyTo?.messageId
                                             ? () => {
-                                                  void scrollToMessage(item.replyTo!.messageId);
+                                                  void scrollToMessage(message.replyTo!.messageId);
                                               }
                                             : undefined
                                     }
                                     onReactionPress={
                                         currentUserId
                                             ? (emoji) => {
-                                                  const reacters = item.reactions?.[emoji] ?? [];
+                                                  const reacters = message.reactions?.[emoji] ?? [];
                                                   if (reacters.includes(currentUserId)) {
-                                                      removeReaction(item.id, emoji);
+                                                      removeReaction(message.id, emoji);
                                                   } else {
-                                                      addReaction(item.id, emoji);
+                                                      addReaction(message.id, emoji);
                                                   }
                                               }
                                             : undefined
                                     }
                                     onThreadOpen={
-                                        item.threadReplyCount && item.threadReplyCount > 0
-                                            ? () => onThreadOpen?.(item.id)
+                                        message.threadReplyCount && message.threadReplyCount > 0
+                                            ? () => onThreadOpen?.(message.id)
                                             : undefined
                                     }
                                 />
@@ -384,7 +456,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             [
                 currentUserId,
                 highlightedMessageId,
-                messages,
+                listItems,
                 shouldShowAvatars,
                 onMessageLongPress,
                 onMessageContextMenu,
@@ -426,10 +498,9 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                     ref={listRef}
                     className="flex-1 px-6 py-6"
                     inverted={true}
-                    data={messages}
-                    keyExtractor={(item) => item.id}
+                    data={listItems}
+                    keyExtractor={getMessageListItemKey}
                     contentContainerStyle={{
-                        gap: 24,
                         flexGrow: 1,
                     }}
                     onViewableItemsChanged={handleViewableItemsChanged}

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -190,7 +190,7 @@ describe("MessagesList loading state", () => {
         });
     });
 
-    it("renders a single inline date separator per message day", () => {
+    it("renders a single date separator per message day", () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date("2026-05-24T12:00:00.000Z"));
         mockChatState = {
@@ -221,6 +221,41 @@ describe("MessagesList loading state", () => {
         expect(screen.getAllByText("Сегодня")).toHaveLength(1);
         expect(screen.getByText(/мая/)).toBeTruthy();
         jest.useRealTimers();
+    });
+
+    it("keeps date separators as independent list rows", () => {
+        mockChatState = {
+            ...mockChatState,
+            messagesByConversation: {
+                "chat-date-rows": [
+                    {
+                        id: "message-today",
+                        body: "today",
+                        senderId: "peer-user",
+                        readAt: null,
+                        createdAt: "2026-05-24T10:00:00.000Z",
+                    },
+                    {
+                        id: "message-yesterday",
+                        body: "yesterday",
+                        senderId: "peer-user",
+                        readAt: null,
+                        createdAt: "2026-05-23T10:00:00.000Z",
+                    },
+                ],
+            },
+            messagesLoadedByConversation: { "chat-date-rows": true },
+        };
+
+        render(<MessagesList chatId="chat-date-rows" type="chat" />);
+
+        const list = screen.UNSAFE_getByType(FlatList);
+        expect(list.props.data).toEqual([
+            expect.objectContaining({ id: "message-today", type: "message" }),
+            expect.objectContaining({ dayKey: "2026-05-24", type: "date" }),
+            expect.objectContaining({ id: "message-yesterday", type: "message" }),
+            expect.objectContaining({ dayKey: "2026-05-23", type: "date" }),
+        ]);
     });
 
     it("highlights a message for a few seconds after imperative scroll", async () => {

--- a/deploy/helm/services/media-service/values-dev.yaml
+++ b/deploy/helm/services/media-service/values-dev.yaml
@@ -14,6 +14,10 @@ service:
 env:
   ASPNETCORE_ENVIRONMENT: Development
   ASPNETCORE_URLS: http://+:8080
+  Storage__Endpoint: http://minio.urfu-platform.svc.cluster.local:9000
+  Storage__PublicEndpoint: http://storage.dev.127.0.0.1.nip.io
+  Storage__PrivateBucket: media-private
+  Storage__PublicBucket: media-public
 
 secrets:
   enabled: true

--- a/deploy/helm/services/media-service/values-prod.yaml
+++ b/deploy/helm/services/media-service/values-prod.yaml
@@ -26,6 +26,10 @@ env:
   Auth__NameClaim: email
   Auth__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
+  Storage__Endpoint: http://urfu-minio.urfu-platform.svc.cluster.local:9000
+  Storage__PublicEndpoint: https://storage.ghjc.ru
+  Storage__PrivateBucket: media-private
+  Storage__PublicBucket: media-public
 
 secrets:
   enabled: true

--- a/deploy/k8s/platform/stateful/minio-buckets-job.yaml
+++ b/deploy/k8s/platform/stateful/minio-buckets-job.yaml
@@ -16,17 +16,40 @@ spec:
           command:
             - /bin/sh
             - -c
-            - >-
-              until [ -s /bootstrap/endpoint ] && [ -s /bootstrap/access_key ] && [ -s /bootstrap/secret_key ]; do sleep 5; done &&
-              MINIO_ENDPOINT="$(cat /bootstrap/endpoint)" &&
-              MINIO_ACCESS_KEY="$(cat /bootstrap/access_key)" &&
-              MINIO_SECRET_KEY="$(cat /bootstrap/secret_key)" &&
-              until mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"; do sleep 5; done &&
-              mc mb -p minio/media-private || true &&
-              mc mb -p minio/media-public || true &&
-              mc anonymous set download minio/media-public &&
-              mc mb -p minio/user-avatars || true &&
+            - |
+              set -eu
+
+              until [ -s /bootstrap/endpoint ] && [ -s /bootstrap/access_key ] && [ -s /bootstrap/secret_key ]; do
+                sleep 5
+              done
+
+              MINIO_ENDPOINT="$(cat /bootstrap/endpoint)"
+              MINIO_ACCESS_KEY="$(cat /bootstrap/access_key)"
+              MINIO_SECRET_KEY="$(cat /bootstrap/secret_key)"
+
+              until mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"; do
+                sleep 5
+              done
+
+              cat >/tmp/media-cors.json <<'EOF'
+              [
+                {
+                  "AllowedOrigins": ["https://urfu-link.ghjc.ru"],
+                  "AllowedMethods": ["GET", "HEAD", "PUT"],
+                  "AllowedHeaders": ["*"],
+                  "ExposeHeaders": ["ETag"],
+                  "MaxAgeSeconds": 3000
+                }
+              ]
+              EOF
+
+              mc mb -p minio/media-private || true
+              mc mb -p minio/media-public || true
+              mc mb -p minio/user-avatars || true
+              mc anonymous set download minio/media-public
               mc anonymous set download minio/user-avatars
+              mc cors set minio/media-private /tmp/media-cors.json
+              mc cors set minio/media-public /tmp/media-cors.json
           volumeMounts:
             - name: bootstrap-secret
               mountPath: /bootstrap

--- a/platform/dev/local-k8s/dependencies.yaml
+++ b/platform/dev/local-k8s/dependencies.yaml
@@ -333,6 +333,54 @@ spec:
       port: 9001
       targetPort: console
 ---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-bootstrap-buckets
+  namespace: urfu-platform
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              until mc alias set minio http://minio.urfu-platform.svc.cluster.local:9000 minio minio123; do
+                sleep 2
+              done
+
+              cat >/tmp/media-cors.json <<'EOF'
+              [
+                {
+                  "AllowedOrigins": [
+                    "http://localhost:3000",
+                    "http://127.0.0.1:3000",
+                    "http://app.dev.127.0.0.1.nip.io"
+                  ],
+                  "AllowedMethods": ["GET", "HEAD", "PUT"],
+                  "AllowedHeaders": ["*"],
+                  "ExposeHeaders": ["ETag"],
+                  "MaxAgeSeconds": 3000
+                }
+              ]
+              EOF
+
+              mc mb -p minio/user-avatars || true
+              mc mb -p minio/media-private || true
+              mc mb -p minio/media-public || true
+              mc anonymous set download minio/user-avatars
+              mc anonymous set download minio/media-public
+              mc cors set minio/media-private /tmp/media-cors.json
+              mc cors set minio/media-public /tmp/media-cors.json
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/platform/dev/local-k8s/dev-secrets.yaml
+++ b/platform/dev/local-k8s/dev-secrets.yaml
@@ -33,6 +33,8 @@ stringData:
   Auth__Authority: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link
   Observability__Otlp__Endpoint: http://otel-collector.observability.svc.cluster.local:4317
   Infrastructure__Redis__Configuration: redis.urfu-platform.svc.cluster.local:6379
+  Storage__AccessKey: minio
+  Storage__SecretKey: minio123
 ---
 apiVersion: v1
 kind: Secret

--- a/platform/dev/local-k8s/local-ingress.yaml
+++ b/platform/dev/local-k8s/local-ingress.yaml
@@ -16,3 +16,22 @@ spec:
                 name: api-gateway
                 port:
                   number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-api-local
+  namespace: urfu-platform
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: storage.dev.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000

--- a/scripts/local-k8s-up.ps1
+++ b/scripts/local-k8s-up.ps1
@@ -100,11 +100,14 @@ kubectl create configmap otel-collector-config -n observability --from-file=conf
 Write-Host "[urfu-link] Applying local platform resources..." -ForegroundColor Cyan
 kubectl delete job postgres-bootstrap -n urfu-platform --ignore-not-found=true
 kubectl delete job kafka-bootstrap -n urfu-platform --ignore-not-found=true
+kubectl delete job minio-bootstrap-buckets -n urfu-platform --ignore-not-found=true
 kubectl apply -k platform/dev/local-k8s
 kubectl wait --namespace urfu-platform --for=condition=available deployment/postgres --timeout=300s
 kubectl wait --namespace urfu-platform --for=condition=available deployment/kafka --timeout=300s
+kubectl wait --namespace urfu-platform --for=condition=available deployment/minio --timeout=300s
 kubectl wait --namespace urfu-platform --for=condition=complete job/postgres-bootstrap --timeout=300s
 kubectl wait --namespace urfu-platform --for=condition=complete job/kafka-bootstrap --timeout=300s
+kubectl wait --namespace urfu-platform --for=condition=complete job/minio-bootstrap-buckets --timeout=300s
 
 if ($BuildImages) {
     & .\scripts\local-k8s-load-images.ps1 -ClusterName $ClusterName

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -19,11 +19,14 @@ public sealed class DeploymentContractTests
     {
         var overlay = ReadRepoFile("platform", "dev", "local-k8s", "kustomization.yaml");
         var dependencies = ReadRepoFile("platform", "dev", "local-k8s", "dependencies.yaml");
+        var localUpScript = ReadRepoFile("scripts", "local-k8s-up.ps1");
 
         Assert.Contains("dependencies.yaml", overlay, StringComparison.Ordinal);
         Assert.Contains("kind: Deployment", dependencies, StringComparison.Ordinal);
         Assert.Contains("name: kafka", dependencies, StringComparison.Ordinal);
         Assert.Contains("name: keycloak", dependencies, StringComparison.Ordinal);
+        Assert.Contains("deployment/minio", localUpScript, StringComparison.Ordinal);
+        Assert.Contains("job/minio-bootstrap-buckets", localUpScript, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -48,6 +51,53 @@ public sealed class DeploymentContractTests
         Assert.Contains("\"EXPO_PUBLIC_API_URL\": \"https://api.urfu-link.ghjc.ru\"", easConfig, StringComparison.Ordinal);
         Assert.Contains("ingress/api-gateway-ingress.yaml", platformKustomization, StringComparison.Ordinal);
         Assert.Contains("- ingress-nginx", gatewayValues, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProductionMediaStorageShouldExposeBrowserReachablePresignedUrls()
+    {
+        var mediaValues = ReadRepoFile("deploy", "helm", "services", "media-service", "values-prod.yaml");
+        var minioIngress = ReadRepoFile("deploy", "k8s", "platform", "ingress", "minio-ingress.yaml");
+        var minioBucketsJob = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-buckets-job.yaml");
+
+        Assert.Contains(
+            "Storage__Endpoint: http://urfu-minio.urfu-platform.svc.cluster.local:9000",
+            mediaValues,
+            StringComparison.Ordinal);
+        Assert.Contains("Storage__PublicEndpoint: https://storage.ghjc.ru", mediaValues, StringComparison.Ordinal);
+        Assert.Contains("Storage__PrivateBucket: media-private", mediaValues, StringComparison.Ordinal);
+        Assert.Contains("Storage__PublicBucket: media-public", mediaValues, StringComparison.Ordinal);
+        Assert.Contains("host: storage.ghjc.ru", minioIngress, StringComparison.Ordinal);
+        Assert.Contains("number: 9000", minioIngress, StringComparison.Ordinal);
+        Assert.Contains("https://urfu-link.ghjc.ru", minioBucketsJob, StringComparison.Ordinal);
+        Assert.Contains("mc cors set minio/media-private", minioBucketsJob, StringComparison.Ordinal);
+        Assert.Contains("mc cors set minio/media-public", minioBucketsJob, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LocalKubernetesMediaStorageShouldUseClusterEndpointAndIngressHost()
+    {
+        var mediaValues = ReadRepoFile("deploy", "helm", "services", "media-service", "values-dev.yaml");
+        var localSecrets = ReadRepoFile("platform", "dev", "local-k8s", "dev-secrets.yaml");
+        var localIngress = ReadRepoFile("platform", "dev", "local-k8s", "local-ingress.yaml");
+        var dependencies = ReadRepoFile("platform", "dev", "local-k8s", "dependencies.yaml");
+        var mediaSecret = GetYamlDocumentByName(localSecrets, "media-service-secrets");
+
+        Assert.Contains(
+            "Storage__Endpoint: http://minio.urfu-platform.svc.cluster.local:9000",
+            mediaValues,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Storage__PublicEndpoint: http://storage.dev.127.0.0.1.nip.io",
+            mediaValues,
+            StringComparison.Ordinal);
+        Assert.Contains("Storage__AccessKey: minio", mediaSecret, StringComparison.Ordinal);
+        Assert.Contains("Storage__SecretKey: minio123", mediaSecret, StringComparison.Ordinal);
+        Assert.Contains("host: storage.dev.127.0.0.1.nip.io", localIngress, StringComparison.Ordinal);
+        Assert.Contains("name: minio-bootstrap-buckets", dependencies, StringComparison.Ordinal);
+        Assert.Contains("http://localhost:3000", dependencies, StringComparison.Ordinal);
+        Assert.Contains("http://app.dev.127.0.0.1.nip.io", dependencies, StringComparison.Ordinal);
+        Assert.Contains("mc cors set minio/media-private", dependencies, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -154,5 +204,17 @@ public sealed class DeploymentContractTests
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
 
         return File.ReadAllText(Path.Combine([repoRoot, .. pathSegments]));
+    }
+
+    private static string GetYamlDocumentByName(string manifest, string name)
+    {
+        var documentStart = manifest.IndexOf($"name: {name}", StringComparison.Ordinal);
+        Assert.True(documentStart >= 0, $"Could not find YAML document named {name}.");
+
+        documentStart = manifest.LastIndexOf("---", documentStart, StringComparison.Ordinal);
+        documentStart = documentStart < 0 ? 0 : documentStart + "---".Length;
+
+        var documentEnd = manifest.IndexOf("---", documentStart, StringComparison.Ordinal);
+        return documentEnd < 0 ? manifest[documentStart..] : manifest[documentStart..documentEnd];
     }
 }

--- a/tests/integration/ChatService.IntegrationTests/Hub/ChatHubReactionsTests.cs
+++ b/tests/integration/ChatService.IntegrationTests/Hub/ChatHubReactionsTests.cs
@@ -70,12 +70,18 @@ public class ChatHubReactionsTests : IAsyncLifetime
             PeerUserId = bob,
         });
 
-        await bobConn.InvokeAsync("AddReaction", sent.Id, "👍");
-
         var aliceCleared = new TaskCompletionSource<IReadOnlyDictionary<string, IReadOnlyList<Guid>>>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         aliceConn.On<Guid, IReadOnlyDictionary<string, IReadOnlyList<Guid>>>("ReactionUpdated",
-            (_, summary) => aliceCleared.TrySetResult(summary));
+            (messageId, summary) =>
+            {
+                if (messageId == sent.Id && summary.Count == 0)
+                {
+                    aliceCleared.TrySetResult(summary);
+                }
+            });
+
+        await bobConn.InvokeAsync("AddReaction", sent.Id, "👍");
 
         await bobConn.InvokeAsync("RemoveReaction", sent.Id, "👍");
 


### PR DESCRIPTION
## Что изменено
- Плашки дат в чате теперь рендерятся отдельными элементами списка и прокручиваются вместе с сообщениями.
- Добавлены storage endpoint/public endpoint/bucket настройки для media-service в dev/prod.
- Добавлен bootstrap MinIO buckets/CORS для prod и local-k8s, плюс contract coverage.
- Устранён race в integration-тесте удаления реакции, который мог ловить запоздавший AddReaction event.

## Проверки
- pnpm --filter @urfu-link/client test -- --runInBand
- pnpm --filter @urfu-link/client typecheck
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- dotnet test tests/integration/ChatService.IntegrationTests/ChatService.IntegrationTests.csproj --filter FullyQualifiedName~RemoveReaction_BroadcastsEmptySummary --no-restore (5 раз подряд)
- git diff --check

## Примечание
- Локальный полный ChatService.IntegrationTests упал на environment-sensitive SearchPerformanceTests (p95 budget), не на reaction; CI до фикса дошёл до reaction и падал именно там.