### PR TITLE
fix(client): make chat date separators sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # URFU Link
 
+## Cluster Access
+
+- `root@89.167.93.199` is for cluster management and log viewing.
+
 Монорепозиторий под on-prem Kubernetes. Бэкенд — ASP.NET 10, шлюз YARP, идентичность через Keycloak, очереди Kafka, данные в PostgreSQL/MongoDB/Redis/MinIO. Фронт — Expo Router (web + mobile). Доставка: GitHub Actions + Argo CD, деплой Blue/Green.
 
 **Стек зафиксирован:** один регион, self-hosted Kafka (KRaft), LiveKit + Coturn для медиа, Linkerd + Viz как service mesh.

--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -93,6 +93,14 @@ const buildMessageListItems = (messages: MessageDto[]): MessageListItem[] => {
     return items;
 };
 
+const getDateStickyHeaderIndices = (items: MessageListItem[], stickyOffset = 0) =>
+    items.reduce<number[]>((indices, item, index) => {
+        if (item.type === "date") {
+            indices.push(index + stickyOffset);
+        }
+        return indices;
+    }, []);
+
 const getMessageListItemKey = (item: MessageListItem) => item.id;
 
 const waitForListUpdate = () => new Promise((resolve) => setTimeout(resolve, 50));
@@ -101,6 +109,7 @@ const styles = StyleSheet.create({
     dateSeparator: {
         marginTop: 24,
         marginBottom: 4,
+        zIndex: 2,
     },
     firstDateSeparator: {
         marginTop: 0,
@@ -158,6 +167,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const isLoaded = messagesLoadedByConversation[chatId] || false;
         const hasMore = hasMoreByConversation[chatId] || false;
         const listItems = useMemo(() => buildMessageListItems(messages), [messages]);
+        const stickyHeaderIndices = useMemo(
+            () => getDateStickyHeaderIndices(listItems, 1),
+            [listItems],
+        );
         const listRef = useRef<FlatList<MessageListItem>>(null);
         const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
         const highlightOpacity = useRef(new Animated.Value(0)).current;
@@ -503,6 +516,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                     contentContainerStyle={{
                         flexGrow: 1,
                     }}
+                    stickyHeaderIndices={stickyHeaderIndices}
+                    invertStickyHeaders
                     onViewableItemsChanged={handleViewableItemsChanged}
                     viewabilityConfig={viewabilityConfig}
                     renderItem={renderItem}

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -190,7 +190,7 @@ describe("MessagesList loading state", () => {
         });
     });
 
-    it("renders a single date separator per message day", () => {
+    it("renders date separators as sticky list rows", () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date("2026-05-24T12:00:00.000Z"));
         mockChatState = {
@@ -218,6 +218,11 @@ describe("MessagesList loading state", () => {
 
         render(<MessagesList chatId="chat-dates" type="chat" />);
 
+        const list = screen.UNSAFE_getByType(FlatList);
+        expect(screen.getByTestId("message-date-separator-2026-05-24")).toBeTruthy();
+        expect(screen.getByTestId("message-date-separator-2026-05-23")).toBeTruthy();
+        expect(list.props.stickyHeaderIndices).toEqual([2, 4]);
+        expect(list.props.invertStickyHeaders).toBe(true);
         expect(screen.getAllByText("Сегодня")).toHaveLength(1);
         expect(screen.getByText(/мая/)).toBeTruthy();
         jest.useRealTimers();


### PR DESCRIPTION
## Summary
- make chat date separator rows sticky inside the message FlatList
- document cluster SSH access for management and log viewing

## Tests
- pnpm --filter @urfu-link/client test -- MessagesList.test.tsx --runInBand
- pnpm --filter @urfu-link/client typecheck