### PR TITLE
fix(infra): исправить claim headers pomerium

### DIFF
--- a/deploy/k8s/platform/identity/pomerium-config.yaml
+++ b/deploy/k8s/platform/identity/pomerium-config.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: urfu-platform
 data:
   config.yaml: |
+    jwt_claims_headers:
+      X-Session-Id: sid
+
     routes:
       # Frontend API — Pomerium passes X-Pomerium-Jwt-Assertion to upstream
       - from: https://urfu-link.ghjc.ru
@@ -15,8 +18,6 @@ data:
               or:
                 - authenticated_user: true
         pass_identity_headers: true
-        jwt_claims_headers:
-          X-Session-Id: sid
 
       # SignalR hubs: authenticated traffic goes through the same gateway as REST.
       - from: https://urfu-link.ghjc.ru
@@ -32,8 +33,6 @@ data:
               or:
                 - authenticated_user: true
         pass_identity_headers: true
-        jwt_claims_headers:
-          X-Session-Id: sid
 
       # Static assets: allow unauthenticated access so app-config.js is loaded
       # before the auth flow starts. Without this Pomerium intercepts app-config.js

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -38,6 +38,8 @@ public sealed class DeploymentContractTests
         Assert.Contains("prefix: /api", config, StringComparison.Ordinal);
         Assert.Contains("prefix: /hubs", config, StringComparison.Ordinal);
         Assert.Contains("allow_websockets: true", config, StringComparison.Ordinal);
+        Assert.Contains("jwt_claims_headers:\n      X-Session-Id: sid\n\n    routes:", config, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(config, "jwt_claims_headers:"));
         Assert.Contains("timeout: 12h", config, StringComparison.Ordinal);
         Assert.Contains("idle_timeout: 75s", config, StringComparison.Ordinal);
         Assert.Contains("nginx.ingress.kubernetes.io/proxy-read-timeout: \"3600\"", ingress, StringComparison.Ordinal);
@@ -312,5 +314,18 @@ public sealed class DeploymentContractTests
 
         var documentEnd = manifest.IndexOf("---", documentStart, StringComparison.Ordinal);
         return documentEnd < 0 ? manifest[documentStart..] : manifest[documentStart..documentEnd];
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
     }
 }


### PR DESCRIPTION
## Что изменено
- Перенесён jwt_claims_headers из route blocks в top-level Pomerium config, чтобы текущий Pomerium Core не логировал unknown config option.
- Сохранена передача X-Session-Id из sid claim.
- Расширен contract-тест на единственный top-level jwt_claims_headers.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- kubectl kustomize deploy/k8s/platform
- git diff --check