### PR TITLE
release: v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # URFU Link
 
+## Cluster Access
+
+- `root@89.167.93.199` is for cluster management and log viewing.
+
 Монорепозиторий под on-prem Kubernetes. Бэкенд — ASP.NET 10, шлюз YARP, идентичность через Keycloak, очереди Kafka, данные в PostgreSQL/MongoDB/Redis/MinIO. Фронт — Expo Router (web + mobile). Доставка: GitHub Actions + Argo CD, деплой Blue/Green.
 
 **Стек зафиксирован:** один регион, self-hosted Kafka (KRaft), LiveKit + Coturn для медиа, Linkerd + Viz как service mesh.

--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -93,6 +93,14 @@ const buildMessageListItems = (messages: MessageDto[]): MessageListItem[] => {
     return items;
 };
 
+const getDateStickyHeaderIndices = (items: MessageListItem[], stickyOffset = 0) =>
+    items.reduce<number[]>((indices, item, index) => {
+        if (item.type === "date") {
+            indices.push(index + stickyOffset);
+        }
+        return indices;
+    }, []);
+
 const getMessageListItemKey = (item: MessageListItem) => item.id;
 
 const waitForListUpdate = () => new Promise((resolve) => setTimeout(resolve, 50));
@@ -101,6 +109,7 @@ const styles = StyleSheet.create({
     dateSeparator: {
         marginTop: 24,
         marginBottom: 4,
+        zIndex: 2,
     },
     firstDateSeparator: {
         marginTop: 0,
@@ -158,6 +167,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         const isLoaded = messagesLoadedByConversation[chatId] || false;
         const hasMore = hasMoreByConversation[chatId] || false;
         const listItems = useMemo(() => buildMessageListItems(messages), [messages]);
+        const stickyHeaderIndices = useMemo(
+            () => getDateStickyHeaderIndices(listItems, 1),
+            [listItems],
+        );
         const listRef = useRef<FlatList<MessageListItem>>(null);
         const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
         const highlightOpacity = useRef(new Animated.Value(0)).current;
@@ -503,6 +516,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
                     contentContainerStyle={{
                         flexGrow: 1,
                     }}
+                    stickyHeaderIndices={stickyHeaderIndices}
+                    invertStickyHeaders
                     onViewableItemsChanged={handleViewableItemsChanged}
                     viewabilityConfig={viewabilityConfig}
                     renderItem={renderItem}

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -190,7 +190,7 @@ describe("MessagesList loading state", () => {
         });
     });
 
-    it("renders a single date separator per message day", () => {
+    it("renders date separators as sticky list rows", () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date("2026-05-24T12:00:00.000Z"));
         mockChatState = {
@@ -218,6 +218,11 @@ describe("MessagesList loading state", () => {
 
         render(<MessagesList chatId="chat-dates" type="chat" />);
 
+        const list = screen.UNSAFE_getByType(FlatList);
+        expect(screen.getByTestId("message-date-separator-2026-05-24")).toBeTruthy();
+        expect(screen.getByTestId("message-date-separator-2026-05-23")).toBeTruthy();
+        expect(list.props.stickyHeaderIndices).toEqual([2, 4]);
+        expect(list.props.invertStickyHeaders).toBe(true);
         expect(screen.getAllByText("Сегодня")).toHaveLength(1);
         expect(screen.getByText(/мая/)).toBeTruthy();
         jest.useRealTimers();

--- a/deploy/helm/services/chat-service/values-prod.yaml
+++ b/deploy/helm/services/chat-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
   GrpcClients__InternalAuth__TokenEndpoint: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/token
   GrpcClients__InternalAuth__ClientId: chat-service-internal

--- a/deploy/helm/services/discipline-service/values-prod.yaml
+++ b/deploy/helm/services/discipline-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
 
 secrets:

--- a/deploy/helm/services/media-service/values-prod.yaml
+++ b/deploy/helm/services/media-service/values-prod.yaml
@@ -25,6 +25,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
   Storage__Endpoint: http://urfu-minio.urfu-platform.svc.cluster.local:9000
   Storage__PublicEndpoint: https://storage.ghjc.ru

--- a/deploy/helm/services/presence-service/values-prod.yaml
+++ b/deploy/helm/services/presence-service/values-prod.yaml
@@ -27,6 +27,10 @@ env:
   Auth__ValidIssuer: urfu-link.ghjc.ru
   Auth__NameClaim: email
   Auth__RoleClaim: groups
+  Auth__Internal__JwksUrl: http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/protocol/openid-connect/certs
+  Auth__Internal__Audience: urfu-link-api
+  Auth__Internal__ValidIssuer: https://id.ghjc.ru/realms/urfu-link
+  Auth__Internal__RoleClaim: groups
   Infrastructure__Redis__Configuration: urfu-redis.urfu-platform.svc.cluster.local:6379
 
 secrets:

--- a/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
+++ b/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
@@ -329,6 +329,10 @@ spec:
               ensure_realm
               ensure_realm_role "service:discipline-read" \
                 "Allows internal gRPC reads on DisciplineService.InternalApi."
+              ensure_realm_role "service:media-internal" \
+                "Allows internal gRPC calls on MediaService.InternalApi."
+              ensure_realm_role "service:presence-internal" \
+                "Allows internal gRPC calls on PresenceService.InternalApi."
 
               # --- Linkerd Viz ---
               ensure_client "linkerd-viz" '["https://linkerd.ghjc.ru/oauth2/callback"]' '["https://linkerd.ghjc.ru"]' "false" "Linkerd Dashboard" "https://linkerd.ghjc.ru"
@@ -392,13 +396,19 @@ spec:
               DISCIPLINE_READ_ROLE="$(curl --silent --fail \
                 -H "Authorization: Bearer ${KC_TOKEN}" \
                 "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:discipline-read")"
+              MEDIA_INTERNAL_ROLE="$(curl --silent --fail \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:media-internal")"
+              PRESENCE_INTERNAL_ROLE="$(curl --silent --fail \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/roles/service:presence-internal")"
               curl --fail --silent --show-error \
                 -X POST \
                 -H "Authorization: Bearer ${KC_TOKEN}" \
                 -H "Content-Type: application/json" \
                 "${KEYCLOAK_URL}/admin/realms/urfu-link/users/${CHAT_SA_ID}/role-mappings/realm" \
-                -d "[${DISCIPLINE_READ_ROLE}]" >/dev/null
-              echo "Granted service:discipline-read to chat-service-internal service account"
+                -d "[${DISCIPLINE_READ_ROLE},${MEDIA_INTERNAL_ROLE},${PRESENCE_INTERNAL_ROLE}]" >/dev/null
+              echo "Granted internal gRPC roles to chat-service-internal service account"
 
               # --- Frontend Web (public client for mobile) ---
               ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*","http://app.dev.127.0.0.1.nip.io/*"]' '["https://urfu-link.ghjc.ru","http://app.dev.127.0.0.1.nip.io"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"

--- a/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
+++ b/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
@@ -369,7 +369,13 @@ spec:
               fi
               MEDIA_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=media_db;Username=media;Password=%s"}}' "$MEDIA_DB_PASSWORD")"
               DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s"}}' "$DISCIPLINE_DB_PASSWORD")"
-              CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
+              EXISTING_CHAT_SVC="$(vault_read urfu-link/prod/chat-service)"
+              EXISTING_INTERNAL_AUTH_SECRET="$(json_get_string "$EXISTING_CHAT_SVC" internal_auth_client_secret)"
+              if [ -n "$EXISTING_INTERNAL_AUTH_SECRET" ]; then
+                CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin","internal_auth_client_secret":"%s"}}' "$MONGO_APP_PASSWORD" "$EXISTING_INTERNAL_AUTH_SECRET")"
+              else
+                CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
+              fi
               PRESENCE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s"}}' "$PRESENCE_DB_PASSWORD")"
               NOTIFICATION_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s","kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}' "$NOTIFICATION_DB_PASSWORD")"
               CALL_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'

--- a/platform/dev/keycloak/realm-urfu-link.json
+++ b/platform/dev/keycloak/realm-urfu-link.json
@@ -13,7 +13,9 @@
       { "name": "service" },
       { "name": "teacher", "description": "Discipline owner / instructor" },
       { "name": "student", "description": "Discipline participant" },
-      { "name": "service:discipline-read", "description": "Allows internal gRPC reads on DisciplineService.InternalApi (membership/listing)" }
+      { "name": "service:discipline-read", "description": "Allows internal gRPC reads on DisciplineService.InternalApi (membership/listing)" },
+      { "name": "service:media-internal", "description": "Allows internal gRPC calls on MediaService.InternalApi" },
+      { "name": "service:presence-internal", "description": "Allows internal gRPC calls on PresenceService.InternalApi" }
     ]
   },
   "clients": [
@@ -213,7 +215,7 @@
     {
       "clientId": "chat-service-internal",
       "name": "Chat Service (internal)",
-      "description": "Service-account client used by ChatService to call DisciplineService.InternalApi gRPC. The associated service-account user holds the realm role 'service:discipline-read'.",
+      "description": "Service-account client used by ChatService to call internal gRPC APIs. The associated service-account user holds service:* realm roles.",
       "enabled": true,
       "publicClient": false,
       "serviceAccountsEnabled": true,
@@ -336,7 +338,7 @@
       "username": "service-account-chat-service-internal",
       "enabled": true,
       "serviceAccountClientId": "chat-service-internal",
-      "realmRoles": ["service:discipline-read"]
+      "realmRoles": ["service:discipline-read", "service:media-internal", "service:presence-internal"]
     }
   ]
 }

