### PR TITLE
fix(infra): продлить websocket timeout для signalr

### DIFF
--- a/deploy/k8s/platform/identity/pomerium-config.yaml
+++ b/deploy/k8s/platform/identity/pomerium-config.yaml
@@ -23,6 +23,10 @@ data:
         to: http://api-gateway.urfu-prod.svc.cluster.local:8080
         prefix: /hubs
         allow_websockets: true
+        # Pomerium defaults route timeout to 30s; SignalR WebSockets must outlive
+        # normal browser sessions and rely on idle timeout plus application keepalive.
+        timeout: 12h
+        idle_timeout: 75s
         policy:
           - allow:
               or:

--- a/deploy/k8s/platform/ingress/frontend-web-ingress.yaml
+++ b/deploy/k8s/platform/ingress/frontend-web-ingress.yaml
@@ -8,6 +8,9 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
 spec:
   ingressClassName: nginx
   tls:

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -33,10 +33,16 @@ public sealed class DeploymentContractTests
     public void ProductionPomeriumRoutesShouldProxyApiAndSignalRHubsToGateway()
     {
         var config = ReadRepoFile("deploy", "k8s", "platform", "identity", "pomerium-config.yaml");
+        var ingress = ReadRepoFile("deploy", "k8s", "platform", "ingress", "frontend-web-ingress.yaml");
 
         Assert.Contains("prefix: /api", config, StringComparison.Ordinal);
         Assert.Contains("prefix: /hubs", config, StringComparison.Ordinal);
         Assert.Contains("allow_websockets: true", config, StringComparison.Ordinal);
+        Assert.Contains("timeout: 12h", config, StringComparison.Ordinal);
+        Assert.Contains("idle_timeout: 75s", config, StringComparison.Ordinal);
+        Assert.Contains("nginx.ingress.kubernetes.io/proxy-read-timeout: \"3600\"", ingress, StringComparison.Ordinal);
+        Assert.Contains("nginx.ingress.kubernetes.io/proxy-send-timeout: \"3600\"", ingress, StringComparison.Ordinal);
+        Assert.Contains("nginx.ingress.kubernetes.io/proxy-http-version: \"1.1\"", ingress, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Что изменено
- Добавлен явный Pomerium timeout/idle_timeout для маршрута /hubs, чтобы SignalR WebSocket не закрывался дефолтным route timeout.
- Добавлены nginx ingress proxy timeout/http-version для urfu-link.ghjc.ru перед Pomerium.
- Расширен contract-тест на production SignalR routing.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- kubectl kustomize deploy/k8s/platform
- git diff --check