### PR TITLE
Fix prod presence typing auth

### DIFF
--- a/deploy/helm/services/chat-service/values-prod.yaml
+++ b/deploy/helm/services/chat-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
   GrpcClients__InternalAuth__TokenEndpoint: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/token
   GrpcClients__InternalAuth__ClientId: chat-service-internal

--- a/deploy/helm/services/discipline-service/values-prod.yaml
+++ b/deploy/helm/services/discipline-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
 
 secrets:

--- a/deploy/helm/services/media-service/values-prod.yaml
+++ b/deploy/helm/services/media-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
   Storage__Endpoint: http://urfu-minio.urfu-platform.svc.cluster.local:9000
   Storage__PublicEndpoint: https://storage.ghjc.ru

--- a/deploy/helm/services/presence-service/values-prod.yaml
+++ b/deploy/helm/services/presence-service/values-prod.yaml
@@ -27,6 +27,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
 
 secrets:

--- a/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
+++ b/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
@@ -369,7 +369,13 @@ spec:
               fi
               MEDIA_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=media_db;Username=media;Password=%s"}}' "$MEDIA_DB_PASSWORD")"
               DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s"}}' "$DISCIPLINE_DB_PASSWORD")"
-              CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
+              EXISTING_CHAT_SVC="$(vault_read urfu-link/prod/chat-service)"
+              EXISTING_INTERNAL_AUTH_SECRET="$(json_get_string "$EXISTING_CHAT_SVC" internal_auth_client_secret)"
+              if [ -n "$EXISTING_INTERNAL_AUTH_SECRET" ]; then
+                CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin","internal_auth_client_secret":"%s"}}' "$MONGO_APP_PASSWORD" "$EXISTING_INTERNAL_AUTH_SECRET")"
+              else
+                CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
+              fi
               PRESENCE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s"}}' "$PRESENCE_DB_PASSWORD")"
               NOTIFICATION_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s","kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}' "$NOTIFICATION_DB_PASSWORD")"
               CALL_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'

--- a/src/BuildingBlocks/Auth/AuthenticationExtensions.cs
+++ b/src/BuildingBlocks/Auth/AuthenticationExtensions.cs
@@ -9,6 +9,9 @@ namespace Urfu.Link.BuildingBlocks.Auth;
 
 public static class AuthenticationExtensions
 {
+    public const string InternalJwtBearerScheme = "InternalJwtBearer";
+    public const string InternalGrpcPolicy = "InternalGrpc";
+
     public static IServiceCollection AddPlatformJwtAuthentication(
         this IServiceCollection services,
         IConfiguration configuration)
@@ -16,65 +19,119 @@ public static class AuthenticationExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var tokenHeader = configuration["Auth:TokenHeader"];
-        var jwksUrl = configuration["Auth:JwksUrl"];
-        var authority = configuration["Auth:Authority"] ?? "http://localhost:8080/realms/urfu-link";
-        var audience = configuration["Auth:Audience"] ?? "urfu-link-api";
-        var metadataAddress = configuration["Auth:MetadataAddress"];
-        var validIssuer = configuration["Auth:ValidIssuer"];
-        var nameClaim = configuration["Auth:NameClaim"] ?? "preferred_username";
-        var roleClaim = configuration["Auth:RoleClaim"] ?? "roles";
+        var defaultJwt = PlatformJwtOptions.From(configuration.GetSection("Auth"));
+        var internalJwt = PlatformJwtOptions.From(configuration.GetSection("Auth:Internal"));
+        var hasInternalJwt = internalJwt.HasExplicitIssuerSource;
 
-        services
+        var authentication = services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
+            .AddJwtBearer(options => ConfigureJwtBearer(options, defaultJwt, useTokenHeader: true));
+
+        if (hasInternalJwt)
+        {
+            authentication.AddJwtBearer(
+                InternalJwtBearerScheme,
+                options => ConfigureJwtBearer(options, internalJwt, useTokenHeader: false));
+        }
+
+        services.AddAuthorizationBuilder()
+            .AddPolicy(InternalGrpcPolicy, policy =>
             {
-                if (!string.IsNullOrEmpty(tokenHeader))
-                {
-                    options.Events = new JwtBearerEvents
-                    {
-                        OnMessageReceived = context =>
-                        {
-                            var jwt = context.Request.Headers[tokenHeader].FirstOrDefault();
-                            if (!string.IsNullOrEmpty(jwt))
-                                context.Token = jwt;
-                            return Task.CompletedTask;
-                        }
-                    };
-                }
-
-                if (!string.IsNullOrEmpty(jwksUrl))
-                {
-                    options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-                        jwksUrl,
-                        new JwksRetriever(),
-                        new HttpDocumentRetriever { RequireHttps = false });
-                }
-                else
-                {
-                    options.Authority = authority;
-                    if (!string.IsNullOrEmpty(metadataAddress))
-                        options.MetadataAddress = metadataAddress;
-                    options.RequireHttpsMetadata = Uri.TryCreate(authority, UriKind.Absolute, out var authorityUri)
-                        && authorityUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
-                }
-
-                options.Audience = audience;
-                options.MapInboundClaims = false;
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateAudience = true,
-                    ValidAudience = audience,
-                    ValidateIssuer = true,
-                    ValidIssuer = validIssuer ?? authority,
-                    NameClaimType = nameClaim,
-                    RoleClaimType = roleClaim,
-                };
+                policy.AddAuthenticationSchemes(
+                    hasInternalJwt
+                        ? InternalJwtBearerScheme
+                        : JwtBearerDefaults.AuthenticationScheme);
+                policy.RequireAuthenticatedUser();
             });
 