--- a/src/BuildingBlocks/Auth/AuthenticationExtensions.cs
+++ b/src/BuildingBlocks/Auth/AuthenticationExtensions.cs
@@ -9,6 +9,9 @@ namespace Urfu.Link.BuildingBlocks.Auth;
 
 public static class AuthenticationExtensions
 {
+    public const string InternalJwtBearerScheme = "InternalJwtBearer";
+    public const string InternalGrpcPolicy = "InternalGrpc";
+
     public static IServiceCollection AddPlatformJwtAuthentication(
         this IServiceCollection services,
         IConfiguration configuration)
@@ -16,65 +19,119 @@ public static class AuthenticationExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var tokenHeader = configuration["Auth:TokenHeader"];
-        var jwksUrl = configuration["Auth:JwksUrl"];
-        var authority = configuration["Auth:Authority"] ?? "http://localhost:8080/realms/urfu-link";
-        var audience = configuration["Auth:Audience"] ?? "urfu-link-api";
-        var metadataAddress = configuration["Auth:MetadataAddress"];
-        var validIssuer = configuration["Auth:ValidIssuer"];
-        var nameClaim = configuration["Auth:NameClaim"] ?? "preferred_username";
-        var roleClaim = configuration["Auth:RoleClaim"] ?? "roles";
+        var defaultJwt = PlatformJwtOptions.From(configuration.GetSection("Auth"));
+        var internalJwt = PlatformJwtOptions.From(configuration.GetSection("Auth:Internal"));
+        var hasInternalJwt = internalJwt.HasExplicitIssuerSource;
 
-        services
+        var authentication = services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
+            .AddJwtBearer(options => ConfigureJwtBearer(options, defaultJwt, useTokenHeader: true));
+
+        if (hasInternalJwt)
+        {
+            authentication.AddJwtBearer(
+                InternalJwtBearerScheme,
+                options => ConfigureJwtBearer(options, internalJwt, useTokenHeader: false));
+        }
+
+        services.AddAuthorizationBuilder()
+            .AddPolicy(InternalGrpcPolicy, policy =>
             {
-                if (!string.IsNullOrEmpty(tokenHeader))
-                {
-                    options.Events = new JwtBearerEvents
-                    {
-                        OnMessageReceived = context =>
-                        {
-                            var jwt = context.Request.Headers[tokenHeader].FirstOrDefault();
-                            if (!string.IsNullOrEmpty(jwt))
-                                context.Token = jwt;
-                            return Task.CompletedTask;
-                        }
-                    };
-                }
-
-                if (!string.IsNullOrEmpty(jwksUrl))
-                {
-                    options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-                        jwksUrl,
-                        new JwksRetriever(),
-                        new HttpDocumentRetriever { RequireHttps = false });
-                }
-                else
-                {
-                    options.Authority = authority;
-                    if (!string.IsNullOrEmpty(metadataAddress))
-                        options.MetadataAddress = metadataAddress;
-                    options.RequireHttpsMetadata = Uri.TryCreate(authority, UriKind.Absolute, out var authorityUri)
-                        && authorityUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
-                }
-
-                options.Audience = audience;
-                options.MapInboundClaims = false;
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateAudience = true,
-                    ValidAudience = audience,
-                    ValidateIssuer = true,
-                    ValidIssuer = validIssuer ?? authority,
-                    NameClaimType = nameClaim,
-                    RoleClaimType = roleClaim,
-                };
+                policy.AddAuthenticationSchemes(
+                    hasInternalJwt
+                        ? InternalJwtBearerScheme
+                        : JwtBearerDefaults.AuthenticationScheme);
+                policy.RequireAuthenticatedUser();
             });
 
