### PR TITLE
Fix internal gRPC auth roles

### DIFF
--- a/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
+++ b/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
@@ -329,6 +329,10 @@ spec:
               ensure_realm
               ensure_realm_role "service:discipline-read" \
                 "Allows internal gRPC reads on DisciplineService.InternalApi."
+              ensure_realm_role "service:media-internal" \
+                "Allows internal gRPC calls on MediaService.InternalApi."
+              ensure_realm_role "service:presence-internal" \
+                "Allows internal gRPC calls on PresenceService.InternalApi."
 
               # --- Linkerd Viz ---
               ensure_client "linkerd-viz" '["https://linkerd.ghjc.ru/oauth2/callback"]' '["https://linkerd.ghjc.ru"]' "false" "Linkerd Dashboard" "https://linkerd.ghjc.ru"
@@ -392,13 +396,19 @@ spec:
               DISCIPLINE_READ_ROLE="$(curl --silent --fail \
                 -H "Authorization: Bearer ${KC_TOKEN}" \
                 "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:discipline-read")"
+              MEDIA_INTERNAL_ROLE="$(curl --silent --fail \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:media-internal")"
+              PRESENCE_INTERNAL_ROLE="$(curl --silent --fail \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:presence-internal")"
               curl --fail --silent --show-error \
                 -X POST \
                 -H "Authorization: Bearer ${KC_TOKEN}" \
                 -H "Content-Type: application/json" \
                 "${KEYCLOAK_URL}/admin/realms/urfu-link/users/${CHAT_SA_ID}/role-mappings/realm" \
-                -d "[${DISCIPLINE_READ_ROLE}]" >/dev/null
-              echo "Granted service:discipline-read to chat-service-internal service account"
+                -d "[${DISCIPLINE_READ_ROLE},${MEDIA_INTERNAL_ROLE},${PRESENCE_INTERNAL_ROLE}]" >/dev/null
+              echo "Granted internal gRPC roles to chat-service-internal service account"
 
               # --- Frontend Web (public client for mobile) ---
               ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*","http://app.dev.127.0.0.1.nip.io/*"]' '["https://urfu-link.ghjc.ru","http://app.dev.127.0.0.1.nip.io"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"

--- a/platform/dev/keycloak/realm-urfu-link.json
+++ b/platform/dev/keycloak/realm-urfu-link.json
@@ -13,7 +13,9 @@
       { "name": "service" },
       { "name": "teacher", "description": "Discipline owner / instructor" },
       { "name": "student", "description": "Discipline participant" },
-      { "name": "service:discipline-read", "description": "Allows internal gRPC reads on DisciplineService.InternalApi (membership/listing)" }
+      { "name": "service:discipline-read", "description": "Allows internal gRPC reads on DisciplineService.InternalApi (membership/listing)" },
+      { "name": "service:media-internal", "description": "Allows internal gRPC calls on MediaService.InternalApi" },
+      { "name": "service:presence-internal", "description": "Allows internal gRPC calls on PresenceService.InternalApi" }
     ]
   },
   "clients": [
@@ -213,7 +215,7 @@
     {
       "clientId": "chat-service-internal",
       "name": "Chat Service (internal)",
-      "description": "Service-account client used by ChatService to call DisciplineService.InternalApi gRPC. The associated service-account user holds the realm role 'service:discipline-read'.",
+      "description": "Service-account client used by ChatService to call internal gRPC APIs. The associated service-account user holds service:* realm roles.",
       "enabled": true,
       "publicClient": false,
       "serviceAccountsEnabled": true,
@@ -336,7 +338,7 @@
       "username": "service-account-chat-service-internal",
       "enabled": true,
       "serviceAccountClientId": "chat-service-internal",
-      "realmRoles": ["service:discipline-read"]
+      "realmRoles": ["service:discipline-read", "service:media-internal", "service:presence-internal"]
     }
   ]
 }

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -76,7 +76,7 @@ public static class ModuleRegistration
             }
 
             // Built-in Grpc.Net retry on transient errors. ChatService relies on MediaService for
