### PR TITLE
release: tmp volume для avatar upload

### DIFF
--- a/deploy/helm/charts/urfu-service/templates/deployment.yaml
+++ b/deploy/helm/charts/urfu-service/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.livenessPath }}
@@ -92,6 +96,10 @@ spec:
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deploy/helm/charts/urfu-service/templates/rollout.yaml
+++ b/deploy/helm/charts/urfu-service/templates/rollout.yaml
@@ -56,6 +56,10 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.livenessPath }}
@@ -92,6 +96,10 @@ spec:
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   strategy:

--- a/deploy/helm/charts/urfu-service/values.yaml
+++ b/deploy/helm/charts/urfu-service/values.yaml
@@ -35,6 +35,10 @@ securityContext:
     drop:
       - ALL
 
+extraVolumeMounts: []
+
+extraVolumes: []
+
 service:
   type: ClusterIP
   port: 8080

--- a/deploy/helm/services/user-service/values-prod.yaml
+++ b/deploy/helm/services/user-service/values-prod.yaml
@@ -55,6 +55,14 @@ resources:
     cpu: 250m
     memory: 256Mi
 
+extraVolumeMounts:
+  - name: tmp
+    mountPath: /tmp
+
+extraVolumes:
+  - name: tmp
+    emptyDir: {}
+
 # Helm pre-upgrade Job (helm.sh/hook-weight: -5) runs `--migrate` against the
 # same image and secrets before any new app pod starts. A non-zero exit aborts
 # the rollout so the new pods never face an un-migrated schema.

--- a/tests/contract/ContractTests/DeploymentContractTests.cs
+++ b/tests/contract/ContractTests/DeploymentContractTests.cs
@@ -75,6 +75,26 @@ public sealed class DeploymentContractTests
     }
 
     [Fact]
+    public void UserServiceAvatarUploadShouldHaveWritableTempVolume()
+    {
+        var chartValues = ReadRepoFile("deploy", "helm", "charts", "urfu-service", "values.yaml");
+        var rollout = ReadRepoFile("deploy", "helm", "charts", "urfu-service", "templates", "rollout.yaml");
+        var deployment = ReadRepoFile("deploy", "helm", "charts", "urfu-service", "templates", "deployment.yaml");
+        var userValues = ReadRepoFile("deploy", "helm", "services", "user-service", "values-prod.yaml");
+
+        Assert.Contains("extraVolumeMounts: []", chartValues, StringComparison.Ordinal);
+        Assert.Contains("extraVolumes: []", chartValues, StringComparison.Ordinal);
+        Assert.Contains("{{- with .Values.extraVolumeMounts }}", rollout, StringComparison.Ordinal);
+        Assert.Contains("{{- with .Values.extraVolumes }}", rollout, StringComparison.Ordinal);
+        Assert.Contains("{{- with .Values.extraVolumeMounts }}", deployment, StringComparison.Ordinal);
+        Assert.Contains("{{- with .Values.extraVolumes }}", deployment, StringComparison.Ordinal);
+        Assert.Contains("readOnlyRootFilesystem: true", chartValues, StringComparison.Ordinal);
+        Assert.Contains("name: tmp", userValues, StringComparison.Ordinal);
+        Assert.Contains("mountPath: /tmp", userValues, StringComparison.Ordinal);
+        Assert.Contains("emptyDir:", userValues, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProductionMediaStorageShouldExposeBrowserReachablePresignedUrls()
     {
         var mediaValues = ReadRepoFile("deploy", "helm", "services", "media-service", "values-prod.yaml");


### PR DESCRIPTION
## Что изменено
- Доставляет production-фикс writable /tmp для UserService avatar upload при read-only root filesystem.
- Helm chart получает extraVolumes/extraVolumeMounts для Rollout/Deployment.

## Проверки
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- helm template user-service deploy/helm/charts/urfu-service -f deploy/helm/services/user-service/values-prod.yaml --namespace urfu-prod
- git diff --check