-        services.AddAuthorization();
-
         return services;
+    }
+
+    private static void ConfigureJwtBearer(
+        JwtBearerOptions options,
+        PlatformJwtOptions jwt,
+        bool useTokenHeader)
+    {
+        if (useTokenHeader && !string.IsNullOrEmpty(jwt.TokenHeader))
+        {
+            options.Events = new JwtBearerEvents
+            {
+                OnMessageReceived = context =>
+                {
+                    var token = context.Request.Headers[jwt.TokenHeader].FirstOrDefault();
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        context.Token = token;
+                    }
+
+                    return Task.CompletedTask;
+                },
+            };
+        }
+
+        if (!string.IsNullOrEmpty(jwt.JwksUrl))
+        {
+            options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                jwt.JwksUrl,
+                new JwksRetriever(),
+                new HttpDocumentRetriever { RequireHttps = false });
+        }
+        else
+        {
+            options.Authority = jwt.Authority;
+            if (!string.IsNullOrEmpty(jwt.MetadataAddress))
+            {
+                options.MetadataAddress = jwt.MetadataAddress;
+            }
+
+            options.RequireHttpsMetadata = Uri.TryCreate(jwt.Authority, UriKind.Absolute, out var authorityUri)
+                && authorityUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+        }
+
+        options.Audience = jwt.Audience;
+        options.MapInboundClaims = false;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateAudience = true,
+            ValidAudience = jwt.Audience,
+            ValidateIssuer = true,
+            ValidIssuer = jwt.ValidIssuer ?? jwt.Authority,
+            NameClaimType = jwt.NameClaim,
+            RoleClaimType = jwt.RoleClaim,
+        };
+    }
+
+    private sealed record PlatformJwtOptions(
+        string? TokenHeader,
+        string? JwksUrl,
+        string Authority,
+        string Audience,
+        string? MetadataAddress,
+        string? ValidIssuer,
+        string NameClaim,
+        string RoleClaim,
+        bool HasExplicitIssuerSource)
+    {
+        public static PlatformJwtOptions From(IConfiguration section)
+        {
+            ArgumentNullException.ThrowIfNull(section);
+
+            var hasExplicitIssuerSource =
+                !string.IsNullOrWhiteSpace(section["JwksUrl"])
+                || !string.IsNullOrWhiteSpace(section["Authority"])
+                || !string.IsNullOrWhiteSpace(section["MetadataAddress"]);
+
+            return new PlatformJwtOptions(
+                section["TokenHeader"],
+                section["JwksUrl"],
+                section["Authority"] ?? "http://localhost:8080/realms/urfu-link",
+                section["Audience"] ?? "urfu-link-api",
+                section["MetadataAddress"],
+                section["ValidIssuer"],
+                section["NameClaim"] ?? "preferred_username",
+                section["RoleClaim"] ?? "roles",
+                hasExplicitIssuerSource);
+        }
     }
 
     private sealed class JwksRetriever : IConfigurationRetriever<OpenIdConnectConfiguration>

--- a/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
+++ b/src/Services/Chat/ChatService.Api/Infrastructure/DependencyInjection.cs
@@ -76,7 +76,7 @@ public static class ModuleRegistration
             }
 
             // Built-in Grpc.Net retry on transient errors. ChatService relies on MediaService for
