### PR TITLE
fix: use XML MinIO CORS config

### DIFF
--- a/deploy/k8s/platform/stateful/minio-buckets-job.yaml
+++ b/deploy/k8s/platform/stateful/minio-buckets-job.yaml
@@ -31,16 +31,18 @@ spec:
                 sleep 5
               done
 
-              cat >/tmp/media-cors.json <<'EOF'
-              [
-                {
-                  "AllowedOrigins": ["https://urfu-link.ghjc.ru"],
-                  "AllowedMethods": ["GET", "HEAD", "PUT"],
-                  "AllowedHeaders": ["*"],
-                  "ExposeHeaders": ["ETag"],
-                  "MaxAgeSeconds": 3000
-                }
-              ]
+              cat >/tmp/media-cors.xml <<'EOF'
+              <CORSConfiguration>
+                <CORSRule>
+                  <AllowedOrigin>https://urfu-link.ghjc.ru</AllowedOrigin>
+                  <AllowedMethod>GET</AllowedMethod>
+                  <AllowedMethod>HEAD</AllowedMethod>
+                  <AllowedMethod>PUT</AllowedMethod>
+                  <AllowedHeader>*</AllowedHeader>
+                  <ExposeHeader>ETag</ExposeHeader>
+                  <MaxAgeSeconds>3000</MaxAgeSeconds>
+                </CORSRule>
+              </CORSConfiguration>
               EOF
 
               mc mb -p minio/media-private || true
@@ -48,8 +50,8 @@ spec:
               mc mb -p minio/user-avatars || true
               mc anonymous set download minio/media-public
               mc anonymous set download minio/user-avatars
-              mc cors set minio/media-private /tmp/media-cors.json
-              mc cors set minio/media-public /tmp/media-cors.json
+              mc cors set minio/media-private /tmp/media-cors.xml
+              mc cors set minio/media-public /tmp/media-cors.xml
           volumeMounts:
             - name: bootstrap-secret
               mountPath: /bootstrap

--- a/platform/dev/local-k8s/dependencies.yaml
+++ b/platform/dev/local-k8s/dependencies.yaml
@@ -357,20 +357,20 @@ spec:
                 sleep 2
               done
 
-              cat >/tmp/media-cors.json <<'EOF'
-              [
-                {
-                  "AllowedOrigins": [
-                    "http://localhost:3000",
-                    "http://127.0.0.1:3000",
-                    "http://app.dev.127.0.0.1.nip.io"
-                  ],
-                  "AllowedMethods": ["GET", "HEAD", "PUT"],
-                  "AllowedHeaders": ["*"],
-                  "ExposeHeaders": ["ETag"],
-                  "MaxAgeSeconds": 3000
-                }
-              ]
+              cat >/tmp/media-cors.xml <<'EOF'
+              <CORSConfiguration>
+                <CORSRule>
+                  <AllowedOrigin>http://localhost:3000</AllowedOrigin>
+                  <AllowedOrigin>http://127.0.0.1:3000</AllowedOrigin>
+                  <AllowedOrigin>http://app.dev.127.0.0.1.nip.io</AllowedOrigin>
+                  <AllowedMethod>GET</AllowedMethod>
+                  <AllowedMethod>HEAD</AllowedMethod>
+                  <AllowedMethod>PUT</AllowedMethod>
+                  <AllowedHeader>*</AllowedHeader>
+                  <ExposeHeader>ETag</ExposeHeader>
+                  <MaxAgeSeconds>3000</MaxAgeSeconds>
+                </CORSRule>
+              </CORSConfiguration>
               EOF
 
               mc mb -p minio/user-avatars || true
@@ -378,8 +378,8 @@ spec:
               mc mb -p minio/media-public || true
               mc anonymous set download minio/user-avatars
               mc anonymous set download minio/media-public
-              mc cors set minio/media-private /tmp/media-cors.json
-              mc cors set minio/media-public /tmp/media-cors.json
+              mc cors set minio/media-private /tmp/media-cors.xml
+              mc cors set minio/media-public /tmp/media-cors.xml
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -69,6 +69,7 @@ public sealed class DeploymentContractTests
         Assert.Contains("Storage__PublicBucket: media-public", mediaValues, StringComparison.Ordinal);
         Assert.Contains("host: storage.ghjc.ru", minioIngress, StringComparison.Ordinal);
         Assert.Contains("number: 9000", minioIngress, StringComparison.Ordinal);
+        Assert.Contains("<CORSConfiguration>", minioBucketsJob, StringComparison.Ordinal);
         Assert.Contains("https://urfu-link.ghjc.ru", minioBucketsJob, StringComparison.Ordinal);
         Assert.Contains("mc cors set minio/media-private", minioBucketsJob, StringComparison.Ordinal);
         Assert.Contains("mc cors set minio/media-public", minioBucketsJob, StringComparison.Ordinal);
@@ -95,6 +96,7 @@ public sealed class DeploymentContractTests
         Assert.Contains("Storage__SecretKey: minio123", mediaSecret, StringComparison.Ordinal);
         Assert.Contains("host: storage.dev.127.0.0.1.nip.io", localIngress, StringComparison.Ordinal);
         Assert.Contains("name: minio-bootstrap-buckets", dependencies, StringComparison.Ordinal);
+        Assert.Contains("<CORSConfiguration>", dependencies, StringComparison.Ordinal);
         Assert.Contains("http://localhost:3000", dependencies, StringComparison.Ordinal);
         Assert.Contains("http://app.dev.127.0.0.1.nip.io", dependencies, StringComparison.Ordinal);
         Assert.Contains("mc cors set minio/media-private", dependencies, StringComparison.Ordinal);


### PR DESCRIPTION
## Что изменено
- `mc cors set` теперь получает XML CORS configuration, как требует MinIO client.
- Обновлён local-k8s MinIO bootstrap тем же форматом.
- Contract tests закрепляют XML CORS configuration для prod/local manifests.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- git diff --check

## Примечание
- Локально `helm` CLI отсутствует; `helm-validate` проверит это в CI.