-            // attachment validation/grant; a single brief outage shouldn't fail SendMessage.
+            // attachment validation/grant; after retries are exhausted SendMessage must still fail.
             var retryPolicy = new RetryPolicy
             {
                 MaxAttempts = 3,

--- a/src/Services/Media/MediaService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
+++ b/src/Services/Media/MediaService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
@@ -1,0 +1,13 @@
+namespace MediaService.Api.Infrastructure.Auth;
+
+public static class InternalGrpcAuthorizationPolicy
+{
+    public const string PolicyName = "MediaInternalApi";
+
+    public const string MediaInternalRole = "service:media-internal";
+
+    public static readonly string[] AllowedRoles =
+    [
+        MediaInternalRole,
+    ];
+}

--- a/src/Services/Media/MediaService.Api/Program.cs
+++ b/src/Services/Media/MediaService.Api/Program.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using MediaService.Api.Infrastructure;
+using MediaService.Api.Infrastructure.Auth;
 using MediaService.Api.Infrastructure.Persistence;
 using MediaService.Api.Messaging;
 using MediaService.Api.Services;
@@ -43,6 +44,10 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "media-service");
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(InternalGrpcAuthorizationPolicy.PolicyName, policy => policy
+        .RequireAuthenticatedUser()
+        .RequireRole(InternalGrpcAuthorizationPolicy.AllowedRoles));
 
 // DataProtection keys persisted to Redis (so they survive pod restarts and scale-out).
 builder.Services.AddDataProtection().SetApplicationName("urfu-link-media-service");
@@ -69,7 +74,10 @@ app.UseFastEndpoints(c =>
 app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
+app.MapGrpcService<InternalApiService>()
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 
 await app.RunAsync();
 

--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
@@ -1,0 +1,13 @@
+namespace Urfu.Link.Services.Presence.Infrastructure.Auth;
+
+public static class InternalGrpcAuthorizationPolicy
+{
+    public const string PolicyName = "PresenceInternalApi";
+
+    public const string PresenceInternalRole = "service:presence-internal";
+
+    public static readonly string[] AllowedRoles =
+    [
+        PresenceInternalRole,
+    ];
+}

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -8,6 +8,7 @@ using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 using Urfu.Link.Services.Presence.Infrastructure;
 using Urfu.Link.Services.Presence.Infrastructure.Persistence;
 using Urfu.Link.Services.Presence.Messaging;
@@ -60,6 +61,10 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "presence-service");
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(InternalGrpcAuthorizationPolicy.PolicyName, policy => policy
+        .RequireAuthenticatedUser()
+        .RequireRole(InternalGrpcAuthorizationPolicy.AllowedRoles));
 
 // SignalR clients can't set the Authorization header during the WebSocket
 // upgrade handshake — accept the bearer token via ?access_token= for /hubs/*.
@@ -93,7 +98,10 @@ app.MapServiceDefaults();
 app.UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api/v1");
 app.UseSwaggerGen();
 app.MapScalarApiReference(o => o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
+app.MapGrpcService<InternalApiService>()
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 app.MapHub<PresenceHub>("/hubs/presence");
 
 await app.RunAsync();

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Images;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.MongoDb;
@@ -180,8 +182,11 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
@@ -1,6 +1,7 @@
 using DotNet.Testcontainers.Images;
 using DisciplineService.Api.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
@@ -105,8 +107,11 @@ public sealed class DisciplineServiceFactory : WebApplicationFactory<Program>, I
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
@@ -1,48 +1,43 @@
+using DisciplineService.Api.Infrastructure.Auth;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MediaService.Api.Infrastructure.Auth;
 using Urfu.Link.BuildingBlocks.Auth;
 
-namespace MediaService.IntegrationTests.Infrastructure;
+namespace DisciplineService.IntegrationTests.Infrastructure;
 
 [Collection(IntegrationCollection.Name)]
 public class GrpcAuthorizationTests
 {
-    private readonly MediaServiceFactory _factory;
+    private readonly DisciplineServiceFactory _factory;
 
-    public GrpcAuthorizationTests(MediaServiceFactory factory)
+    public GrpcAuthorizationTests(DisciplineServiceFactory factory)
     {
         _factory = factory;
     }
 
     [Fact]
-    public void InternalApiGrpcEndpoints_RequireAuthorization()
+    public void InternalApiGrpcEndpoints_UseInternalGrpcPolicy()
     {
-        // Force the host to build so endpoints are registered.
         _ = _factory.CreateClient();
 
         var dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
         var grpcEndpoints = dataSource.Endpoints
-            .Where(e => e.DisplayName?.Contains("media.internal.v1.InternalApi", StringComparison.Ordinal) == true)
+            .Where(e => e.DisplayName?.Contains("discipline.internal.v1.InternalApi", StringComparison.Ordinal) == true)
             .ToList();
 
-        grpcEndpoints.Should().NotBeEmpty(
-            "MediaService must expose the InternalApi gRPC service");
-
+        grpcEndpoints.Should().NotBeEmpty();
         foreach (var endpoint in grpcEndpoints)
         {
             var policies = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()
                 .Select(data => data.Policy)
                 .ToList();
 
-            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy,
-                "every gRPC endpoint on InternalApi must use internal gRPC authentication");
-            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName,
-                "every gRPC endpoint on InternalApi must require the media internal service role");
+            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy);
+            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName);
         }
 
         var options = _factory.Services.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
