### PR TITLE
fix(infra): стабилизировать production-инфраструктуру

### DIFF
--- a/deploy/k8s/platform/argocd/apps/wave-5/platform-stateful.yaml
+++ b/deploy/k8s/platform/argocd/apps/wave-5/platform-stateful.yaml
@@ -18,12 +18,6 @@ spec:
       jsonPointers:
         - /data/password
         - /stringData
-    - kind: Secret
-      name: mongo-app-user-password
-      namespace: urfu-platform
-      jsonPointers:
-        - /data/password
-        - /stringData
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:

--- a/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
+++ b/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
@@ -309,6 +309,45 @@ spec:
                 fi
               }
 
+              verify_internal_grpc_token() {
+                echo "Verifying chat-service-internal token claims..."
+                TOKEN_RESPONSE="$(curl --silent --fail \
+                  -X POST "${KEYCLOAK_URL}/realms/urfu-link/protocol/openid-connect/token" \
+                  -d "grant_type=client_credentials" \
+                  -d "client_id=chat-service-internal" \
+                  -d "client_secret=${CHAT_SERVICE_INTERNAL_SECRET}")"
+                ACCESS_TOKEN="$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')"
+                if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+                  echo "chat-service-internal token response did not contain access_token"
+                  exit 1
+                fi
+
+                PAYLOAD_B64="$(printf "%s" "$ACCESS_TOKEN" | cut -d. -f2 | tr '_-' '/+')"
+                case $(( ${#PAYLOAD_B64} % 4 )) in
+                  2) PAYLOAD_B64="${PAYLOAD_B64}==" ;;
+                  3) PAYLOAD_B64="${PAYLOAD_B64}=" ;;
+                  1) echo "Invalid JWT payload padding"; exit 1 ;;
+                esac
+                PAYLOAD="$(printf "%s" "$PAYLOAD_B64" | base64 -d)"
+
+                echo "$PAYLOAD" | jq -e \
+                  --arg iss "https://id.ghjc.ru/realms/urfu-link" \
+                  --arg aud "urfu-link-api" \
+                  --arg discipline "service:discipline-read" \
+                  --arg presence "service:presence-internal" \
+                  '
+                    def aud_has($expected):
+                      (.aud == $expected)
+                      or ((.aud | type) == "array" and ((.aud | index($expected)) != null));
+
+                    .iss == $iss
+                    and aud_has($aud)
+                    and (((.groups // []) | index($discipline)) != null)
+                    and (((.groups // []) | index($presence)) != null)
+                  ' >/dev/null
+                echo "chat-service-internal token claims verified."
+              }
+
               # --- Main ---
 
               wait_for_vault
@@ -409,6 +448,7 @@ spec:
                 "${KEYCLOAK_URL}/admin/realms/urfu-link/users/${CHAT_SA_ID}/role-mappings/realm" \
                 -d "[${DISCIPLINE_READ_ROLE},${MEDIA_INTERNAL_ROLE},${PRESENCE_INTERNAL_ROLE}]" >/dev/null
               echo "Granted internal gRPC roles to chat-service-internal service account"
+              verify_internal_grpc_token
 
               # --- Frontend Web (public client for mobile) ---
               ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*","http://app.dev.127.0.0.1.nip.io/*"]' '["https://urfu-link.ghjc.ru","http://app.dev.127.0.0.1.nip.io"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"

--- a/deploy/k8s/platform/network/coredns-custom.yaml
+++ b/deploy/k8s/platform/network/coredns-custom.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: kube-system
 data:
   id.ghjc.ru.override: |
+    # Compatibility override for components that must validate the public issuer.
+    # New in-cluster integrations should prefer internal service URLs for OIDC discovery.
     rewrite name id.ghjc.ru ingress-nginx-controller.ingress-nginx.svc.cluster.local

--- a/deploy/k8s/platform/network/platform-network-policies.yaml
+++ b/deploy/k8s/platform/network/platform-network-policies.yaml
@@ -183,6 +183,27 @@ spec:
         - protocol: TCP
           port: 9000
 ---
+# MinIO: allow OIDC discovery against the internal Keycloak service.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: minio-egress-keycloak
+  namespace: urfu-platform
+spec:
+  podSelector:
+    matchLabels:
+      app: urfu-minio
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: keycloak
+      ports:
+        - protocol: TCP
+          port: 8080
+---
 # LiveKit + CoTURN: allow ingress from urfu-prod (call-service)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/deploy/k8s/platform/stateful/kustomization.yaml
+++ b/deploy/k8s/platform/stateful/kustomization.yaml
@@ -4,7 +4,9 @@ kind: Kustomization
 resources:
   - storageclass-fast-ssd.yaml
   - postgres-cluster.yaml
+  - mongo-app-user-password-external-secret.yaml
   - mongodb-cluster.yaml
+  - mongodb-auth-preflight-job.yaml
   - mongodb-backup-cronjob.yaml
   - redis.yaml
   - kafka-cluster.yaml

--- a/deploy/k8s/platform/stateful/minio-buckets-job.yaml
+++ b/deploy/k8s/platform/stateful/minio-buckets-job.yaml
@@ -34,6 +34,7 @@ spec:
               mc mb -p minio/media-private || true
               mc mb -p minio/media-public || true
               mc mb -p minio/user-avatars || true
+              mc mb -p minio/urfu-backups || true
               mc anonymous set download minio/media-public
               mc anonymous set download minio/user-avatars
           volumeMounts:

--- a/deploy/k8s/platform/stateful/minio-tenant.yaml
+++ b/deploy/k8s/platform/stateful/minio-tenant.yaml
@@ -39,7 +39,7 @@ spec:
             - name: MINIO_API_CORS_ALLOW_ORIGIN
               value: "https://urfu-link.ghjc.ru"
             - name: MINIO_IDENTITY_OPENID_CONFIG_URL
-              value: "https://id.ghjc.ru/realms/urfu-link/.well-known/openid-configuration"
+              value: "http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/.well-known/openid-configuration"
             - name: MINIO_IDENTITY_OPENID_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/platform/stateful/mongo-app-user-password-external-secret.yaml
+++ b/deploy/k8s/platform/stateful/mongo-app-user-password-external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mongo-app-user-password
+  namespace: urfu-platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-backend
+  target:
+    name: mongo-app-user-password
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: urfu-link/prod/mongo
+        property: app_user_password

--- a/deploy/k8s/platform/stateful/mongodb-auth-preflight-job.yaml
+++ b/deploy/k8s/platform/stateful/mongodb-auth-preflight-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-auth-preflight
+  namespace: urfu-platform
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mongodb-auth-preflight
+          image: mongo:8.0
+          env:
+            - name: MONGO_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-app-user-password
+                  key: password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              MONGO_URI="mongodb://app-user:${MONGO_APP_PASSWORD}@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/admin?authSource=admin"
+              until mongosh "$MONGO_URI" --quiet --eval 'if (db.runCommand({ ping: 1 }).ok !== 1) quit(9)' >/dev/null; do
+                sleep 5
+              done

--- a/deploy/k8s/platform/stateful/mongodb-backup-cronjob.yaml
+++ b/deploy/k8s/platform/stateful/mongodb-backup-cronjob.yaml
@@ -5,27 +5,83 @@ metadata:
   namespace: urfu-platform
 spec:
   schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 900
+      backoffLimit: 2
       template:
         spec:
           restartPolicy: OnFailure
-          containers:
-            - name: mongo-backup
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            - name: mongodump
               image: mongo:8.0
+              imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh
                 - -c
-                - >-
-                  mongodump --uri "$MONGO_URI" --archive=/tmp/backup.archive &&
-                  mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" &&
-                  mc cp /tmp/backup.archive minio/urfu-backups/mongo/backup-$(date +%F-%H%M).archive
+                - |
+                  set -eu
+
+                  BACKUP_DATE="$(date -u +%Y/%m/%d)"
+                  BACKUP_NAME="backup-$(date -u +%Y%m%dT%H%M%SZ).archive.gz"
+                  ARCHIVE="/backup/${BACKUP_NAME}"
+                  OBJECT_PATH="urfu-backups/mongo/${BACKUP_DATE}/${BACKUP_NAME}"
+
+                  mongodump --uri "$MONGO_URI" --archive="$ARCHIVE" --gzip
+                  printf "%s" "$ARCHIVE" > /backup/archive_path
+                  printf "%s" "$OBJECT_PATH" > /backup/object_path
               env:
                 - name: MONGO_URI
                   valueFrom:
                     secretKeyRef:
                       name: mongo-backup-secret
                       key: mongo_uri
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+          containers:
+            - name: upload-to-minio
+              image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+
+                  export MC_CONFIG_DIR=/backup/.mc
+                  ARCHIVE="$(cat /backup/archive_path)"
+                  OBJECT_PATH="$(cat /backup/object_path)"
+
+                  mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+                  mc cp "$ARCHIVE" minio/${OBJECT_PATH}
+                  mc stat minio/${OBJECT_PATH}
+              env:
                 - name: MINIO_ENDPOINT
                   valueFrom:
                     secretKeyRef:
@@ -41,3 +97,22 @@ spec:
                     secretKeyRef:
                       name: mongo-backup-secret
                       key: minio_secret_key
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+          volumes:
+            - name: backup
+              emptyDir: {}

--- a/deploy/k8s/platform/stateful/mongodb-backup-smoke-job.yaml
+++ b/deploy/k8s/platform/stateful/mongodb-backup-smoke-job.yaml
@@ -1,0 +1,111 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-backup-smoke
+  namespace: urfu-platform
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: mongodump
+          image: mongo:8.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              BACKUP_DATE="$(date -u +smoke/%Y/%m/%d)"
+              BACKUP_NAME="smoke-$(date -u +%Y%m%dT%H%M%SZ).archive.gz"
+              ARCHIVE="/backup/${BACKUP_NAME}"
+              OBJECT_PATH="urfu-backups/mongo/${BACKUP_DATE}/${BACKUP_NAME}"
+
+              mongodump --uri "$MONGO_URI" --archive="$ARCHIVE" --gzip
+              printf "%s" "$ARCHIVE" > /backup/archive_path
+              printf "%s" "$OBJECT_PATH" > /backup/object_path
+          env:
+            - name: MONGO_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-backup-secret
+                  key: mongo_uri
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: backup
+              mountPath: /backup
+      containers:
+        - name: upload-to-minio
+          image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              export MC_CONFIG_DIR=/backup/.mc
+              ARCHIVE="$(cat /backup/archive_path)"
+              OBJECT_PATH="$(cat /backup/object_path)"
+
+              mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+              mc cp "$ARCHIVE" minio/${OBJECT_PATH}
+              mc stat minio/${OBJECT_PATH}
+          env:
+            - name: MINIO_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-backup-secret
+                  key: minio_endpoint
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-backup-secret
+                  key: minio_access_key
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-backup-secret
+                  key: minio_secret_key
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: backup
+              mountPath: /backup
+      volumes:
+        - name: backup
+          emptyDir: {}

--- a/deploy/k8s/platform/stateful/mongodb-cluster.yaml
+++ b/deploy/k8s/platform/stateful/mongodb-cluster.yaml
@@ -1,15 +1,4 @@
 apiVersion: v1
-kind: Secret
-metadata:
-  name: mongo-app-user-password
-  namespace: urfu-platform
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
-type: Opaque
-stringData:
-  password: "PLACEHOLDER_WILL_BE_REPLACED_BY_BOOTSTRAP"
----
-apiVersion: v1
 kind: Service
 metadata:
   name: urfu-mongo-svc
@@ -28,7 +17,7 @@ metadata:
   name: urfu-mongo
   namespace: urfu-platform
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   serviceName: urfu-mongo-svc
   replicas: 1

--- a/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
+++ b/deploy/k8s/platform/stateful/platform-bootstrap-job.yaml
@@ -136,6 +136,7 @@ spec:
                 KEYCLOAK_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" keycloak_admin_password 2>/dev/null || true)"
                 API_GATEWAY_CLIENT_SECRET="$(secret_value "$GENERATED_JSON" api_gateway_client_secret 2>/dev/null || true)"
                 POMERIUM_DB_PASSWORD="$(secret_value "$GENERATED_JSON" pomerium_db_password 2>/dev/null || true)"
+                MONGO_APP_PASSWORD="$(secret_value "$GENERATED_JSON" mongo_app_password 2>/dev/null || true)"
 
                 [ -n "$USER_DB_PASSWORD" ] || USER_DB_PASSWORD="$(rand 32)"
                 [ -n "$MEDIA_DB_PASSWORD" ] || MEDIA_DB_PASSWORD="$(rand 32)"
@@ -146,11 +147,19 @@ spec:
                 [ -n "$KEYCLOAK_ADMIN_PASSWORD" ] || KEYCLOAK_ADMIN_PASSWORD="$(rand 32)"
                 [ -n "$API_GATEWAY_CLIENT_SECRET" ] || API_GATEWAY_CLIENT_SECRET="$(rand 40)"
                 [ -n "$POMERIUM_DB_PASSWORD" ] || POMERIUM_DB_PASSWORD="$(rand 32)"
+                if [ -z "$MONGO_APP_PASSWORD" ]; then
+                  EXISTING_MONGO_JSON="$(get_secret_json mongo-app-user-password)"
+                  MONGO_APP_PASSWORD="$(secret_value "$EXISTING_MONGO_JSON" password 2>/dev/null || true)"
+                  if echo "$MONGO_APP_PASSWORD" | grep -q "PLACEHOLDER"; then
+                    MONGO_APP_PASSWORD=""
+                  fi
+                fi
+                [ -n "$MONGO_APP_PASSWORD" ] || MONGO_APP_PASSWORD="$(rand 32)"
 
                 GRAFANA_ADMIN_PASSWORD="$(secret_value "$GENERATED_JSON" grafana_admin_password 2>/dev/null || true)"
                 [ -n "$GRAFANA_ADMIN_PASSWORD" ] || GRAFANA_ADMIN_PASSWORD="$(rand 32)"
 
-                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                GENERATED_PATCH="$(printf '{"data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s","mongo_app_password":"%s"}}' \
                   "$(b64 "$USER_DB_PASSWORD")" \
                   "$(b64 "$MEDIA_DB_PASSWORD")" \
                   "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
@@ -160,12 +169,13 @@ spec:
                   "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                   "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
                   "$(b64 "$GRAFANA_ADMIN_PASSWORD")" \
-                  "$(b64 "$POMERIUM_DB_PASSWORD")")"
+                  "$(b64 "$POMERIUM_DB_PASSWORD")" \
+                  "$(b64 "$MONGO_APP_PASSWORD")")"
 
                 if [ "$GENERATED_EXISTS" = "true" ]; then
                   patch_secret_json platform-bootstrap-generated "$GENERATED_PATCH"
                 else
-                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s"}}' \
+                  GENERATED_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"platform-bootstrap-generated"},"type":"Opaque","data":{"user_db_password":"%s","media_db_password":"%s","discipline_db_password":"%s","presence_db_password":"%s","notification_db_password":"%s","keycloak_db_password":"%s","keycloak_admin_password":"%s","api_gateway_client_secret":"%s","grafana_admin_password":"%s","pomerium_db_password":"%s","mongo_app_password":"%s"}}' \
                     "$(b64 "$USER_DB_PASSWORD")" \
                     "$(b64 "$MEDIA_DB_PASSWORD")" \
                     "$(b64 "$DISCIPLINE_DB_PASSWORD")" \
@@ -175,25 +185,9 @@ spec:
                     "$(b64 "$KEYCLOAK_ADMIN_PASSWORD")" \
                     "$(b64 "$API_GATEWAY_CLIENT_SECRET")" \
                     "$(b64 "$GRAFANA_ADMIN_PASSWORD")" \
-                    "$(b64 "$POMERIUM_DB_PASSWORD")")"
+                    "$(b64 "$POMERIUM_DB_PASSWORD")" \
+                    "$(b64 "$MONGO_APP_PASSWORD")")"
                   create_secret_json "$GENERATED_CREATE"
-                fi
-              }
-
-              ensure_mongo_password_secret() {
-                MONGO_JSON="$(get_secret_json mongo-app-user-password)"
-                MONGO_CODE="$(secret_http_code mongo-app-user-password)"
-                if [ "$MONGO_CODE" = "404" ]; then
-                  MONGO_APP_PASSWORD="$(rand 32)"
-                  MONGO_CREATE="$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"mongo-app-user-password"},"type":"Opaque","data":{"password":"%s"}}' "$(b64 "$MONGO_APP_PASSWORD")")"
-                  create_secret_json "$MONGO_CREATE"
-                else
-                  MONGO_APP_PASSWORD="$(secret_value "$MONGO_JSON" password 2>/dev/null || true)"
-                  if [ -z "$MONGO_APP_PASSWORD" ] || echo "$MONGO_APP_PASSWORD" | grep -q "PLACEHOLDER"; then
-                    MONGO_APP_PASSWORD="$(rand 32)"
-                    MONGO_PATCH="$(printf '{"data":{"password":"%s"}}' "$(b64 "$MONGO_APP_PASSWORD")")"
-                    patch_secret_json mongo-app-user-password "$MONGO_PATCH"
-                  fi
                 fi
               }
 
@@ -347,7 +341,6 @@ spec:
               }
 
               ensure_generated_secret