-            // attachment validation/grant; a single brief outage shouldn't fail SendMessage.
+            // attachment validation/grant; after retries are exhausted SendMessage must still fail.
             var retryPolicy = new RetryPolicy
             {
                 MaxAttempts = 3,

--- a/src/Services/Chat/ChatService.Api/Program.cs
+++ b/src/Services/Chat/ChatService.Api/Program.cs
@@ -2,6 +2,7 @@ using FastEndpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.SignalR;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Domain;
@@ -77,7 +78,7 @@ app.UseFastEndpoints(c =>
     c.Serializer.Options.Converters.Add(
         new System.Text.Json.Serialization.JsonStringEnumConverter());
 });
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 app.MapHub<ChatHub>("/hubs/chat");
 
 app.MapGet("/", (ServiceProfile descriptor) => Results.Ok(new

--- a/src/Services/Discipline/DisciplineService.Api/Program.cs
+++ b/src/Services/Discipline/DisciplineService.Api/Program.cs
@@ -7,6 +7,7 @@ using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.EntityFrameworkCore;
 using Scalar.AspNetCore;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
@@ -71,7 +72,9 @@ app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
 app.MapGrpcService<InternalApiService>()
-    .RequireAuthorization(InternalGrpcAuthorizationPolicy.PolicyName);
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 
 await app.RunAsync();
 

--- a/src/Services/Media/MediaService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
+++ b/src/Services/Media/MediaService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
@@ -1,0 +1,13 @@
+namespace MediaService.Api.Infrastructure.Auth;
+
+public static class InternalGrpcAuthorizationPolicy
+{
+    public const string PolicyName = "MediaInternalApi";
+
+    public const string MediaInternalRole = "service:media-internal";
+
+    public static readonly string[] AllowedRoles =
+    [
+        MediaInternalRole,
+    ];
+}

--- a/src/Services/Media/MediaService.Api/Program.cs
+++ b/src/Services/Media/MediaService.Api/Program.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using MediaService.Api.Infrastructure;
+using MediaService.Api.Infrastructure.Auth;
 using MediaService.Api.Infrastructure.Persistence;
 using MediaService.Api.Messaging;
 using MediaService.Api.Services;
@@ -43,6 +44,10 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "media-service");
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(InternalGrpcAuthorizationPolicy.PolicyName, policy => policy
+        .RequireAuthenticatedUser()
+        .RequireRole(InternalGrpcAuthorizationPolicy.AllowedRoles));
 
 // DataProtection keys persisted to Redis (so they survive pod restarts and scale-out).
 builder.Services.AddDataProtection().SetApplicationName("urfu-link-media-service");
@@ -69,7 +74,10 @@ app.UseFastEndpoints(c =>
 app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
+app.MapGrpcService<InternalApiService>()
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 
 await app.RunAsync();
 

--- a/src/Services/Media/MediaService.Api/Program.cs
+++ b/src/Services/Media/MediaService.Api/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 
@@ -68,7 +69,7 @@ app.UseFastEndpoints(c =>
 app.UseSwaggerGen();
 app.MapScalarApiReference(o =>
     o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 
 await app.RunAsync();
 

--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Auth/InternalGrpcAuthorizationPolicy.cs
@@ -1,0 +1,13 @@
+namespace Urfu.Link.Services.Presence.Infrastructure.Auth;
+
+public static class InternalGrpcAuthorizationPolicy
+{
+    public const string PolicyName = "PresenceInternalApi";
+
+    public const string PresenceInternalRole = "service:presence-internal";
+
+    public static readonly string[] AllowedRoles =
+    [
+        PresenceInternalRole,
+    ];
+}

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -8,6 +8,7 @@ using StackExchange.Redis;
 using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 using Urfu.Link.Services.Presence.Infrastructure;
 using Urfu.Link.Services.Presence.Infrastructure.Persistence;
 using Urfu.Link.Services.Presence.Messaging;
@@ -60,6 +61,10 @@ builder.Services.SwaggerDocument(o =>
 });
 
 builder.Services.AddServiceDefaults(builder.Configuration, "presence-service");
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(InternalGrpcAuthorizationPolicy.PolicyName, policy => policy
+        .RequireAuthenticatedUser()
+        .RequireRole(InternalGrpcAuthorizationPolicy.AllowedRoles));
 
 // SignalR clients can't set the Authorization header during the WebSocket
 // upgrade handshake — accept the bearer token via ?access_token= for /hubs/*.
@@ -93,7 +98,10 @@ app.MapServiceDefaults();
 app.UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api/v1");
 app.UseSwaggerGen();
 app.MapScalarApiReference(o => o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
+app.MapGrpcService<InternalApiService>()
+    .RequireAuthorization(
+        AuthenticationExtensions.InternalGrpcPolicy,
+        InternalGrpcAuthorizationPolicy.PolicyName);
 app.MapHub<PresenceHub>("/hubs/presence");
 
 await app.RunAsync();

--- a/src/Services/Presence/PresenceService.Api/Program.cs
+++ b/src/Services/Presence/PresenceService.Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.BuildingBlocks.ServiceDefaults;
 using Urfu.Link.Services.Presence.Infrastructure;
@@ -92,7 +93,7 @@ app.MapServiceDefaults();
 app.UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api/v1");
 app.UseSwaggerGen();
 app.MapScalarApiReference(o => o.WithOpenApiRoutePattern("/swagger/v1/swagger.json"));
-app.MapGrpcService<InternalApiService>().RequireAuthorization();
+app.MapGrpcService<InternalApiService>().RequireAuthorization(AuthenticationExtensions.InternalGrpcPolicy);
 app.MapHub<PresenceHub>("/hubs/presence");
 
 await app.RunAsync();

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Images;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.MongoDb;
@@ -180,8 +182,11 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
+++ b/tests/integration/ChatService.IntegrationTests/Infrastructure/ChatServiceFactory.cs
@@ -11,6 +11,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.MongoDb;
 using Testcontainers.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Chat.Application.Authorization;
@@ -190,5 +191,11 @@ public sealed class ChatServiceFactory : WebApplicationFactory<Program>, IAsyncL
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 
@@ -115,5 +116,11 @@ public sealed class DisciplineServiceFactory : WebApplicationFactory<Program>, I
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/DisciplineServiceFactory.cs
@@ -1,6 +1,7 @@
 using DotNet.Testcontainers.Images;
 using DisciplineService.Api.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
@@ -105,8 +107,11 @@ public sealed class DisciplineServiceFactory : WebApplicationFactory<Program>, I
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
@@ -1,48 +1,43 @@
+using DisciplineService.Api.Infrastructure.Auth;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MediaService.Api.Infrastructure.Auth;
 using Urfu.Link.BuildingBlocks.Auth;
 
-namespace MediaService.IntegrationTests.Infrastructure;
+namespace DisciplineService.IntegrationTests.Infrastructure;
 
 [Collection(IntegrationCollection.Name)]
 public class GrpcAuthorizationTests
 {
-    private readonly MediaServiceFactory _factory;
+    private readonly DisciplineServiceFactory _factory;
 
-    public GrpcAuthorizationTests(MediaServiceFactory factory)
+    public GrpcAuthorizationTests(DisciplineServiceFactory factory)
     {
         _factory = factory;
     }
 
     [Fact]
-    public void InternalApiGrpcEndpoints_RequireAuthorization()
+    public void InternalApiGrpcEndpoints_UseInternalGrpcPolicy()
     {
-        // Force the host to build so endpoints are registered.
         _ = _factory.CreateClient();
 
         var dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
         var grpcEndpoints = dataSource.Endpoints
-            .Where(e => e.DisplayName?.Contains("media.internal.v1.InternalApi", StringComparison.Ordinal) == true)
+            .Where(e => e.DisplayName?.Contains("discipline.internal.v1.InternalApi", StringComparison.Ordinal) == true)
             .ToList();
 
-        grpcEndpoints.Should().NotBeEmpty(
-            "MediaService must expose the InternalApi gRPC service");
-
+        grpcEndpoints.Should().NotBeEmpty();
         foreach (var endpoint in grpcEndpoints)
         {
             var policies = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()
                 .Select(data => data.Policy)
                 .ToList();
 
-            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy,
-                "every gRPC endpoint on InternalApi must use internal gRPC authentication");
-            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName,
-                "every gRPC endpoint on InternalApi must require the media internal service role");
+            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy);
+            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName);
         }
 
         var options = _factory.Services.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
@@ -55,6 +50,6 @@ public class GrpcAuthorizationTests
         rolePolicy!.Requirements.OfType<RolesAuthorizationRequirement>()
             .Should().ContainSingle()
             .Which.AllowedRoles.Should()
-            .Contain(InternalGrpcAuthorizationPolicy.MediaInternalRole);
+            .Contain(InternalGrpcAuthorizationPolicy.DisciplineReadRole);
     }
 }

