### PR TITLE
fix: configure MinIO global CORS

### DIFF
--- a/deploy/k8s/platform/stateful/minio-buckets-job.yaml
+++ b/deploy/k8s/platform/stateful/minio-buckets-job.yaml
@@ -31,27 +31,11 @@ spec:
                 sleep 5
               done
 
-              cat >/tmp/media-cors.xml <<'EOF'
-              <CORSConfiguration>
-                <CORSRule>
-                  <AllowedOrigin>https://urfu-link.ghjc.ru</AllowedOrigin>
-                  <AllowedMethod>GET</AllowedMethod>
-                  <AllowedMethod>HEAD</AllowedMethod>
-                  <AllowedMethod>PUT</AllowedMethod>
-                  <AllowedHeader>*</AllowedHeader>
-                  <ExposeHeader>ETag</ExposeHeader>
-                  <MaxAgeSeconds>3000</MaxAgeSeconds>
-                </CORSRule>
-              </CORSConfiguration>
-              EOF
-
               mc mb -p minio/media-private || true
               mc mb -p minio/media-public || true
               mc mb -p minio/user-avatars || true
               mc anonymous set download minio/media-public
               mc anonymous set download minio/user-avatars
-              mc cors set minio/media-private /tmp/media-cors.xml
-              mc cors set minio/media-public /tmp/media-cors.xml
           volumeMounts:
             - name: bootstrap-secret
               mountPath: /bootstrap

--- a/deploy/k8s/platform/stateful/minio-tenant.yaml
+++ b/deploy/k8s/platform/stateful/minio-tenant.yaml
@@ -36,6 +36,8 @@ spec:
                   key: root_password
             - name: MINIO_BROWSER_REDIRECT_URL
               value: "https://minio.ghjc.ru"
+            - name: MINIO_API_CORS_ALLOW_ORIGIN
+              value: "https://urfu-link.ghjc.ru"
             - name: MINIO_IDENTITY_OPENID_CONFIG_URL
               value: "https://id.ghjc.ru/realms/urfu-link/.well-known/openid-configuration"
             - name: MINIO_IDENTITY_OPENID_CLIENT_ID

--- a/platform/dev/local-k8s/dependencies.yaml
+++ b/platform/dev/local-k8s/dependencies.yaml
@@ -305,6 +305,8 @@ spec:
               value: minio
             - name: MINIO_ROOT_PASSWORD
               value: minio123
+            - name: MINIO_API_CORS_ALLOW_ORIGIN
+              value: http://localhost:3000,http://127.0.0.1:3000,http://app.dev.127.0.0.1.nip.io
           ports:
             - containerPort: 9000
               name: api
@@ -357,29 +359,11 @@ spec:
                 sleep 2
               done
 
-              cat >/tmp/media-cors.xml <<'EOF'
-              <CORSConfiguration>
-                <CORSRule>
-                  <AllowedOrigin>http://localhost:3000</AllowedOrigin>
-                  <AllowedOrigin>http://127.0.0.1:3000</AllowedOrigin>
-                  <AllowedOrigin>http://app.dev.127.0.0.1.nip.io</AllowedOrigin>
-                  <AllowedMethod>GET</AllowedMethod>
-                  <AllowedMethod>HEAD</AllowedMethod>
-                  <AllowedMethod>PUT</AllowedMethod>
-                  <AllowedHeader>*</AllowedHeader>
-                  <ExposeHeader>ETag</ExposeHeader>
-                  <MaxAgeSeconds>3000</MaxAgeSeconds>
-                </CORSRule>
-              </CORSConfiguration>
-              EOF
-
               mc mb -p minio/user-avatars || true
               mc mb -p minio/media-private || true
               mc mb -p minio/media-public || true
               mc anonymous set download minio/user-avatars
               mc anonymous set download minio/media-public
-              mc cors set minio/media-private /tmp/media-cors.xml
-              mc cors set minio/media-public /tmp/media-cors.xml
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -58,6 +58,7 @@ public sealed class DeploymentContractTests
     {
         var mediaValues = ReadRepoFile("deploy", "helm", "services", "media-service", "values-prod.yaml");
         var minioIngress = ReadRepoFile("deploy", "k8s", "platform", "ingress", "minio-ingress.yaml");
+        var minioTenant = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-tenant.yaml");
         var minioBucketsJob = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-buckets-job.yaml");
 
         Assert.Contains(
@@ -69,10 +70,9 @@ public sealed class DeploymentContractTests
         Assert.Contains("Storage__PublicBucket: media-public", mediaValues, StringComparison.Ordinal);
         Assert.Contains("host: storage.ghjc.ru", minioIngress, StringComparison.Ordinal);
         Assert.Contains("number: 9000", minioIngress, StringComparison.Ordinal);
-        Assert.Contains("<CORSConfiguration>", minioBucketsJob, StringComparison.Ordinal);
-        Assert.Contains("https://urfu-link.ghjc.ru", minioBucketsJob, StringComparison.Ordinal);
-        Assert.Contains("mc cors set minio/media-private", minioBucketsJob, StringComparison.Ordinal);
-        Assert.Contains("mc cors set minio/media-public", minioBucketsJob, StringComparison.Ordinal);
+        Assert.Contains("MINIO_API_CORS_ALLOW_ORIGIN", minioTenant, StringComparison.Ordinal);
+        Assert.Contains("https://urfu-link.ghjc.ru", minioTenant, StringComparison.Ordinal);
+        Assert.DoesNotContain("mc cors set", minioBucketsJob, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -96,10 +96,10 @@ public sealed class DeploymentContractTests
         Assert.Contains("Storage__SecretKey: minio123", mediaSecret, StringComparison.Ordinal);
         Assert.Contains("host: storage.dev.127.0.0.1.nip.io", localIngress, StringComparison.Ordinal);
         Assert.Contains("name: minio-bootstrap-buckets", dependencies, StringComparison.Ordinal);
-        Assert.Contains("<CORSConfiguration>", dependencies, StringComparison.Ordinal);
+        Assert.Contains("MINIO_API_CORS_ALLOW_ORIGIN", dependencies, StringComparison.Ordinal);
         Assert.Contains("http://localhost:3000", dependencies, StringComparison.Ordinal);
         Assert.Contains("http://app.dev.127.0.0.1.nip.io", dependencies, StringComparison.Ordinal);
-        Assert.Contains("mc cors set minio/media-private", dependencies, StringComparison.Ordinal);
+        Assert.DoesNotContain("mc cors set", dependencies, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Что изменено
- CORS для MinIO задан через `MINIO_API_CORS_ALLOW_ORIGIN`, совместимый с текущим OSS MinIO в prod.
- Bucket bootstrap больше не вызывает `mc cors set`, который падает на текущем MinIO API.
- Local-k8s использует тот же global CORS подход.
- Contract tests закрепляют env-based CORS и отсутствие bucket-level `mc cors set`.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- git diff --check

## Prod context
- Предыдущий `minio-bootstrap-buckets` падал на `mc cors set` с `A header you provided implies functionality that is not implemented`.