-              ensure_mongo_password_secret
               ensure_postgres_superuser_secret
               bootstrap_postgres
               wait_for_vault
@@ -363,12 +356,12 @@ spec:
               EXISTING_USER_SVC="$(vault_read urfu-link/prod/user-service)"
               EXISTING_KC_SECRET="$(json_get_string "$EXISTING_USER_SVC" keycloak_client_secret)"
               if [ -n "$EXISTING_KC_SECRET" ]; then
-                USER_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=user_db;Username=user;Password=%s","keycloak_client_secret":"%s"}}' "$USER_DB_PASSWORD" "$EXISTING_KC_SECRET")"
+                USER_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=user_db;Username=user;Password=%s;GSS Encryption Mode=Disable","keycloak_client_secret":"%s"}}' "$USER_DB_PASSWORD" "$EXISTING_KC_SECRET")"
               else
-                USER_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=user_db;Username=user;Password=%s"}}' "$USER_DB_PASSWORD")"
+                USER_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=user_db;Username=user;Password=%s;GSS Encryption Mode=Disable"}}' "$USER_DB_PASSWORD")"
               fi
-              MEDIA_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=media_db;Username=media;Password=%s"}}' "$MEDIA_DB_PASSWORD")"
-              DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s"}}' "$DISCIPLINE_DB_PASSWORD")"
+              MEDIA_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=media_db;Username=media;Password=%s;GSS Encryption Mode=Disable"}}' "$MEDIA_DB_PASSWORD")"
+              DISCIPLINE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=discipline_db;Username=discipline;Password=%s;GSS Encryption Mode=Disable"}}' "$DISCIPLINE_DB_PASSWORD")"
               EXISTING_CHAT_SVC="$(vault_read urfu-link/prod/chat-service)"
               EXISTING_INTERNAL_AUTH_SECRET="$(json_get_string "$EXISTING_CHAT_SVC" internal_auth_client_secret)"
               if [ -n "$EXISTING_INTERNAL_AUTH_SECRET" ]; then