-        services.AddAuthorization();
-
         return services;
+    }
+
+    private static void ConfigureJwtBearer(
+        JwtBearerOptions options,
+        PlatformJwtOptions jwt,
+        bool useTokenHeader)
+    {
+        if (useTokenHeader && !string.IsNullOrEmpty(jwt.TokenHeader))
+        {
+            options.Events = new JwtBearerEvents
+            {
+                OnMessageReceived = context =>
+                {
+                    var token = context.Request.Headers[jwt.TokenHeader].FirstOrDefault();
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        context.Token = token;
+                    }
+
+                    return Task.CompletedTask;
+                },
+            };
+        }
+
+        if (!string.IsNullOrEmpty(jwt.JwksUrl))
+        {
+            options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                jwt.JwksUrl,
+                new JwksRetriever(),
+                new HttpDocumentRetriever { RequireHttps = false });
+        }
+        else
+        {
+            options.Authority = jwt.Authority;
+            if (!string.IsNullOrEmpty(jwt.MetadataAddress))
+            {
+                options.MetadataAddress = jwt.MetadataAddress;
+            }
+
+            options.RequireHttpsMetadata = Uri.TryCreate(jwt.Authority, UriKind.Absolute, out var authorityUri)
+                && authorityUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+        }
+
+        options.Audience = jwt.Audience;
+        options.MapInboundClaims = false;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateAudience = true,
+            ValidAudience = jwt.Audience,
+            ValidateIssuer = true,
+            ValidIssuer = jwt.ValidIssuer ?? jwt.Authority,
+            NameClaimType = jwt.NameClaim,
+            RoleClaimType = jwt.RoleClaim,
+        };
+    }
+
+    private sealed record PlatformJwtOptions(
+        string? TokenHeader,
+        string? JwksUrl,
+        string Authority,
+        string Audience,
+        string? MetadataAddress,
+        string? ValidIssuer,
+        string NameClaim,
+        string RoleClaim,
+        bool HasExplicitIssuerSource)
+    {
+        public static PlatformJwtOptions From(IConfiguration section)
+        {
+            ArgumentNullException.ThrowIfNull(section);
+
+            var hasExplicitIssuerSource =
+                !string.IsNullOrWhiteSpace(section["JwksUrl"])
+                || !string.IsNullOrWhiteSpace(section["Authority"])
+                || !string.IsNullOrWhiteSpace(section["MetadataAddress"]);
+
+            return new PlatformJwtOptions(
+                section["TokenHeader"],
+                section["JwksUrl"],
+                section["Authority"] ?? "http://localhost:8080/realms/urfu-link",
+                section["Audience"] ?? "urfu-link-api",
+                section["MetadataAddress"],
+                section["ValidIssuer"],
+                section["NameClaim"] ?? "preferred_username",
+                section["RoleClaim"] ?? "roles",
+                hasExplicitIssuerSource);
+        }
     }
 
     private sealed class JwksRetriever : IConfigurationRetriever<OpenIdConnectConfiguration>