--- a/tests/integration/DisciplineService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/DisciplineService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -32,7 +32,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/MediaService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
+++ b/tests/integration/MediaService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using global::Grpc.Net.Client;
+using MediaService.Api.Infrastructure.Auth;
 using MediaService.Api.Grpc;
 using MediaService.IntegrationTests.Infrastructure;
 
@@ -34,7 +35,21 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
     private InternalApi.InternalApiClient AuthorizedClient(Guid userId)
     {
+        TestAuthHandler.CurrentPrincipal = TestAssetBuilder.MakeUser(
+            userId,
+            InternalGrpcAuthorizationPolicy.MediaInternalRole);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient ClientWithoutInternalRole(Guid userId)
+    {
         TestAuthHandler.CurrentPrincipal = TestAssetBuilder.MakeUser(userId);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient AnonymousClient()
+    {
+        TestAuthHandler.CurrentPrincipal = null;
         return new InternalApi.InternalApiClient(_channel);
     }
 
@@ -47,6 +62,27 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
         reply.Service.Should().Be("media-service");
         reply.Message.Should().Be("pong:hello");
+    }
+
+    [Fact]
+    public async Task Ping_WithoutAuthentication_IsRejected()
+    {
+        var client = AnonymousClient();
+        var act = () => client.PingAsync(new PingRequest { Message = "no-auth" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task Ping_WithoutMediaInternalRole_IsRejected()
+    {
+        var client = ClientWithoutInternalRole(Guid.NewGuid());
+        var act = () => client.PingAsync(new PingRequest { Message = "wrong-role" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.PermissionDenied
+                || ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
     }
 
     [Fact]

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
@@ -4,6 +4,7 @@ using DotNet.Testcontainers.Images;
 using MediaService.Api.Domain.Interfaces;
 using MediaService.Api.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.Minio;
@@ -174,8 +176,11 @@ public sealed class MediaServiceFactory : WebApplicationFactory<Program>, IAsync
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/MediaServiceFactory.cs
@@ -15,6 +15,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.Minio;
 using Testcontainers.PostgreSql;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 
@@ -184,5 +185,11 @@ public sealed class MediaServiceFactory : WebApplicationFactory<Program>, IAsync
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAssetBuilder.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAssetBuilder.cs
@@ -6,6 +6,7 @@ using MediaService.Api.Application.Contracts.Requests;
 using MediaService.Api.Application.Contracts.Responses;
 using MediaService.Api.Domain.Enums;
 using MediaService.Api.Grpc;
+using MediaService.Api.Infrastructure.Auth;
 
 namespace MediaService.IntegrationTests.Infrastructure;
 
@@ -18,8 +19,20 @@ public static class TestAssetBuilder
     /// <summary>Default in-memory payload used by helpers that just need "some bytes".</summary>
     public const int DefaultContentSize = 64;
 
-    public static ClaimsPrincipal MakeUser(Guid userId)
-        => new(new ClaimsIdentity([new Claim("sub", userId.ToString())], TestAuthHandler.SchemeName));
+    public static ClaimsPrincipal MakeUser(Guid userId, params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new("sub", userId.ToString()),
+        };
+        foreach (var role in roles ?? [])
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("groups", role));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, TestAuthHandler.SchemeName));
+    }
 
     public static HttpClient AuthorizedClient(MediaServiceFactory factory, Guid userId)
     {
@@ -37,7 +50,7 @@ public static class TestAssetBuilder
     public static (GrpcChannel Channel, HttpClient Http, InternalApi.InternalApiClient Client) CreateGrpcClient(
         MediaServiceFactory factory, Guid userId)
     {
-        TestAuthHandler.CurrentPrincipal = MakeUser(userId);
+        TestAuthHandler.CurrentPrincipal = MakeUser(userId, InternalGrpcAuthorizationPolicy.MediaInternalRole);
         var http = factory.CreateClient();
         var channel = GrpcChannel.ForAddress(http.BaseAddress!,
             new GrpcChannelOptions { HttpClient = http });

--- a/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/MediaService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -32,7 +32,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Grpc/InternalApiGrpcTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using global::Grpc.Net.Client;
 using Microsoft.Extensions.DependencyInjection;
 using PresenceService.IntegrationTests.Infrastructure;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 using Urfu.Link.Services.Presence.Domain.Enums;
 using Urfu.Link.Services.Presence.Domain.Interfaces;
 using Urfu.Link.Services.Presence.Domain.ValueObjects;
@@ -39,7 +40,21 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
     private InternalApi.InternalApiClient AuthorizedClient(Guid userId)
     {
+        TestAuthHandler.CurrentPrincipal = TestUserBuilder.MakeUser(
+            userId,
+            roles: [InternalGrpcAuthorizationPolicy.PresenceInternalRole]);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient ClientWithoutInternalRole(Guid userId)
+    {
         TestAuthHandler.CurrentPrincipal = TestUserBuilder.MakeUser(userId);
+        return new InternalApi.InternalApiClient(_channel);
+    }
+
+    private InternalApi.InternalApiClient AnonymousClient()
+    {
+        TestAuthHandler.CurrentPrincipal = null;
         return new InternalApi.InternalApiClient(_channel);
     }
 
@@ -52,6 +67,49 @@ public sealed class InternalApiGrpcTests : IAsyncLifetime
 
         reply.Service.Should().Be("presence-service");
         reply.Message.Should().Be("pong:hi");
+    }
+
+    [Fact]
+    public async Task Ping_WithoutAuthentication_IsRejected()
+    {
+        var client = AnonymousClient();
+        var act = () => client.PingAsync(new PingRequest { Message = "no-auth" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task Ping_WithoutPresenceInternalRole_IsRejected()
+    {
+        var client = ClientWithoutInternalRole(Guid.NewGuid());
+        var act = () => client.PingAsync(new PingRequest { Message = "wrong-role" }).ResponseAsync;
+
+        await act.Should().ThrowAsync<global::Grpc.Core.RpcException>()
+            .Where(ex => ex.StatusCode == global::Grpc.Core.StatusCode.PermissionDenied
+                || ex.StatusCode == global::Grpc.Core.StatusCode.Unauthenticated);
+    }
+
+    [Fact]
+    public async Task SetTyping_WithPresenceInternalRole_UpdatesTypingState()
+    {
+        var caller = Guid.NewGuid();
+        var conv = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var client = AuthorizedClient(caller);
+
+        var reply = await client.SetTypingAsync(new SetTypingRequest
+        {
+            ConversationId = conv.ToString(),
+            UserId = target.ToString(),
+            IsTyping = true,
+        });
+
+        reply.Changed.Should().BeTrue();
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var typing = scope.ServiceProvider.GetRequiredService<ITypingStore>();
+        var isTyping = await typing.IsTypingAsync(conv, target, CancellationToken.None);
+        isTyping.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/GrpcAuthorizationTests.cs
@@ -4,45 +4,40 @@ using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MediaService.Api.Infrastructure.Auth;
 using Urfu.Link.BuildingBlocks.Auth;
+using Urfu.Link.Services.Presence.Infrastructure.Auth;
 
-namespace MediaService.IntegrationTests.Infrastructure;
+namespace PresenceService.IntegrationTests.Infrastructure;
 
 [Collection(IntegrationCollection.Name)]
 public class GrpcAuthorizationTests
 {
-    private readonly MediaServiceFactory _factory;
+    private readonly PresenceServiceFactory _factory;
 
-    public GrpcAuthorizationTests(MediaServiceFactory factory)
+    public GrpcAuthorizationTests(PresenceServiceFactory factory)
     {
         _factory = factory;
     }
 
     [Fact]
-    public void InternalApiGrpcEndpoints_RequireAuthorization()
+    public void InternalApiGrpcEndpoints_UseInternalGrpcPolicy()
     {
-        // Force the host to build so endpoints are registered.
         _ = _factory.CreateClient();
 
         var dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
         var grpcEndpoints = dataSource.Endpoints
-            .Where(e => e.DisplayName?.Contains("media.internal.v1.InternalApi", StringComparison.Ordinal) == true)
+            .Where(e => e.DisplayName?.Contains("presence.internal.v1.InternalApi", StringComparison.Ordinal) == true)
             .ToList();
 
-        grpcEndpoints.Should().NotBeEmpty(
-            "MediaService must expose the InternalApi gRPC service");
-
+        grpcEndpoints.Should().NotBeEmpty();
         foreach (var endpoint in grpcEndpoints)
         {
             var policies = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()
                 .Select(data => data.Policy)
                 .ToList();
 
-            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy,
-                "every gRPC endpoint on InternalApi must use internal gRPC authentication");
-            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName,
-                "every gRPC endpoint on InternalApi must require the media internal service role");
+            policies.Should().Contain(AuthenticationExtensions.InternalGrpcPolicy);
+            policies.Should().Contain(InternalGrpcAuthorizationPolicy.PolicyName);
         }
 
         var options = _factory.Services.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
@@ -55,6 +50,6 @@ public class GrpcAuthorizationTests
         rolePolicy!.Requirements.OfType<RolesAuthorizationRequirement>()
             .Should().ContainSingle()
             .Which.AllowedRoles.Should()
-            .Contain(InternalGrpcAuthorizationPolicy.MediaInternalRole);
+            .Contain(InternalGrpcAuthorizationPolicy.PresenceInternalRole);
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
@@ -12,6 +12,7 @@ using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
 using Testcontainers.Redis;
+using Urfu.Link.BuildingBlocks.Auth;
 using Urfu.Link.BuildingBlocks.Idempotency;
 using Urfu.Link.BuildingBlocks.Outbox;
 using Urfu.Link.Services.Presence.Infrastructure.Persistence;
@@ -146,5 +147,11 @@ public sealed class PresenceServiceFactory : WebApplicationFactory<Program>, IAs
         services.AddAuthentication(defaultScheme: TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
+        services.AddAuthorization(options =>
+            options.AddPolicy(
+                AuthenticationExtensions.InternalGrpcPolicy,
+                policy => policy
+                    .AddAuthenticationSchemes(TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/PresenceServiceFactory.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Images;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Testcontainers.PostgreSql;
@@ -136,8 +138,11 @@ public sealed class PresenceServiceFactory : WebApplicationFactory<Program>, IAs
     private static void ReplaceAuthWithTestScheme(IServiceCollection services)
     {
         var authDescriptors = services
-            .Where(d => d.ServiceType.FullName?.Contains("AuthenticationScheme", StringComparison.Ordinal) == true
-                || d.ServiceType.FullName?.Contains("JwtBearer", StringComparison.Ordinal) == true)
+            .Where(d => d.ServiceType == typeof(IConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<AuthenticationOptions>)
+                || d.ServiceType == typeof(IConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IPostConfigureOptions<JwtBearerOptions>)
+                || d.ServiceType == typeof(IOptionsChangeTokenSource<JwtBearerOptions>))
             .ToList();
         foreach (var d in authDescriptors)
         {

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -27,7 +27,7 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var ticket = new AuthenticationTicket(CurrentPrincipal, SchemeName);
+        var ticket = new AuthenticationTicket(CurrentPrincipal, Scheme.Name);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestUserBuilder.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Infrastructure/TestUserBuilder.cs
@@ -4,7 +4,7 @@ namespace PresenceService.IntegrationTests.Infrastructure;
 
 public static class TestUserBuilder
 {
-    public static ClaimsPrincipal MakeUser(Guid userId, string? deviceId = null)
+    public static ClaimsPrincipal MakeUser(Guid userId, string? deviceId = null, params string[] roles)
     {
         var claims = new List<Claim>
         {
@@ -14,6 +14,11 @@ public static class TestUserBuilder
         if (!string.IsNullOrEmpty(deviceId))
         {
             claims.Add(new Claim("device_id", deviceId));
+        }
+        foreach (var role in roles ?? [])
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("groups", role));
         }
 
         var identity = new ClaimsIdentity(claims, authenticationType: TestAuthHandler.SchemeName);

--- a/tests/unit/BuildingBlocks.UnitTests/Auth/AuthenticationExtensionsTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/Auth/AuthenticationExtensionsTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Urfu.Link.BuildingBlocks.Auth;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.Auth;
+
+public sealed class AuthenticationExtensionsTests
+{
+    [Fact]
+    public async Task InternalGrpc_policy_uses_default_jwt_scheme_when_internal_auth_is_not_configured()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddPlatformJwtAuthentication(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var policy = provider.GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value.GetPolicy(AuthenticationExtensions.InternalGrpcPolicy);
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        policy.Should().NotBeNull();
+        policy!.AuthenticationSchemes.Should().ContainSingle()
+            .Which.Should().Be(JwtBearerDefaults.AuthenticationScheme);
+        (await schemes.GetSchemeAsync(AuthenticationExtensions.InternalJwtBearerScheme))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public async Task InternalGrpc_policy_uses_internal_jwt_scheme_when_internal_auth_is_configured()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:TokenHeader"] = "X-Pomerium-Jwt-Assertion",
+                ["Auth:JwksUrl"] = "http://pomerium/.well-known/pomerium/jwks.json",
+                ["Auth:Audience"] = "urfu-link.ghjc.ru",
+                ["Auth:ValidIssuer"] = "urfu-link.ghjc.ru",
+                ["Auth:Internal:JwksUrl"] = "http://keycloak/realms/urfu-link/protocol/openid-connect/certs",
+                ["Auth:Internal:Audience"] = "urfu-link-api",
+                ["Auth:Internal:ValidIssuer"] = "https://id.ghjc.ru/realms/urfu-link",
+                ["Auth:Internal:RoleClaim"] = "groups",
+            })
+            .Build();
+
+        services.AddPlatformJwtAuthentication(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var policy = provider.GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value.GetPolicy(AuthenticationExtensions.InternalGrpcPolicy);
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        policy.Should().NotBeNull();
+        policy!.AuthenticationSchemes.Should().ContainSingle()
+            .Which.Should().Be(AuthenticationExtensions.InternalJwtBearerScheme);
+        (await schemes.GetSchemeAsync(AuthenticationExtensions.InternalJwtBearerScheme))
+            .Should().NotBeNull();
+    }
+}

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Auth\Auth.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Contracts\Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Observability\Observability.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />

--- a/tests/unit/ChatService.UnitTests/Infrastructure/MediaServiceClientTests.cs
+++ b/tests/unit/ChatService.UnitTests/Infrastructure/MediaServiceClientTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Grpc.Core;
+using Urfu.Link.Services.Chat.Domain.Enums;
+using Urfu.Link.Services.Chat.Infrastructure.Grpc;
+using MediaGrpc = MediaService.Api.Grpc;
+
+namespace Urfu.Link.Services.Chat.UnitTests.Infrastructure;
+
+public sealed class MediaServiceClientTests
+{
+    [Fact]
+    public async Task BatchGetMetadataAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var assetId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var grpcClient = new StubInternalApiClient(assetId, ownerId);
+        var sut = new MediaServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"));
+
+        await sut.BatchGetMetadataAsync(new[] { assetId }, default);
+
+        grpcClient.LastBatchGetMetadataHeaders.Should().NotBeNull();
+        grpcClient.LastBatchGetMetadataHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
+    [Fact]
+    public async Task GrantConversationAccessAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var grpcClient = new StubInternalApiClient(Guid.NewGuid(), Guid.NewGuid());
+        var sut = new MediaServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"));
+
+        await sut.GrantConversationAccessAsync(
+            Guid.NewGuid(),
+            new[] { Guid.NewGuid() },
+            "conversation-1",
+            Guid.NewGuid(),
+            default);
+
+        grpcClient.LastGrantAssetAccessHeaders.Should().NotBeNull();
+        grpcClient.LastGrantAssetAccessHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
+    private sealed class StubInternalApiClient(Guid assetId, Guid ownerId)
+        : MediaGrpc.InternalApi.InternalApiClient
+    {
+        public Metadata? LastBatchGetMetadataHeaders { get; private set; }
+
+        public Metadata? LastGrantAssetAccessHeaders { get; private set; }
+
+        public override AsyncUnaryCall<MediaGrpc.BatchGetMetadataReply> BatchGetMetadataAsync(
+            MediaGrpc.BatchGetMetadataRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastBatchGetMetadataHeaders = headers;
+            return Unary(new MediaGrpc.BatchGetMetadataReply
+            {
+                Items =
+                {
+                    new MediaGrpc.AssetMetadata
+                    {
+                        AssetId = assetId.ToString("D"),
+                        OwnerId = ownerId.ToString("D"),
+                        Kind = (int)AttachmentType.Image,
+                        SizeBytes = 1024,
+                        MimeType = "image/png",
+                        OriginalFileName = "asset.png",
+                        State = MediaGrpc.AssetState.Uploaded,
+                    },
+                },
+            });
+        }
+
+        public override AsyncUnaryCall<MediaGrpc.GrantAssetAccessReply> GrantAssetAccessAsync(
+            MediaGrpc.GrantAssetAccessRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastGrantAssetAccessHeaders = headers;
+            return Unary(new MediaGrpc.GrantAssetAccessReply());
+        }
+    }
+
+    private sealed class StubGrpcBearerTokenProvider(string? token) : IGrpcBearerTokenProvider
+    {
+        public ValueTask<Metadata?> GetAuthorizationMetadataAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return ValueTask.FromResult<Metadata?>(null);
+            }
+
+            return ValueTask.FromResult<Metadata?>(new Metadata
+            {
+                { "authorization", $"Bearer {token}" },
+            });
+        }
+    }
+
+    private static AsyncUnaryCall<T> Unary<T>(T response)
+        => new(
+            Task.FromResult(response),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+}

--- a/tests/unit/ChatService.UnitTests/Infrastructure/PresenceServiceClientTests.cs
+++ b/tests/unit/ChatService.UnitTests/Infrastructure/PresenceServiceClientTests.cs
@@ -1,11 +1,30 @@
 using System.Globalization;
 using FluentAssertions;
+using Grpc.Core;
+using Microsoft.Extensions.Logging.Abstractions;
 using Urfu.Link.Services.Chat.Infrastructure.Grpc;
+using PresenceGrpc = Urfu.Link.Services.Presence.Grpc;
 
 namespace ChatService.UnitTests.Infrastructure;
 
 public sealed class PresenceServiceClientTests
 {
+    [Fact]
+    public async Task SetTypingAsync_AddsAuthorizationMetadata_WhenBearerTokenIsAvailable()
+    {
+        var grpcClient = new StubInternalApiClient();
+        var sut = new PresenceServiceClient(
+            grpcClient,
+            new StubGrpcBearerTokenProvider("service-token"),
+            NullLogger<PresenceServiceClient>.Instance);
+
+        await sut.SetTypingAsync(Guid.NewGuid().ToString("D"), Guid.NewGuid(), isTyping: true, default);
+
+        grpcClient.LastSetTypingHeaders.Should().NotBeNull();
+        grpcClient.LastSetTypingHeaders!.Should()
+            .ContainSingle(h => h.Key == "authorization" && h.Value == "Bearer service-token");
+    }
+
     [Fact]
     public void MapToConversationGuid_UsesFirstThirtyTwoHexCharsForDirectConversationIds()
     {
@@ -25,5 +44,41 @@ public sealed class PresenceServiceClientTests
 
         mapped.ToString("D", CultureInfo.InvariantCulture)
             .Should().Be("11111111-1111-4111-8111-111111111111");
+    }
+
+    private sealed class StubInternalApiClient : PresenceGrpc.InternalApi.InternalApiClient
+    {
+        public Metadata? LastSetTypingHeaders { get; private set; }
+
+        public override AsyncUnaryCall<PresenceGrpc.SetTypingReply> SetTypingAsync(
+            PresenceGrpc.SetTypingRequest request,
+            Metadata? headers = null,
+            DateTime? deadline = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastSetTypingHeaders = headers;
+            return new AsyncUnaryCall<PresenceGrpc.SetTypingReply>(
+                Task.FromResult(new PresenceGrpc.SetTypingReply()),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+    }
+
+    private sealed class StubGrpcBearerTokenProvider(string? token) : IGrpcBearerTokenProvider
+    {
+        public ValueTask<Metadata?> GetAuthorizationMetadataAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return ValueTask.FromResult<Metadata?>(null);
+            }
+
+            return ValueTask.FromResult<Metadata?>(new Metadata
+            {
+                { "authorization", $"Bearer {token}" },
+            });
+        }
     }
 }


### PR DESCRIPTION
## Исправлено

- Исправлен вход через корпоративную авторизацию и возврат после входа.
- Убраны дублирующиеся метки дат в чате; разделители дат теперь остаются видимыми и не мешают прокрутке.
- Исправлена отправка первого сообщения в личных чатах и сохранение черновиков до создания чата.
- Стабилизированы онлайн-статусы, индикатор набора и подписки на статусы присутствия.
- Восстановлена стабильная работа маршрутов к чатам, медиа, уведомлениям и другим сервисам в production.
- Исправлены настройки хранилища медиа и подключений к базам данных для production.
- Внутренние сервисные вызовы теперь требуют правильных служебных ролей.

## Улучшено

- Обновлены production-сборки сервисов и веб-клиента после исправлений.
- Обновлены настройки сборки сервисов для более надежного выпуска.