@@ -376,12 +369,13 @@ spec:
               else
                 CHAT_PAYLOAD="$(printf '{"data":{"primary_connection":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin"}}' "$MONGO_APP_PASSWORD")"
               fi
-              PRESENCE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s"}}' "$PRESENCE_DB_PASSWORD")"
-              NOTIFICATION_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s","kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}' "$NOTIFICATION_DB_PASSWORD")"
+              PRESENCE_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s;GSS Encryption Mode=Disable"}}' "$PRESENCE_DB_PASSWORD")"
+              NOTIFICATION_PAYLOAD="$(printf '{"data":{"primary_connection":"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s;GSS Encryption Mode=Disable","kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}' "$NOTIFICATION_DB_PASSWORD")"
               CALL_PAYLOAD='{"data":{"kafka_bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'
               GRAFANA_PAYLOAD="$(printf '{"data":{"admin_password":"%s"}}' "$GRAFANA_ADMIN_PASSWORD")"
               KAFKA_PAYLOAD='{"data":{"bootstrap_servers":"urfu-kafka.urfu-platform.svc.cluster.local:9092"}}'
               API_GATEWAY_PAYLOAD="$(printf '{"data":{"auth_client_secret":"%s"}}' "$API_GATEWAY_CLIENT_SECRET")"