@@ -55,6 +50,6 @@ public class GrpcAuthorizationTests
         rolePolicy!.Requirements.OfType<RolesAuthorizationRequirement>()
             .Should().ContainSingle()
             .Which.AllowedRoles.Should()
-            .Contain(InternalGrpcAuthorizationPolicy.MediaInternalRole);
+            .Contain(InternalGrpcAuthorizationPolicy.DisciplineReadRole);
     }
 }

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -32,7 +32,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/MediaService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
+++ b/tests/integration/MediaService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using global::Grpc.Net.Client;
+using MediaService.Api.Infrastructure.Auth;
 using MediaService.Api.Grpc;
 using MediaService.IntegrationTests.Infrastructure;
 
@@ -34,7 +35,21 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
     private InternalApi.InternalApiClient AuthorizedClient(Guid userId)
     {
+        TestAuthHandler.CurrentPrincipal = TestAssetBuilder.MakeUser(
+            userId,
+            InternalGrpcAuthorizationPolicy.MediaInternalRole);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient ClientWithoutInternalRole(Guid userId)
+    {
         TestAuthHandler.CurrentPrincipal = TestAssetBuilder.MakeUser(userId);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient AnonymousClient()
+    {
+        TestAuthHandler.CurrentPrincipal = null;
         return new InternalApi.InternalApiClient(_channel);
     }
 
@@ -47,6 +62,27 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
         reply.Service.Should().Be("media-service");
         reply.Message.Should().Be("pong:hello");
+    }
+
+    [Fact]
+    public async Task Ping_WithoutAuthentication_IsRejected()
+    {
+        var client = AnonymousClient();
+        var act = () => client.PingAsync(new PingRequest { Message = "no-auth" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task Ping_WithoutMediaInternalRole_IsRejected()
+    {
+        var client = ClientWithoutInternalRole(Guid.NewGuid());
+        var act = () => client.PingAsync(new PingRequest { Message = "wrong-role" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.PermissionDenied
+                || ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
     }
 
     [Fact]

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
@@ -4,6 +4,7 @@ using DotNet.Testcontainers.Images;
 using MediaService.Api.Domain.Interfaces;
 using MediaService.Api.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.Minio;
@@ -174,8 +176,11 @@ public sealed class MediaServiceFactory : WebApplicationFactory<Program>, IAsync
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAssetBuilder.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAssetBuilder.cs
@@ -6,6 +6,7 @@ using MediaService.Api.Application.Contracts.Requests;
 using MediaService.Api.Application.Contracts.Responses;
 using MediaService.Api.Domain.Enums;
 using MediaService.Api.Grpc;
+using MediaService.Api.Infrastructure.Auth;
 
 namespace MediaService.IntegrationTests.Infrastructure;
 
@@ -18,8 +19,20 @@ public static class TestAssetBuilder
     /// <summary>Default in-memory payload used by helpers that just need "some bytes".</summary>
     public const int DefaultContentSize = 64;
 
-    public static ClaimsPrincipal MakeUser(Guid userId)
-        => new(new ClaimsIdentity([new Claim("sub", userId.ToString())], TestAuthHandler.SchemeName));
+    public static ClaimsPrincipal MakeUser(Guid userId, params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new("sub", userId.ToString()),
+        };
+        foreach (var role in roles ?? [])
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("groups", role));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, TestAuthHandler.SchemeName));
+    }
 
     public static HttpClient AuthorizedClient(MediaServiceFactory factory, Guid userId)
     {
@@ -37,7 +50,7 @@ public static class TestAssetBuilder
     public static (GrpcChannel Channel, HttpClient Http, InternalApi.InternalApiClient Client) CreateGrpcClient(
         MediaServiceFactory factory, Guid userId)
     {
-        TestAuthHandler.CurrentPrincipal = MakeUser(userId);
+        TestAuthHandler.CurrentPrincipal = MakeUser(userId, InternalGrpcAuthorizationPolicy.MediaInternalRole);
         var http = factory.CreateClient();
         var channel = GrpcChannel.ForAddress(http.BaseAddress!,
             new GrpcChannelOptions { HttpClient = http });

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -32,7 +32,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using global::Grpc.Net.Client;
 using Microsoft.Extensions.DependencyInjection;
 using PresenceService.IntegrationTests.Infrastructure;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 using Urfu.Link.Services.Presence.Domain.Enums;
 using Urfu.Link.Services.Presence.Domain.Interfaces;
 using Urfu.Link.Services.Presence.Domain.ValueObjects;
@@ -39,7 +40,21 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
     private InternalApi.InternalApiClient AuthorizedClient(Guid userId)
     {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.MakeUser(
+            userId,
+            roles: [InternalGrpcAuthorizationPolicy.PresenceInternalRole]);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient ClientWithoutInternalRole(Guid userId)
+    {
         TestAuthHandler.CurrentPrincipal = TestUserBuilder.MakeUser(userId);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient AnonymousClient()
+    {
+        TestAuthHandler.CurrentPrincipal = null;
         return new InternalApi.InternalApiClient(_channel);
     }
 
@@ -52,6 +67,49 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
         reply.Service.Should().Be("presence-service");
         reply.Message.Should().Be("pong:hi");
+    }
+
+    [Fact]
+    public async Task Ping_WithoutAuthentication_IsRejected()
+    {
+        var client = AnonymousClient();
+        var act = () => client.PingAsync(new PingRequest { Message = "no-auth" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task Ping_WithoutPresenceInternalRole_IsRejected()
+    {
+        var client = ClientWithoutInternalRole(Guid.NewGuid());
+        var act = () => client.PingAsync(new PingRequest { Message = "wrong-role" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.PermissionDenied
+                || ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task SetTyping_WithPresenceInternalRole_UpdatesTypingState()
+    {
+        var caller = Guid.NewGuid();
+        var conv = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var client = AuthorizedClient(caller);
+
+        var reply = await client.SetTypingAsync(new SetTypingRequest
+        {
+            ConversationId = conv.ToString(),
+            UserId = target.ToString(),
+            IsTyping = true,
+        });
+
+        reply.Changed.Should().BeTrue();
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var typing = scope.ServiceProvider.GetRequiredService<ITypingStore>();
+        var isTyping = await typing.IsTypingAsync(conv, target, CancellationToken.None);
+        isTyping.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
@@ -4,45 +4,40 @@ using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MediaService.Api.Infrastructure.Auth;
 using Urfu.Link.BuildingBlocks.Auth;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 
-namespace MediaService.IntegrationTests.Infrastructure;
+namespace PresenceService.IntegrationTests.Infrastructure;
 
 [Collection(IntegrationCollection.Name)]
 public class GrpcAuthorizationTests
 {
-    private readonly MediaServiceFactory _factory;
+    private readonly PresenceServiceFactory _factory;
 
-    public GrpcAuthorizationTests(MediaServiceFactory factory)
+    public GrpcAuthorizationTests(PresenceServiceFactory factory)
     {
         _factory = factory;
     }
 
     [Fact]
-    public void InternalApiGrpcEndpoints_RequireAuthorization()
+    public void InternalApiGrpcEndpoints_UseInternalGrpcPolicy()
     {
-        // Force the host to build so endpoints are registered.
         _ = _factory.CreateClient();
 
         var dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
         var grpcEndpoints = dataSource.Endpoints
-            .Where(e => e.DisplayName?.Contains("media.internal.v1.InternalApi", StringComparison.Ordinal) == true)
+            .Where(e => e.DisplayName?.Contains("presence.internal.v1.InternalApi", StringComparison.Ordinal) == true)
             .ToList();
 
-        grpcEndpoints.Should().NotBeEmpty(
-            "MediaService must expose the InternalApi gRPC service");
-
+        grpcEndpoints.Should().NotBeEmpty();
         foreach (var endpoint in grpcEndpoints)
         {
             var policies = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()
                 .Select(data => data.Policy)
                 .ToList();
 
-            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy,
-                "every gRPC endpoint on InternalApi must use internal gRPC authentication");
-            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName,
-                "every gRPC endpoint on InternalApi must require the media internal service role");
+            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy);
+            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName);
         }
 
         var options = _factory.Services.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
@@ -55,6 +50,6 @@ public class GrpcAuthorizationTests
         rolePolicy!.Requirements.OfType<RolesAuthorizationRequirement>()
             .Should().ContainSingle()
             .Which.AllowedRoles.Should()
-            .Contain(InternalGrpcAuthorizationPolicy.MediaInternalRole);
+            .Contain(InternalGrpcAuthorizationPolicy.PresenceInternalRole);
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Images;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
@@ -136,8 +138,11 @@ public sealed class PresenceServiceFactory : WebApplicationFactory<Program>, IAs
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -27,7 +27,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestUserBuilder.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestUserBuilder.cs
@@ -4,7 +4,7 @@ namespace PresenceService.IntegrationTests.Infrastructure;
 
 public static class TestUserBuilder
 {
-    public static ClaimsPrincipal MakeUser(Guid userId, string? deviceId = null)
+    public static ClaimsPrincipal MakeUser(Guid userId, string? deviceId = null, params string[] roles)
     {
         var claims = new List<Claim>
         {
@@ -14,6 +14,11 @@ public static class TestUserBuilder
         if (!string.IsNullOrEmpty(deviceId))
         {
             claims.Add(new Claim("device_id", deviceId));
+        }
+        foreach (var role in roles ?? [])
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("groups", role));
         }
 
         var identity = new ClaimsIdentity(claims, authenticationType: TestAuthHandler.SchemeName);

--- a/tests/unit/ChatService.UnitTests/Infrastructure/MediaServiceClientTests.cs
+++ b/tests/unit/ChatService.UnitTests/Infrastructure/MediaServiceClientTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Grpc.Core;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Infrastructure.Grpc;
+using MediaGrpc = MediaService.Api.Grpc;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Infrastructure;
+
+public sealed class MediaServiceClientTests
+{
+    [Fact]
+    public async Task BatchGetMetadataAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var assetId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var grpcClient = new StubInternalApiClient(assetId, ownerId);
+        var sut = new MediaServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"));
+
+        await sut.BatchGetMetadataAsync(new[] { assetId }, default);
+
+        grpcClient.LastBatchGetMetadataHeaders.Should().NotBeNull();
+        grpcClient.LastBatchGetMetadataHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
+    [Fact]
+    public async Task GrantConversationAccessAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var grpcClient = new StubInternalApiClient(Guid.NewGuid(), Guid.NewGuid());
+        var sut = new MediaServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"));
+
+        await sut.GrantConversationAccessAsync(
+            Guid.NewGuid(),
+            new[] { Guid.NewGuid() },
+            "conversation-1",
+            Guid.NewGuid(),
+            default);
+
+        grpcClient.LastGrantAssetAccessHeaders.Should().NotBeNull();
+        grpcClient.LastGrantAssetAccessHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
+    private sealed class StubInternalApiClient(Guid assetId, Guid ownerId)
+        : MediaGrpc.InternalApi.InternalApiClient
+    {
+        public Metadata? LastBatchGetMetadataHeaders { get; private set; }
+
+        public Metadata? LastGrantAssetAccessHeaders { get; private set; }
+
+        public override AsyncUnaryCall<MediaGrpc.BatchGetMetadataReply> BatchGetMetadataAsync(
+            MediaGrpc.BatchGetMetadataRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastBatchGetMetadataHeaders = headers;
+            return Unary(new MediaGrpc.BatchGetMetadataReply
+            {
+                Items =
+                {
+                    new MediaGrpc.AssetMetadata
+                    {
+                        AssetId = assetId.ToString("D"),
+                        OwnerId = ownerId.ToString("D"),
+                        Kind = (int)AttachmentType.Image,
+                        SizeBytes = 1024,
+                        MimeType = "image/png",
+                        OriginalFileName = "asset.png",
+                        State = MediaGrpc.AssetState.Uploaded,
+                    },
+                },
+            });
+        }
+
+        public override AsyncUnaryCall<MediaGrpc.GrantAssetAccessReply> GrantAssetAccessAsync(
+            MediaGrpc.GrantAssetAccessRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastGrantAssetAccessHeaders = headers;
+            return Unary(new MediaGrpc.GrantAssetAccessReply());
+        }
+    }
+
+    private sealed class StubGrpcBearerTokenProvider(string? token) : IGrpcBearerTokenProvider
+    {
+        public ValueTask<Metadata?> GetAuthorizationMetadataAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return ValueTask.FromResult<Metadata?>(null);
+            }
+
+            return ValueTask.FromResult<Metadata?>(new Metadata
+            {
+                { "authorization", $"Bearer {token}" },
+            });
+        }
+    }
+
+    private static AsyncUnaryCall<T> Unary<T>(T response)
+        => new(
+            Task.FromResult(response),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+}

--- a/tests/unit/ChatService.UnitTests/Infrastructure/PresenceServiceClientTests.cs
+++ b/tests/unit/ChatService.UnitTests/Infrastructure/PresenceServiceClientTests.cs
@@ -1,11 +1,30 @@
 using System.Globalization;
 using FluentAssertions;
+using Grpc.Core;
+using Microsoft.Extensions.Logging.Abstractions;
 using Urfu.Link.Services.Chat.Infrastructure.Grpc;
+using PresenceGrpc = Urfu.Link.Services.Presence.Grpc;
 
 namespace ChatService.UnitTests.Infrastructure;
 
 public sealed class PresenceServiceClientTests
 {
+    [Fact]
+    public async Task SetTypingAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var grpcClient = new StubInternalApiClient();
+        var sut = new PresenceServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"),
+            NullLogger<PresenceServiceClient>.Instance);
+
+        await sut.SetTypingAsync(Guid.NewGuid().ToString("D"), Guid.NewGuid(), isTyping: true, default);
+
+        grpcClient.LastSetTypingHeaders.Should().NotBeNull();
+        grpcClient.LastSetTypingHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
     [Fact]
     public void MapToConversationGuid_UsesFirstThirtyTwoHexCharsForDirectConversationIds()
     {
@@ -25,5 +44,41 @@ public sealed class PresenceServiceClientTests
 
         mapped.ToString("D", CultureInfo.InvariantCulture)
             .Should().Be("11111111-1111-4111-8111-111111111111");
+    }
+
+    private sealed class StubInternalApiClient : PresenceGrpc.InternalApi.InternalApiClient
+    {
+        public Metadata? LastSetTypingHeaders { get; private set; }
+
+        public override AsyncUnaryCall<PresenceGrpc.SetTypingReply> SetTypingAsync(
+            PresenceGrpc.SetTypingRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastSetTypingHeaders = headers;
+            return new AsyncUnaryCall<PresenceGrpc.SetTypingReply>(
+                Task.FromResult(new PresenceGrpc.SetTypingReply()),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+    }
+
+    private sealed class StubGrpcBearerTokenProvider(string? token) : IGrpcBearerTokenProvider
+    {
+        public ValueTask<Metadata?> GetAuthorizationMetadataAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return ValueTask.FromResult<Metadata?>(null);
+            }
+
+            return ValueTask.FromResult<Metadata?>(new Metadata
+            {
+                { "authorization", $"Bearer {token}" },
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- require the shared internal gRPC auth policy plus service-specific realm roles on Media, Presence, and Discipline internal APIs
- grant `service:media-internal` and `service:presence-internal` to `chat-service-internal` in Keycloak bootstrap/dev realm
- add integration/unit coverage for unauthenticated callers, missing roles, endpoint policy wiring, and chat-side bearer metadata on media/presence gRPC calls

## Notes
- `develop` already has the shared internal JWT wiring as `Auth:Internal` / `InternalGrpc`, so this PR extends that existing path instead of adding a second parallel `Auth:InternalGrpc` config namespace.

## Tests
- `dotnet build Urfu.Link.slnx`
- `dotnet vstest tests\integration\MediaService.IntegrationTests\bin\Debug\net10.0\MediaService.IntegrationTests.dll /TestCaseFilter:FullyQualifiedName~Grpc`
- `dotnet vstest tests\integration\PresenceService.IntegrationTests\bin\Debug\net10.0\PresenceService.IntegrationTests.dll /TestCaseFilter:FullyQualifiedName~Grpc`
- `dotnet vstest tests\integration\DisciplineService.IntegrationTests\bin\Debug\net10.0\DisciplineService.IntegrationTests.dll /TestCaseFilter:FullyQualifiedName~Grpc`
- `dotnet vstest tests\unit\ChatService.UnitTests\bin\Debug\net10.0\ChatService.UnitTests.dll /TestCaseFilter:FullyQualifiedName~Infrastructure`
- `dotnet vstest tests\integration\ChatService.IntegrationTests\bin\Debug\net10.0\ChatService.IntegrationTests.dll /TestCaseFilter:FullyQualifiedName~SendMessageServiceTests`
- `dotnet vstest tests\unit\BuildingBlocks.UnitTests\bin\Debug\net10.0\BuildingBlocks.UnitTests.dll /TestCaseFilter:FullyQualifiedName~AuthenticationExtensionsTests`