--- a/src/Services/Chat/ChatService.Api/Program.cs
+++ b/src/Services/Chat/ChatService.Api/Program.cs
@@ -2,6 +2,7 @@ using FastEndpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Domain;
@@ -77,7 +78,7 @@ app.UseFastEndpoints(c =>
     c.Serializer.Options.Converters.Add(
         new System.Text.Json.Serialization.JsonStringEnumConverter());
 });
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 app.MapHub<ChatHub>("/hubs/chat");
 
 app.MapGet("/", (ServiceProfile descriptor) => Results.Ok(new

--- a/src/Services/Discipline/DisciplineService.Api/Program.cs
+++ b/src/Services/Discipline/DisciplineService.Api/Program.cs
@@ -7,6 +7,7 @@ using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.EntityFrameworkCore;
 using Scalar.AspNetCore;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
@@ -71,7 +72,9 @@ app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
 app.MapGrpcService<InternalApiService>()
-    .RequireAuthorization(InternalGrpcAuthorizationPolicy.PolicyName);
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 
 await app.RunAsync();
 

--- a/src/Services/Media/MediaService.Api/Program.cs
+++ b/src/Services/Media/MediaService.Api/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
@@ -68,7 +69,7 @@ app.UseFastEndpoints(c =>
 app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 
 await app.RunAsync();
 

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.Services.Presence.Infrastructure;
@@ -92,7 +93,7 @@ app.MapServiceDefaults();
 app.UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api/v1");
 app.UseSwaggerGen();
 app.MapScalarApiReference(o => o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 app.MapHub<PresenceHub>("/hubs/presence");
 
 await app.RunAsync();

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -11,6 +11,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.MongoDb;
 using Testcontainers.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application.Authorization;
@@ -190,5 +191,11 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 
@@ -115,5 +116,11 @@ public sealed class DisciplineServiceFactory : WebApplicationFactory<Program>, I
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
@@ -15,6 +15,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.Minio;
 using Testcontainers.PostgreSql;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 
@@ -184,5 +185,11 @@ public sealed class MediaServiceFactory : WebApplicationFactory<Program>, IAsync
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
@@ -12,6 +12,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
 using Testcontainers.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Presence.Infrastructure.Persistence;
@@ -146,5 +147,11 @@ public sealed class PresenceServiceFactory : WebApplicationFactory<Program>, IAs
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/unit/BuildingBlocks.UnitTests/Auth/AuthenticationExtensionsTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/Auth/AuthenticationExtensionsTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.Auth;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.Auth;
+
+public sealed class AuthenticationExtensionsTests
+{
+    [Fact]
+    public async Task InternalGrpc_policy_uses_default_jwt_scheme_when_internal_auth_is_not_configured()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddPlatformJwtAuthentication(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var policy = provider.GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value.GetPolicy(AuthenticationExtensions.InternalGrpcPolicy);
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        policy.Should().NotBeNull();
+        policy!.AuthenticationSchemes.Should().ContainSingle()
+            .Which.Should().Be(JwtBearerDefaults.AuthenticationScheme);
+        (await schemes.GetSchemeAsync(AuthenticationExtensions.InternalJwtBearerScheme))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task InternalGrpc_policy_uses_internal_jwt_scheme_when_internal_auth_is_configured()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:TokenHeader"] = "X-Pomerium-Jwt-Assertion",
+                ["Auth:JwksUrl"] = "http://pomerium/.well-known/pomerium/jwks.json",
+                ["Auth:Audience"] = "urfu-link.ghjc.ru",
+                ["Auth:ValidIssuer"] = "urfu-link.ghjc.ru",
+                ["Auth:Internal:JwksUrl"] = "http://keycloak/realms/urfu-link/protocol/openid-connect/certs",
+                ["Auth:Internal:Audience"] = "urfu-link-api",
+                ["Auth:Internal:ValidIssuer"] = "https://id.ghjc.ru/realms/urfu-link",
+                ["Auth:Internal:RoleClaim"] = "groups",
+            })
+            .Build();
+
+        services.AddPlatformJwtAuthentication(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var policy = provider.GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value.GetPolicy(AuthenticationExtensions.InternalGrpcPolicy);
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        policy.Should().NotBeNull();
+        policy!.AuthenticationSchemes.Should().ContainSingle()
+            .Which.Should().Be(AuthenticationExtensions.InternalJwtBearerScheme);
+        (await schemes.GetSchemeAsync(AuthenticationExtensions.InternalJwtBearerScheme))
+            .Should().NotBeNull();
+    }
+}

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Auth\Auth.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Contracts\Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Observability\Observability.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />


### PR DESCRIPTION
## Summary
- add optional internal Keycloak JWT auth scheme and `InternalGrpc` authorization policy
- apply `InternalGrpc` to protected chat, presence, media, and discipline gRPC endpoints while preserving discipline role checks
- add prod Helm internal JWT validation env and preserve chat-service `internal_auth_client_secret` during Vault bootstrap

## Tests
- `dotnet test tests\unit\BuildingBlocks.UnitTests\BuildingBlocks.UnitTests.csproj`
- `dotnet test tests\integration\PresenceService.IntegrationTests\PresenceService.IntegrationTests.csproj`
- `dotnet test tests\integration\MediaService.IntegrationTests\MediaService.IntegrationTests.csproj`
- `dotnet test tests\integration\DisciplineService.IntegrationTests\DisciplineService.IntegrationTests.csproj`
- `dotnet test tests\integration\ChatService.IntegrationTests\ChatService.IntegrationTests.csproj --filter ChatHubTypingTests`
- `git diff --check`

## Prod validation after deploy
- `kubectl -n urfu-prod describe externalsecret chat-service-secrets` should be Ready
- chat-service logs should no longer show `PresenceService SetTyping failed ... 401`
- two-user prod typing test should show the typing indicator within one SignalR round trip