+              MONGO_PAYLOAD="$(printf '{"data":{"app_user_password":"%s"}}' "$MONGO_APP_PASSWORD")"
               MONGO_BACKUP_PAYLOAD="$(printf '{"data":{"mongo_uri":"mongodb://app-user:%s@urfu-mongo-svc.urfu-platform.svc.cluster.local:27017/chat_db?authSource=admin","minio_endpoint":"http://urfu-minio.urfu-platform.svc.cluster.local:9000","minio_access_key":"%s","minio_secret_key":"%s"}}' \
                 "$MONGO_APP_PASSWORD" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY")"  
 
@@ -399,4 +393,5 @@ spec:
               vault_put urfu-link/prod/grafana "$GRAFANA_PAYLOAD"
               vault_put urfu-link/prod/kafka "$KAFKA_PAYLOAD"
               vault_put urfu-link/prod/api-gateway "$API_GATEWAY_PAYLOAD"
+              vault_put urfu-link/prod/mongo "$MONGO_PAYLOAD"
               vault_put urfu-link/prod/mongo-backup "$MONGO_BACKUP_PAYLOAD"

--- a/deploy/k8s/platform/vault/vault-auto-init-job.yaml
+++ b/deploy/k8s/platform/vault/vault-auto-init-job.yaml
@@ -165,6 +165,9 @@ spec:
               path "kv/data/urfu-link/prod/linkerd-viz" {
                 capabilities = ["create", "update", "read"]
               }
