### PR TITLE
fix(infra): исправить oidc backchannel для minio

### DIFF
--- a/deploy/k8s/platform/identity/keycloak.yaml
+++ b/deploy/k8s/platform/identity/keycloak.yaml
@@ -49,6 +49,7 @@ spec:
             - "start"
             - "--http-enabled=true"
             - "--hostname=https://id.ghjc.ru"
+            - "--hostname-backchannel-dynamic=true"
             - "--proxy-headers=xforwarded"
             - "--cache=local"
             - "--health-enabled=true"

--- a/scripts/prod-remediation-smoke.sh
+++ b/scripts/prod-remediation-smoke.sh
@@ -45,7 +45,10 @@ kubectl get pods -A -o json \
           ready: ([.status.containerStatuses[]? | select(.ready == true)] | length),
           total: ([.status.containerStatuses[]?] | length)
         }
-      | select(.phase != "Running" and .phase != "Succeeded" or .waiting != "" or .ready != .total)
+      | select(
+          (.phase != "Running" and .phase != "Succeeded")
+          or (.phase == "Running" and (.waiting != "" or .ready != .total))
+        )
       | [.ns, .name, .phase, .waiting, (.ready|tostring)+"/"+(.total|tostring), (.restarts|tostring)]
       | @tsv
     ' \

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -232,6 +232,7 @@ public sealed class DeploymentContractTests
     public void MinioShouldUseInternalKeycloakDiscoveryWithExplicitEgress()
     {
         var minio = ReadRepoFile("deploy", "k8s", "platform", "stateful", "minio-tenant.yaml");
+        var keycloak = ReadRepoFile("deploy", "k8s", "platform", "identity", "keycloak.yaml");
         var policies = ReadRepoFile("deploy", "k8s", "platform", "network", "platform-network-policies.yaml");
         var coredns = ReadRepoFile("deploy", "k8s", "platform", "network", "coredns-custom.yaml");
 
@@ -246,6 +247,7 @@ public sealed class DeploymentContractTests
         Assert.Contains("name: minio-egress-keycloak", policies, StringComparison.Ordinal);
         Assert.Contains("app: keycloak", policies, StringComparison.Ordinal);
         Assert.Contains("port: 8080", policies, StringComparison.Ordinal);
+        Assert.Contains("--hostname-backchannel-dynamic=true", keycloak, StringComparison.Ordinal);
         Assert.Contains("prefer internal service URLs", coredns, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary
- Enables Keycloak dynamic backchannel endpoints so MinIO can use internal discovery and internal JWKS/token endpoints while keeping the public issuer.
- Fixes production smoke pod filtering so completed Job pods are not treated as unhealthy.
- Adds deployment contract coverage for the Keycloak backchannel flag.

## Validation
- dotnet test tests/contract/ContractTests/ContractTests.csproj --filter DeploymentContractTests
- kubectl kustomize deploy/k8s/platform
- bash -n scripts/prod-remediation-smoke.sh