### PR TITLE
release: databroker startup gate для pomerium

### DIFF
--- a/deploy/k8s/platform/identity/pomerium.yaml
+++ b/deploy/k8s/platform/identity/pomerium.yaml
@@ -15,6 +15,33 @@ spec:
       labels:
         app.kubernetes.io/name: pomerium
     spec:
+      initContainers:
+        - name: wait-for-databroker-postgres
+          image: busybox:1.36.1
+          command:
+            - sh
+            - -ec
+            - |
+              until nc -z urfu-postgres-rw.urfu-platform.svc.cluster.local 5432; do
+                echo "waiting for pomerium databroker postgres"
+                sleep 2
+              done
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: pomerium
           image: cr.pomerium.com/pomerium/pomerium:v0.27.2

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -48,6 +48,19 @@ public sealed class DeploymentContractTests
     }
 
     [Fact]
+    public void ProductionPomeriumShouldWaitForDatabrokerPostgresBeforeStarting()
+    {
+        var deployment = ReadRepoFile("deploy", "k8s", "platform", "identity", "pomerium.yaml");
+
+        Assert.Contains("initContainers:", deployment, StringComparison.Ordinal);
+        Assert.Contains("name: wait-for-databroker-postgres", deployment, StringComparison.Ordinal);
+        Assert.Contains("image: busybox:1.36.1", deployment, StringComparison.Ordinal);
+        Assert.Contains("nc -z urfu-postgres-rw.urfu-platform.svc.cluster.local 5432", deployment, StringComparison.Ordinal);
+        Assert.Contains("runAsNonRoot: true", deployment, StringComparison.Ordinal);
+        Assert.Contains("readOnlyRootFilesystem: true", deployment, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProductionApiHostShouldResolveToGateway()
     {
         var frontendValues = ReadRepoFile("deploy", "helm", "services", "frontend-web", "values-prod.yaml");


### PR DESCRIPTION
## Что изменено
- Доставляет production-фикс: Pomerium ждёт доступность Postgres databroker через initContainer перед стартом.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- kubectl kustomize deploy/k8s/platform
- git diff --check