+              path "kv/data/urfu-link/prod/mongo" {
+                capabilities = ["create", "update", "read"]
+              }
               path "kv/data/urfu-link/prod/mongo-backup" {
                 capabilities = ["create", "update", "read"]
               }

--- a/scripts/prod-remediation-smoke.sh
+++ b/scripts/prod-remediation-smoke.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SINCE="${SINCE:-60m}"
+APP_NAMESPACES="${APP_NAMESPACES:-urfu-prod urfu-platform argocd ingress-nginx observability}"
+ERROR_PATTERN='MongoAuthenticationException|Authentication failed|Unable to initialize OpenID|StatusCode="Unauthenticated"|HTTP status code: 401|CrashLoopBackOff|Back-off restarting failed container'
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+require kubectl
+require jq
+require curl
+
+echo "== ArgoCD applications =="
+kubectl -n argocd get applications.argoproj.io -o json \
+  | jq -r '
+      .items[]
+      | [.metadata.name, .status.sync.status, .status.health.status]
+      | @tsv
+    ' \
+  | tee /tmp/urfu-argocd-apps.tsv
+if awk '$2 != "Synced" || $3 != "Healthy" { bad=1 } END { exit bad ? 1 : 0 }' /tmp/urfu-argocd-apps.tsv; then
+  echo "ArgoCD applications are Synced/Healthy."
+else
+  echo "At least one ArgoCD application is not Synced/Healthy." >&2
+  exit 1
+fi
+
+echo "== Pods =="
+kubectl get pods -A -o json \
+  | jq -r '
+      .items[]
+      | select(.metadata.namespace | IN("urfu-prod","urfu-platform","argocd","ingress-nginx","observability"))
+      | {
+          ns: .metadata.namespace,
+          name: .metadata.name,
+          phase: .status.phase,
+          waiting: ([.status.containerStatuses[]? | select(.state.waiting != null) | .state.waiting.reason] | join(",")),
+          restarts: ([.status.containerStatuses[]?.restartCount] | add // 0),
+          ready: ([.status.containerStatuses[]? | select(.ready == true)] | length),
+          total: ([.status.containerStatuses[]?] | length)
+        }
+      | select(.phase != "Running" and .phase != "Succeeded" or .waiting != "" or .ready != .total)
+      | [.ns, .name, .phase, .waiting, (.ready|tostring)+"/"+(.total|tostring), (.restarts|tostring)]
+      | @tsv
+    ' \
+  | tee /tmp/urfu-bad-pods.tsv
+if [ -s /tmp/urfu-bad-pods.tsv ]; then
+  echo "Pods with bad phase/waiting containers/not-ready containers were found." >&2
+  exit 1
+fi
+echo "Pods are ready; no CrashLoopBackOff/not-ready containers found."
+
+echo "== Argo Rollouts =="
+if kubectl get rollouts.argoproj.io -A -o json >/tmp/urfu-rollouts.json 2>/dev/null; then
+  jq -r '
+      .items[]
+      | {
+          ns: .metadata.namespace,
+          name: .metadata.name,
+          phase: (.status.phase // ""),
+          degraded: ([.status.conditions[]? | select(.type == "Degraded" and .status == "True")] | length)
+        }
+      | select(.phase != "Healthy" or .degraded > 0)
+      | [.ns, .name, .phase, (.degraded|tostring)]
+      | @tsv
+    ' /tmp/urfu-rollouts.json | tee /tmp/urfu-bad-rollouts.tsv
+  if [ -s /tmp/urfu-bad-rollouts.tsv ]; then
+    echo "Unhealthy or degraded rollouts were found." >&2
+    exit 1
+  fi
+  echo "Rollouts are healthy."
+else
+  echo "Argo Rollouts CRD is not available; skipping rollout check."
+fi
+
+echo "== Jobs =="
+kubectl get jobs -A -o json \
+  | jq -r '
+      .items[]
+      | select(.metadata.namespace | IN("urfu-prod","urfu-platform"))
+      | select((.status.failed // 0) > 0)
+      | [.metadata.namespace, .metadata.name, (.status.failed|tostring), (.status.conditions[]? | select(.type == "Failed") | .reason)]
+      | @tsv
+    ' \
+  | tee /tmp/urfu-failed-jobs.tsv
+if [ -s /tmp/urfu-failed-jobs.tsv ]; then
+  echo "Failed jobs were found." >&2
+  exit 1
+fi
+echo "No failed jobs found."
+
+echo "== Gateway downstream health =="
+GATEWAY_PORT="${GATEWAY_PORT:-18080}"
+kubectl -n urfu-prod port-forward svc/api-gateway "${GATEWAY_PORT}:8080" >/tmp/urfu-gateway-port-forward.log 2>&1 &
+PF_PID=$!
+cleanup_port_forward() {
+  kill "$PF_PID" >/dev/null 2>&1 || true
+}
+trap cleanup_port_forward EXIT
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${GATEWAY_PORT}/health/downstreams" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT}/health/downstreams" >/dev/null
+cleanup_port_forward
+trap - EXIT
+echo "Gateway downstream health endpoint returned 200."
+
+echo "== Recent logs (${SINCE}) =="
+for ns in $APP_NAMESPACES; do
+  while IFS= read -r pod; do
+    [ -n "$pod" ] || continue
+    kubectl -n "$ns" logs "$pod" --all-containers --since="$SINCE" --prefix=true 2>/dev/null || true
+  done < <(kubectl -n "$ns" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+done | grep -E "$ERROR_PATTERN" | tee /tmp/urfu-recent-log-errors.txt || true
+if [ -s /tmp/urfu-recent-log-errors.txt ]; then
+  echo "Recent critical log patterns were found." >&2
+  exit 1
+fi
+echo "No recent critical log patterns found."

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -139,14 +139,25 @@ public sealed class DeploymentContractTests
     }
 
     [Fact]
-    public void PlatformStatefulShouldNotReconcileGeneratedMongoPassword()
+    public void PlatformStatefulShouldSourceMongoPasswordFromVaultExternalSecret()
     {
         var application = ReadRepoFile("deploy", "k8s", "platform", "argocd", "apps", "wave-5", "platform-stateful.yaml");
+        var kustomization = ReadRepoFile("deploy", "k8s", "platform", "stateful", "kustomization.yaml");
+        var externalSecret = ReadRepoFile(
+            "deploy",
+            "k8s",
+            "platform",
+            "stateful",
+            "mongo-app-user-password-external-secret.yaml");
+        var mongo = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-cluster.yaml");
 
-        Assert.Contains("name: mongo-app-user-password", application, StringComparison.Ordinal);
-        Assert.Contains("/data/password", application, StringComparison.Ordinal);
-        Assert.Contains("/stringData", application, StringComparison.Ordinal);
-        Assert.Contains("RespectIgnoreDifferences=true", application, StringComparison.Ordinal);
+        Assert.DoesNotContain("name: mongo-app-user-password", application, StringComparison.Ordinal);
+        Assert.Contains("mongo-app-user-password-external-secret.yaml", kustomization, StringComparison.Ordinal);
+        Assert.Contains("kind: ExternalSecret", externalSecret, StringComparison.Ordinal);
+        Assert.Contains("name: mongo-app-user-password", externalSecret, StringComparison.Ordinal);
+        Assert.Contains("key: urfu-link/prod/mongo", externalSecret, StringComparison.Ordinal);
+        Assert.Contains("property: app_user_password", externalSecret, StringComparison.Ordinal);
+        Assert.DoesNotContain("PLACEHOLDER_WILL_BE_REPLACED_BY_BOOTSTRAP", mongo, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -155,9 +166,9 @@ public sealed class DeploymentContractTests
         var manifest = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-cluster.yaml");
 
         Assert.Contains("name: mongo-app-user-password", manifest, StringComparison.Ordinal);
-        Assert.Contains("argocd.argoproj.io/sync-wave: \"-1\"", manifest, StringComparison.Ordinal);
+        Assert.DoesNotContain("kind: Secret", manifest, StringComparison.Ordinal);
         Assert.Contains("name: urfu-mongo", manifest, StringComparison.Ordinal);
-        Assert.Contains("argocd.argoproj.io/sync-wave: \"3\"", manifest, StringComparison.Ordinal);
+        Assert.Contains("argocd.argoproj.io/sync-wave: \"4\"", manifest, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -169,7 +180,7 @@ public sealed class DeploymentContractTests
         Assert.Contains("CREATE ROLE presence LOGIN PASSWORD '$PRESENCE_DB_PASSWORD'", manifest, StringComparison.Ordinal);
         Assert.Contains("CREATE DATABASE presence_db OWNER presence", manifest, StringComparison.Ordinal);
         Assert.Contains(
-            "primary_connection\":\"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s",
+            "primary_connection\":\"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=presence_db;Username=presence;Password=%s;GSS Encryption Mode=Disable",
             manifest,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -188,7 +199,7 @@ public sealed class DeploymentContractTests
         Assert.Contains("CREATE ROLE notification LOGIN PASSWORD '$NOTIFICATION_DB_PASSWORD'", bootstrap, StringComparison.Ordinal);
         Assert.Contains("CREATE DATABASE notification_db OWNER notification", bootstrap, StringComparison.Ordinal);
         Assert.Contains(
-            "primary_connection\":\"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s",
+            "primary_connection\":\"Host=urfu-postgres-rw.urfu-platform.svc.cluster.local;Port=5432;Database=notification_db;Username=notification;Password=%s;GSS Encryption Mode=Disable",
             bootstrap,
             StringComparison.Ordinal);
 
@@ -199,6 +210,81 @@ public sealed class DeploymentContractTests
         Assert.Contains("secretKey: ConnectionStrings__Primary", notificationSecret, StringComparison.Ordinal);
         Assert.Contains("key: urfu-link/prod/notification-service", notificationSecret, StringComparison.Ordinal);
         Assert.Contains("property: primary_connection", notificationSecret, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlatformBootstrapShouldPersistMongoPasswordInVaultAndPreflightMongoAuth()
+    {
+        var bootstrap = ReadRepoFile("deploy", "k8s", "platform", "stateful", "platform-bootstrap-job.yaml");
+        var preflight = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-auth-preflight-job.yaml");
+        var vault = ReadRepoFile("deploy", "k8s", "platform", "vault", "vault-auto-init-job.yaml");
+
+        Assert.Contains("mongo_app_password", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("vault_put urfu-link/prod/mongo", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("app_user_password", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("path \"kv/data/urfu-link/prod/mongo\"", vault, StringComparison.Ordinal);
+        Assert.Contains("kind: Job", preflight, StringComparison.Ordinal);
+        Assert.Contains("name: mongodb-auth-preflight", preflight, StringComparison.Ordinal);
+        Assert.Contains("mongosh \"$MONGO_URI\"", preflight, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MinioShouldUseInternalKeycloakDiscoveryWithExplicitEgress()
+    {
+        var minio = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-tenant.yaml");
+        var policies = ReadRepoFile("deploy", "k8s", "platform", "network", "platform-network-policies.yaml");
+        var coredns = ReadRepoFile("deploy", "k8s", "platform", "network", "coredns-custom.yaml");
+
+        Assert.Contains(
+            "MINIO_IDENTITY_OPENID_CONFIG_URL",
+            minio,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "http://keycloak.urfu-platform.svc.cluster.local:8080/realms/urfu-link/.well-known/openid-configuration",
+            minio,
+            StringComparison.Ordinal);
+        Assert.Contains("name: minio-egress-keycloak", policies, StringComparison.Ordinal);
+        Assert.Contains("app: keycloak", policies, StringComparison.Ordinal);
+        Assert.Contains("port: 8080", policies, StringComparison.Ordinal);
+        Assert.Contains("prefer internal service URLs", coredns, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MongoBackupCronJobShouldUseHardenedSequentialOfficialImages()
+    {
+        var cronJob = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-backup-cronjob.yaml");
+        var smokeJob = ReadRepoFile("deploy", "k8s", "platform", "stateful", "mongodb-backup-smoke-job.yaml");
+        var bucketsJob = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-buckets-job.yaml");
+
+        Assert.Contains("initContainers:", cronJob, StringComparison.Ordinal);
+        Assert.Contains("name: mongodump", cronJob, StringComparison.Ordinal);
+        Assert.Contains("image: mongo:8.0", cronJob, StringComparison.Ordinal);
+        Assert.Contains("name: upload-to-minio", cronJob, StringComparison.Ordinal);
+        Assert.Contains("image: minio/mc:RELEASE.2025-08-13T08-35-41Z", cronJob, StringComparison.Ordinal);
+        Assert.Contains("concurrencyPolicy: Forbid", cronJob, StringComparison.Ordinal);
+        Assert.Contains("activeDeadlineSeconds: 900", cronJob, StringComparison.Ordinal);
+        Assert.Contains("successfulJobsHistoryLimit: 3", cronJob, StringComparison.Ordinal);
+        Assert.Contains("failedJobsHistoryLimit: 3", cronJob, StringComparison.Ordinal);
+        Assert.Contains("readOnlyRootFilesystem: true", cronJob, StringComparison.Ordinal);
+        Assert.Contains("runAsNonRoot: true", cronJob, StringComparison.Ordinal);
+        Assert.Contains("mongodump --uri \"$MONGO_URI\" --archive=\"$ARCHIVE\" --gzip", cronJob, StringComparison.Ordinal);
+        Assert.Contains("OBJECT_PATH=\"urfu-backups/mongo", cronJob, StringComparison.Ordinal);
+        Assert.Contains("mc stat minio/${OBJECT_PATH}", cronJob, StringComparison.Ordinal);
+        Assert.Contains("mc mb -p minio/urfu-backups", bucketsJob, StringComparison.Ordinal);
+        Assert.Contains("name: mongo-backup-smoke", smokeJob, StringComparison.Ordinal);
+        Assert.Contains("initContainers:", smokeJob, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void KeycloakBootstrapShouldVerifyInternalGrpcTokenClaims()
+    {
+        var bootstrap = ReadRepoFile("deploy", "k8s", "platform", "identity", "keycloak-bootstrap-job.yaml");
+
+        Assert.Contains("verify_internal_grpc_token", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("service:discipline-read", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("service:presence-internal", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("urfu-link-api", bootstrap, StringComparison.Ordinal);
+        Assert.Contains("https://id.ghjc.ru/realms/urfu-link", bootstrap, StringComparison.Ordinal);
     }
 
     private static string ReadRepoFile(params string[] pathSegments)


### PR DESCRIPTION
## Summary
- Переводит Mongo app password под постоянное ownership через Vault и ExternalSecret.
- Добавляет Mongo auth preflight перед rollout сервисов и фиксирует bootstrap генерацию секретов.
- Переключает MinIO OIDC discovery на внутренний Keycloak URL и добавляет узкую egress policy.
- Укрепляет Mongo backup CronJob и добавляет manual backup smoke Job.
- Добавляет production smoke script и contract coverage для remediation-манифестов.

## Production notes
- P0 recovery в live-кластере уже выполнен: fresh Mongo backup создан, реальный Mongo app-user приведен к текущему Vault/K8s desired secret, chat-service rollout восстановлен.
- Оставшиеся MinIO OIDC и backup изменения должны примениться через GitOps после merge.

## Test plan
- dotnet test tests/contract/ContractTests/ContractTests.csproj --filter DeploymentContractTests
- kubectl kustomize deploy/k8s/platform
- bash -n scripts/prod-remediation-smoke.sh