### PR TITLE
feat: добавить центр in-app уведомлений

### DIFF
--- a/apps/client/app/(authorized)/_layout.tsx
+++ b/apps/client/app/(authorized)/_layout.tsx
@@ -9,6 +9,7 @@ import type { Edge } from "react-native-safe-area-context";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { usePresenceHub } from "@/shared/lib/usePresenceHub";
 import { useChatHub } from "@/shared/lib/useChatHub";
+import { useNotificationHub } from "@/features/notifications";
 
 export default function AuthLayout() {
     const segments = useSegments() as string[];
@@ -21,6 +22,7 @@ export default function AuthLayout() {
     // Хуки сами обрабатывают AppState (background/foreground) и cleanup при unmount.
     useChatHub();
     usePresenceHub();
+    useNotificationHub();
 
     const safeAreaEdges: Edge[] = isMobile
         ? ["top", "left", "right", "bottom"]

--- a/apps/client/app/(authorized)/notifications.tsx
+++ b/apps/client/app/(authorized)/notifications.tsx
@@ -1,0 +1,5 @@
+import { NotificationCenterScreen } from "@/features/notifications";
+
+export default function NotificationsScreen() {
+    return <NotificationCenterScreen />;
+}

--- a/apps/client/src/entities/view/ui/ViewToggle.tsx
+++ b/apps/client/src/entities/view/ui/ViewToggle.tsx
@@ -1,4 +1,6 @@
 import { useWindowSize } from "@/shared/lib/useWindowSize";
+import { useNotificationBadge } from "@/features/notifications";
+import { useNotificationStore } from "@/shared/store/notification-store";
 import { BellIcon, ChatCircleTextIcon } from "@/shared/ui/phosphor";
 import { Link } from "expo-router";
 import React from "react";
@@ -17,6 +19,9 @@ const TOGGLE_ITEMS = [
 
 export const ViewToggle = ({ currentView, createHref }: ViewToggleProps) => {
     const { isMobile } = useWindowSize();
+    const { data } = useNotificationBadge();
+    const liveBadge = useNotificationStore((s) => s.badge);
+    const unreadCount = (liveBadge ?? data)?.total ?? 0;
 
     const containerClasses = isMobile
         ? "flex-row items-center gap-1"
@@ -49,7 +54,7 @@ export const ViewToggle = ({ currentView, createHref }: ViewToggleProps) => {
                         >
                             <View className="relative">
                                 <Icon size={iconSize} weight={iconWeight} className={iconColor} />
-                                {hasBadge && (
+                                {hasBadge && unreadCount > 0 && (
                                     <View className="absolute top-0 right-0 w-2 h-2 bg-red-500 rounded-full border border-app-bg" />
                                 )}
                             </View>

--- a/apps/client/src/features/notifications/index.ts
+++ b/apps/client/src/features/notifications/index.ts
@@ -1,0 +1,8 @@
+export { useNotificationBadge, useNotifications, notificationKeys } from "./model/queries";
+export {
+    useMarkNotificationRead,
+    useMarkNotificationDone,
+    useMarkAllNotificationsRead,
+} from "./model/mutations";
+export { useNotificationHub } from "./model/use-notification-hub";
+export { NotificationCenterScreen } from "./ui/NotificationCenterScreen";

--- a/apps/client/src/features/notifications/model/mutations.ts
+++ b/apps/client/src/features/notifications/model/mutations.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { NotificationListStatus } from "@urfu-link/api-client";
+import { apiClient } from "@/shared/lib/api";
+import { notificationKeys } from "./queries";
+
+const useInvalidateNotifications = () => {
+    const queryClient = useQueryClient();
+    return () => {
+        queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+    };
+};
+
+export function useMarkNotificationRead() {
+    const invalidate = useInvalidateNotifications();
+    return useMutation({
+        mutationFn: (id: string) => apiClient.notifications.markRead(id),
+        onSuccess: invalidate,
+    });
+}
+
+export function useMarkNotificationDone() {
+    const invalidate = useInvalidateNotifications();
+    return useMutation({
+        mutationFn: (id: string) => apiClient.notifications.markDone(id),
+        onSuccess: invalidate,
+    });
+}
+
+export function useMarkAllNotificationsRead(status: NotificationListStatus = "unread") {
+    const invalidate = useInvalidateNotifications();
+    return useMutation({
+        mutationFn: () =>
+            apiClient.notifications.bulk({
+                action: "read",
+                filter: { status },
+            }),
+        onSuccess: invalidate,
+    });
+}

--- a/apps/client/src/features/notifications/model/queries.ts
+++ b/apps/client/src/features/notifications/model/queries.ts
@@ -1,0 +1,39 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import type { ListNotificationsParams, NotificationListStatus } from "@urfu-link/api-client";
+import { apiClient } from "@/shared/lib/api";
+
+export const notificationKeys = {
+    all: ["notifications"] as const,
+    lists: () => [...notificationKeys.all, "list"] as const,
+    list: (status: NotificationListStatus, query: string) =>
+        [...notificationKeys.lists(), { status, query }] as const,
+    badge: () => [...notificationKeys.all, "badge"] as const,
+};
+
+export function useNotificationBadge() {
+    return useQuery({
+        queryKey: notificationKeys.badge(),
+        queryFn: () => apiClient.notifications.getBadge(),
+        staleTime: 15_000,
+    });
+}
+
+export function useNotifications(status: NotificationListStatus, query = "") {
+    return useInfiniteQuery({
+        queryKey: notificationKeys.list(status, query),
+        initialPageParam: undefined as string | undefined,
+        queryFn: ({ pageParam }) => {
+            const params: ListNotificationsParams = {
+                cursor: pageParam,
+                limit: 30,
+                status,
+            };
+            if (query.trim().length > 0) {
+                params.query = query.trim();
+            }
+
+            return apiClient.notifications.list(params);
+        },
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    });
+}

--- a/apps/client/src/features/notifications/model/use-notification-hub.ts
+++ b/apps/client/src/features/notifications/model/use-notification-hub.ts
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { AppState, AppStateStatus } from "react-native";
+import { HubConnectionState } from "@microsoft/signalr";
+import { useQueryClient } from "@tanstack/react-query";
+import type { NotificationBadgeDto, NotificationDto } from "@urfu-link/api-client";
+import { createHubConnection } from "@/shared/lib/signalr";
+import { useNotificationStore } from "@/shared/store/notification-store";
+import { notificationKeys } from "./queries";
+
+export function useNotificationHub() {
+    const queryClient = useQueryClient();
+    const setConnected = useNotificationStore((s) => s.setConnected);
+    const setBadge = useNotificationStore((s) => s.setBadge);
+
+    useEffect(() => {
+        const connection = createHubConnection("/hubs/notifications");
+
+        const invalidateNotifications = () => {
+            queryClient.invalidateQueries({ queryKey: notificationKeys.all });
+        };
+
+        connection.on("BadgeUpdated", (badge: NotificationBadgeDto) => {
+            setBadge(badge);
+            queryClient.setQueryData(notificationKeys.badge(), badge);
+        });
+
+        connection.on("NotificationReceived", (_notification: NotificationDto) => {
+            invalidateNotifications();
+        });
+
+        connection.on("NotificationUpserted", (_notification: NotificationDto) => {
+            invalidateNotifications();
+        });
+
+        connection.on("NotificationStateChanged", () => {
+            invalidateNotifications();
+        });
+
+        connection.on("NotificationRemoved", () => {
+            invalidateNotifications();
+        });
+
+        connection.on("NotificationBackfillRequired", () => {
+            invalidateNotifications();
+        });
+
+        connection.onreconnected(() => {
+            setConnected(true);
+            invalidateNotifications();
+        });
+
+        connection.onreconnecting(() => {
+            setConnected(false);
+        });
+
+        connection.onclose(() => {
+            setConnected(false);
+        });
+
+        const connect = async () => {
+            if (connection.state === HubConnectionState.Connected) {
+                return;
+            }
+
+            try {
+                await connection.start();
+                setConnected(true);
+            } catch (error) {
+                console.warn("NotificationHub connection failed", error);
+                setConnected(false);
+            }
+        };
+
+        void connect();
+
+        const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
+            if (nextState === "active") {
+                void connect();
+            }
+        });
+
+        return () => {
+            subscription.remove();
+            void connection.stop();
+            setConnected(false);
+        };
+    }, [queryClient, setBadge, setConnected]);
+}

--- a/apps/client/src/features/notifications/ui/NotificationCenterScreen.tsx
+++ b/apps/client/src/features/notifications/ui/NotificationCenterScreen.tsx
@@ -1,0 +1,33 @@
+import type { NotificationListStatus } from "@urfu-link/api-client";
+import React, { useMemo, useState } from "react";
+import { NotificationCenter } from "@/widgets/notifications";
+import {
+    useMarkNotificationDone,
+    useMarkNotificationRead,
+    useNotifications,
+} from "@/features/notifications";
+
+export const NotificationCenterScreen = () => {
+    const [filter, setFilter] = useState<NotificationListStatus>("all");
+    const notifications = useNotifications(filter);
+    const markRead = useMarkNotificationRead();
+    const markDone = useMarkNotificationDone();
+
+    const items = useMemo(
+        () => notifications.data?.pages.flatMap((page) => page.items) ?? [],
+        [notifications.data],
+    );
+
+    return (
+        <NotificationCenter
+            items={items}
+            isLoading={notifications.isLoading}
+            filter={filter}
+            onFilterChange={setFilter}
+            onMarkRead={(id) => markRead.mutate(id)}
+            onMarkDone={(id) => markDone.mutate(id)}
+            onLoadMore={() => notifications.fetchNextPage()}
+            hasMore={notifications.hasNextPage ?? false}
+        />
+    );
+};

--- a/apps/client/src/shared/api/inbox.ts
+++ b/apps/client/src/shared/api/inbox.ts
@@ -1,4 +1,15 @@
 import { InboxNotificationProps } from "@/entities/inbox-notification";
+import { apiClient } from "@/shared/lib/api";
+
+const chatCategories = new Set([1, 2, 10, 11, 40, 41]);
+
+const formatTime = (iso: string) =>
+    new Intl.DateTimeFormat("ru-RU", {
+        day: "2-digit",
+        month: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+    }).format(new Date(iso));
 
 /**
  * Inbox API сжалось до notifications: чаты и предметы теперь читаются
@@ -6,7 +17,14 @@ import { InboxNotificationProps } from "@/entities/inbox-notification";
  */
 export const inboxApi = {
     getNotifications: async (): Promise<InboxNotificationProps[]> => {
-        // TODO: подключить реальный NotificationService.
-        return [];
+        const response = await apiClient.notifications.list({ limit: 50, status: "all" });
+        return response.items.map((item) => ({
+            id: item.id,
+            title: item.title,
+            description: item.body,
+            time: formatTime(item.lastOccurrenceAtUtc),
+            scope: chatCategories.has(item.category) ? "chats" : "subjects",
+            isRead: item.readAtUtc !== null,
+        }));
     },
 };

--- a/apps/client/src/shared/store/notification-store.ts
+++ b/apps/client/src/shared/store/notification-store.ts
@@ -1,0 +1,16 @@
+import type { NotificationBadgeDto } from "@urfu-link/api-client";
+import { create } from "zustand";
+
+type NotificationConnectionState = {
+    isConnected: boolean;
+    badge: NotificationBadgeDto | null;
+    setConnected: (isConnected: boolean) => void;
+    setBadge: (badge: NotificationBadgeDto | null) => void;
+};
+
+export const useNotificationStore = create<NotificationConnectionState>((set) => ({
+    isConnected: false,
+    badge: null,
+    setConnected: (isConnected) => set({ isConnected }),
+    setBadge: (badge) => set({ badge }),
+}));

--- a/apps/client/src/widgets/header-mobile/ui/MobileHeader.tsx
+++ b/apps/client/src/widgets/header-mobile/ui/MobileHeader.tsx
@@ -1,5 +1,10 @@
 import { Logo } from "@/shared/ui";
 import { ViewToggle, ViewType } from "@/entities/view";
+import { useNotificationBadge } from "@/features/notifications";
+import { useNotificationStore } from "@/shared/store/notification-store";
+import { NotificationBell } from "@/widgets/notifications";
+import type { Href } from "expo-router";
+import { router } from "expo-router";
 import React from "react";
 import { Text, View } from "react-native";
 
@@ -12,8 +17,9 @@ export const MobileHeader = ({
     currentView = "messages",
     createHref,
 }: MobileHeaderProps) => {
-    const messagesActive = currentView === "messages";
-    const notificationsActive = currentView === "notifications";
+    const { data } = useNotificationBadge();
+    const liveBadge = useNotificationStore((s) => s.badge);
+    const badge = liveBadge ?? data;
 
     return (
         <View className="flex-row items-center justify-between px-4 py-1.5">
@@ -22,7 +28,14 @@ export const MobileHeader = ({
                 <Text className="text-white text-lg font-extrabold tracking-tight">URFU LINK</Text>
             </View>
 
-            <ViewToggle currentView={currentView} createHref={createHref} />
+            <View className="flex-row items-center gap-2">
+                <NotificationBell
+                    unreadCount={badge?.total ?? 0}
+                    unseenCount={badge?.totalUnseen ?? 0}
+                    onPress={() => router.push("/notifications" as Href)}
+                />
+                <ViewToggle currentView={currentView} createHref={createHref} />
+            </View>
         </View>
     );
 };

--- a/apps/client/src/widgets/notifications/index.ts
+++ b/apps/client/src/widgets/notifications/index.ts
@@ -1,0 +1,2 @@
+export { NotificationBell } from "./ui/NotificationBell";
+export { NotificationCenter } from "./ui/NotificationCenter";

--- a/apps/client/src/widgets/notifications/ui/NotificationBell.tsx
+++ b/apps/client/src/widgets/notifications/ui/NotificationBell.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import { BellIcon } from "@/shared/ui/phosphor";
+
+type NotificationBellProps = {
+    unreadCount: number;
+    unseenCount: number;
+    onPress: () => void;
+};
+
+const formatCount = (count: number) => (count > 99 ? "99+" : String(count));
+
+export const NotificationBell = ({ unreadCount, unseenCount, onPress }: NotificationBellProps) => {
+    const hasUnread = unreadCount > 0;
+    const hasUnseen = unseenCount > 0;
+
+    return (
+        <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Открыть уведомления"
+            onPress={onPress}
+            hitSlop={8}
+            className="relative h-11 w-11 items-center justify-center rounded-xl bg-white/5 border border-white/5"
+        >
+            <BellIcon
+                size={22}
+                weight={hasUnread ? "fill" : "regular"}
+                className={hasUnread ? "text-white" : "text-text-muted"}
+            />
+            {hasUnread && (
+                <View className="absolute -right-1 -top-1 min-w-[22px] h-[22px] rounded-full bg-red-500 px-1.5 items-center justify-center border border-app-bg">
+                    <Text className="text-[10px] leading-none font-bold text-white">
+                        {formatCount(unreadCount)}
+                    </Text>
+                </View>
+            )}
+            {hasUnseen && !hasUnread && (
+                <View className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-red-500 border border-app-bg" />
+            )}
+        </Pressable>
+    );
+};

--- a/apps/client/src/widgets/notifications/ui/NotificationCenter.tsx
+++ b/apps/client/src/widgets/notifications/ui/NotificationCenter.tsx
@@ -1,0 +1,177 @@
+import type { NotificationDto, NotificationListStatus } from "@urfu-link/api-client";
+import React from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import {
+    AtIcon,
+    BellIcon,
+    ChatCircleTextIcon,
+    CheckIcon,
+    ClockIcon,
+    FileIcon,
+    PhoneIcon,
+    PushPinIcon,
+    ShieldCheckIcon,
+    WarningCircleIcon,
+} from "@/shared/ui/phosphor";
+import { EmptyState } from "@/shared/ui/EmptyState";
+import { Skeleton } from "@/shared/ui/Skeleton";
+
+type NotificationCenterProps = {
+    items: NotificationDto[];
+    isLoading: boolean;
+    filter: NotificationListStatus;
+    onFilterChange: (filter: NotificationListStatus) => void;
+    onMarkRead: (id: string) => void;
+    onMarkDone: (id: string) => void;
+    onLoadMore: () => void;
+    hasMore: boolean;
+};
+
+const filters: { id: NotificationListStatus; label: string }[] = [
+    { id: "all", label: "Все" },
+    { id: "unread", label: "Непрочитанные" },
+    { id: "saved", label: "Сохраненные" },
+    { id: "done", label: "Готово" },
+];
+
+const typeIcon = (type: string) => {
+    if (type.includes("mention")) return AtIcon;
+    if (type.includes("chat")) return ChatCircleTextIcon;
+    if (type.includes("deadline")) return ClockIcon;
+    if (type.includes("material")) return FileIcon;
+    if (type.includes("call")) return PhoneIcon;
+    if (type.includes("admin")) return ShieldCheckIcon;
+    if (type.includes("system") || type.includes("maintenance")) return WarningCircleIcon;
+    return BellIcon;
+};
+
+const formatTime = (iso: string) =>
+    new Intl.DateTimeFormat("ru-RU", {
+        day: "2-digit",
+        month: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+    }).format(new Date(iso));
+
+function NotificationRow({
+    item,
+    onMarkRead,
+    onMarkDone,
+}: {
+    item: NotificationDto;
+    onMarkRead: (id: string) => void;
+    onMarkDone: (id: string) => void;
+}) {
+    const Icon = typeIcon(item.type);
+    const unread = item.readAtUtc === null;
+
+    return (
+        <View className="flex-row gap-3 px-4 py-3 border-b border-white/5 bg-app-bg">
+            <View className={`h-11 w-11 rounded-xl items-center justify-center border ${unread ? "bg-brand-600 border-brand-500" : "bg-white/5 border-white/5"}`}>
+                <Icon size={22} className="text-white" weight={unread ? "bold" : "regular"} />
+            </View>
+
+            <View className="flex-1 min-w-0 gap-1">
+                <View className="flex-row items-start gap-2">
+                    <Text numberOfLines={1} className={`flex-1 text-[15px] ${unread ? "text-white font-bold" : "text-text-secondary font-semibold"}`}>
+                        {item.title}
+                    </Text>
+                    <Text className="text-[11px] text-text-muted">{formatTime(item.lastOccurrenceAtUtc)}</Text>
+                </View>
+                <Text numberOfLines={2} className="text-[13px] leading-5 text-text-muted">
+                    {item.body}
+                </Text>
+                {item.occurrenceCount > 1 && (
+                    <Text className="text-xs text-text-placeholder">{item.occurrenceCount} событий в группе</Text>
+                )}
+                <View className="flex-row gap-2 pt-1">
+                    {unread && (
+                        <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel="Отметить прочитанным"
+                            onPress={() => onMarkRead(item.id)}
+                            className="h-8 w-8 items-center justify-center rounded-lg bg-white/5"
+                        >
+                            <CheckIcon size={17} className="text-text-secondary" />
+                        </Pressable>
+                    )}
+                    <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Готово"
+                        onPress={() => onMarkDone(item.id)}
+                        className="h-8 w-8 items-center justify-center rounded-lg bg-white/5"
+                    >
+                        <PushPinIcon size={17} className="text-text-secondary" />
+                    </Pressable>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+export const NotificationCenter = ({
+    items,
+    isLoading,
+    filter,
+    onFilterChange,
+    onMarkRead,
+    onMarkDone,
+    onLoadMore,
+    hasMore,
+}: NotificationCenterProps) => {
+    return (
+        <View className="flex-1 bg-app-bg" accessibilityLiveRegion="polite">
+            <View className="px-4 pt-4 pb-3 border-b border-white/5 gap-3">
+                <Text className="text-white text-2xl font-bold">Уведомления</Text>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2">
+                    {filters.map((item) => {
+                        const active = item.id === filter;
+                        return (
+                            <Pressable
+                                key={item.id}
+                                accessibilityRole="tab"
+                                accessibilityState={{ selected: active }}
+                                onPress={() => onFilterChange(item.id)}
+                                className={`px-3 h-9 rounded-lg items-center justify-center border ${active ? "bg-brand-600 border-brand-500" : "bg-white/5 border-white/5"}`}
+                            >
+                                <Text className={`text-sm font-semibold ${active ? "text-white" : "text-text-muted"}`}>
+                                    {item.label}
+                                </Text>
+                            </Pressable>
+                        );
+                    })}
+                </ScrollView>
+            </View>
+
+            {isLoading && items.length === 0 ? (
+                <View className="px-4 py-4 gap-3">
+                    {[0, 1, 2, 3].map((key) => (
+                        <Skeleton key={key} className="h-[92px] rounded-xl" />
+                    ))}
+                </View>
+            ) : items.length === 0 ? (
+                <EmptyState size="full" title="Уведомлений нет" description="Здесь появятся важные события по чатам, дисциплинам и системе." />
+            ) : (
+                <ScrollView className="flex-1">
+                    {items.map((item) => (
+                        <NotificationRow
+                            key={item.id}
+                            item={item}
+                            onMarkRead={onMarkRead}
+                            onMarkDone={onMarkDone}
+                        />
+                    ))}
+                    {hasMore && (
+                        <Pressable
+                            accessibilityRole="button"
+                            onPress={onLoadMore}
+                            className="mx-4 my-4 h-11 rounded-xl bg-white/5 items-center justify-center"
+                        >
+                            <Text className="text-text-secondary font-semibold">Загрузить еще</Text>
+                        </Pressable>
+                    )}
+                </ScrollView>
+            )}
+        </View>
+    );
+};

--- a/apps/client/src/widgets/notifications/ui/__tests__/NotificationBell.test.tsx
+++ b/apps/client/src/widgets/notifications/ui/__tests__/NotificationBell.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { NotificationBell } from "../NotificationBell";
+
+describe("NotificationBell", () => {
+    it("renders unread badge count and opens the center", () => {
+        const onPress = jest.fn();
+
+        render(<NotificationBell unreadCount={12} unseenCount={3} onPress={onPress} />);
+
+        expect(screen.getByText("12")).toBeTruthy();
+        fireEvent.press(screen.getByRole("button"));
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("caps large badge counts", () => {
+        render(<NotificationBell unreadCount={150} unseenCount={0} onPress={jest.fn()} />);
+
+        expect(screen.getByText("99+")).toBeTruthy();
+    });
+});

--- a/apps/client/src/widgets/notifications/ui/__tests__/NotificationCenter.test.tsx
+++ b/apps/client/src/widgets/notifications/ui/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { NotificationCenter } from "../NotificationCenter";
+
+const items = [
+    {
+        id: "n1",
+        recipientUserId: "u1",
+        type: "chat.mention",
+        category: 2,
+        severity: 2 as const,
+        title: "Вас упомянули",
+        body: "Преподаватель отметил вас в обсуждении",
+        imageUrl: null,
+        deepLink: "/chats/c1",
+        data: {},
+        actor: null,
+        entity: null,
+        actions: [],
+        groupKey: null,
+        occurrenceCount: 1,
+        createdAtUtc: "2026-05-25T10:00:00.000Z",
+        lastOccurrenceAtUtc: "2026-05-25T10:00:00.000Z",
+        readAtUtc: null,
+        seenAtUtc: null,
+        savedAtUtc: null,
+        doneAtUtc: null,
+        archivedAtUtc: null,
+        snoozedUntilUtc: null,
+        expiresAtUtc: null,
+    },
+];
+
+describe("NotificationCenter", () => {
+    it("renders notification rows and quick actions", () => {
+        const markRead = jest.fn();
+        const markDone = jest.fn();
+
+        render(
+            <NotificationCenter
+                items={items}
+                isLoading={false}
+                filter="all"
+                onFilterChange={jest.fn()}
+                onMarkRead={markRead}
+                onMarkDone={markDone}
+                onLoadMore={jest.fn()}
+                hasMore={false}
+            />,
+        );
+
+        expect(screen.getByText("Вас упомянули")).toBeTruthy();
+        fireEvent.press(screen.getByLabelText("Отметить прочитанным"));
+        fireEvent.press(screen.getByLabelText("Готово"));
+
+        expect(markRead).toHaveBeenCalledWith("n1");
+        expect(markDone).toHaveBeenCalledWith("n1");
+    });
+});

--- a/apps/client/src/widgets/sidebar-desktop/ui/Header.tsx
+++ b/apps/client/src/widgets/sidebar-desktop/ui/Header.tsx
@@ -1,11 +1,20 @@
 import { AnimatedView } from "@/shared/lib/nativewind-interop";
 import { AnimatedViewStyle } from "@/shared/types";
 import { Logo } from "@/shared/ui";
+import { useNotificationBadge } from "@/features/notifications";
+import { useNotificationStore } from "@/shared/store/notification-store";
+import { NotificationBell } from "@/widgets/notifications";
+import type { Href } from "expo-router";
+import { router } from "expo-router";
 import { Text, View } from "react-native";
 interface HeaderProps {
     textAnimatedStyle: AnimatedViewStyle;
 }
 export const Header = ({ textAnimatedStyle }: HeaderProps) => {
+    const { data } = useNotificationBadge();
+    const liveBadge = useNotificationStore((s) => s.badge);
+    const badge = liveBadge ?? data;
+
     return (<View className="flex justify-start w-full py-[28px] px-6 flex-row gap-3 items-center">
       <Logo size={39}/>
       <AnimatedView style={textAnimatedStyle}>
@@ -13,5 +22,12 @@ export const Header = ({ textAnimatedStyle }: HeaderProps) => {
           URFU LINK
         </Text>
       </AnimatedView>
+      <View className="ml-auto">
+        <NotificationBell
+          unreadCount={badge?.total ?? 0}
+          unseenCount={badge?.totalUnseen ?? 0}
+          onPress={() => router.push("/notifications" as Href)}
+        />
+      </View>
     </View>);
 };

--- a/packages/api-client/src/__tests__/createApiClient.test.ts
+++ b/packages/api-client/src/__tests__/createApiClient.test.ts
@@ -159,6 +159,72 @@ describe("createApiClient", () => {
     });
   });
 
+  describe("notifications", () => {
+    it("lists notifications with enterprise filters", async () => {
+      const fetchSpy = mockFetchWith({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ items: [], nextCursor: "cursor-2" }),
+      });
+
+      const client = createApiClient({ baseUrl: "" });
+      const result = await client.notifications.list({
+        status: "unread",
+        type: "chat.mention",
+        severity: 2,
+        query: "teacher",
+        limit: 30,
+      });
+
+      expect(result).toEqual({ items: [], nextCursor: "cursor-2" });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/notifications/me/notifications?limit=30&status=unread&type=chat.mention&severity=2&query=teacher",
+        expect.any(Object),
+      );
+    });
+
+    it("applies notification state actions without a request body", async () => {
+      const fetchSpy = mockFetchWith({ status: 204, ok: true });
+
+      const client = createApiClient({ baseUrl: "" });
+      await client.notifications.markDone("notification-1");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/notifications/me/notifications/notification-1/done",
+        expect.objectContaining({ method: "POST" }),
+      );
+      const [, init] = fetchSpy.mock.calls[0];
+      const headers = new Headers((init as RequestInit).headers as HeadersInit);
+      expect(headers.get("Content-Type")).toBeNull();
+    });
+
+    it("sends bulk notification actions", async () => {
+      const fetchSpy = mockFetchWith({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ updated: 2 }),
+      });
+
+      const client = createApiClient({ baseUrl: "" });
+      const result = await client.notifications.bulk({
+        action: "read",
+        filter: { status: "unread", category: 1 },
+      });
+
+      expect(result).toEqual({ updated: 2 });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/notifications/me/notifications/bulk",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            action: "read",
+            filter: { status: "unread", category: 1 },
+          }),
+        }),
+      );
+    });
+  });
+
   describe("media", () => {
     it("does not send JSON content type for bodyless download-url requests", async () => {
       const fetchSpy = mockFetchWith({

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -57,10 +57,26 @@ export type {
   PresenceInfo,
 } from "./presence";
 
+export type {
+  NotificationSeverity,
+  NotificationActorDto,
+  NotificationEntityDto,
+  NotificationActionDto,
+  NotificationDto,
+  NotificationBadgeDto,
+  NotificationListStatus,
+  ListNotificationsParams,
+  ListNotificationsResponse,
+  BulkNotificationFilter,
+  BulkNotificationAction,
+  BulkNotificationActionResponse,
+} from "./notifications";
+
 import { createUsersApi } from "./users";
 import { createChatApi } from "./chat";
 import { createMediaApi } from "./media";
 import { createPresenceApi } from "./presence";
+import { createNotificationsApi } from "./notifications";
 
 type ApiClientConfig = {
   baseUrl: string;
@@ -104,6 +120,7 @@ export function createApiClient({ baseUrl, getAccessToken, onUnauthorized }: Api
     chat: createChatApi(normalizedBaseUrl, authHeaders, handleUnauthorized),
     media: createMediaApi(normalizedBaseUrl, authHeaders, handleUnauthorized),
     presence: createPresenceApi(normalizedBaseUrl, authHeaders, handleUnauthorized),
+    notifications: createNotificationsApi(normalizedBaseUrl, authHeaders, handleUnauthorized),
 
     async health(): Promise<BackendHealth> {
       try {

--- a/packages/api-client/src/notifications.ts
+++ b/packages/api-client/src/notifications.ts
@@ -1,0 +1,174 @@
+import { AuthHeaders, HandleUnauthorized, createRequest } from "./utils";
+
+const PREFIX = "/api/notifications";
+
+export type NotificationSeverity = 0 | 1 | 2 | 3;
+
+export type NotificationActorDto = {
+  id: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type NotificationEntityDto = {
+  kind: string;
+  id: string;
+  displayName: string | null;
+};
+
+export type NotificationActionDto = {
+  id: string;
+  label: string;
+  kind: string;
+  deepLink: string | null;
+};
+
+export type NotificationDto = {
+  id: string;
+  recipientUserId: string;
+  type: string;
+  category: number;
+  severity: NotificationSeverity;
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  deepLink: string | null;
+  data: Record<string, string>;
+  actor: NotificationActorDto | null;
+  entity: NotificationEntityDto | null;
+  actions: NotificationActionDto[];
+  groupKey: string | null;
+  occurrenceCount: number;
+  createdAtUtc: string;
+  lastOccurrenceAtUtc: string;
+  readAtUtc: string | null;
+  seenAtUtc: string | null;
+  savedAtUtc: string | null;
+  doneAtUtc: string | null;
+  archivedAtUtc: string | null;
+  snoozedUntilUtc: string | null;
+  expiresAtUtc: string | null;
+};
+
+export type NotificationBadgeDto = {
+  total: number;
+  perCategory: Record<number, number>;
+  totalUnseen: number;
+  urgentUnread: number;
+  perType: Record<string, number> | null;
+};
+
+export type NotificationListStatus =
+  | "all"
+  | "unread"
+  | "read"
+  | "seen"
+  | "unseen"
+  | "saved"
+  | "done"
+  | "archived";
+
+export type ListNotificationsParams = {
+  cursor?: string;
+  limit?: number;
+  category?: number;
+  status?: NotificationListStatus;
+  type?: string;
+  severity?: NotificationSeverity;
+  query?: string;
+  from?: string;
+  to?: string;
+};
+
+export type ListNotificationsResponse = {
+  items: NotificationDto[];
+  nextCursor?: string | null;
+};
+
+export type BulkNotificationFilter = Omit<ListNotificationsParams, "cursor" | "limit">;
+
+export type BulkNotificationAction = {
+  action: "read" | "unread" | "seen" | "save" | "unsave" | "done" | "restore" | "archive";
+  ids?: string[];
+  filter?: BulkNotificationFilter;
+};
+
+export type BulkNotificationActionResponse = {
+  updated: number;
+};
+
+export function createNotificationsApi(
+  baseUrl: string,
+  authHeaders: AuthHeaders,
+  handleUnauthorized: HandleUnauthorized,
+) {
+  const request = createRequest(baseUrl, authHeaders, handleUnauthorized);
+
+  const stateAction = (id: string, action: BulkNotificationAction["action"]) =>
+    request<void>(`${PREFIX}/me/notifications/${encodeURIComponent(id)}/${action}`, {
+      method: "POST",
+    });
+
+  return {
+    list(params: ListNotificationsParams = {}): Promise<ListNotificationsResponse> {
+      const query = new URLSearchParams();
+      if (params.limit) query.append("limit", String(params.limit));
+      if (params.cursor) query.append("cursor", params.cursor);
+      if (params.status) query.append("status", params.status);
+      if (params.type) query.append("type", params.type);
+      if (params.severity !== undefined) query.append("severity", String(params.severity));
+      if (params.query) query.append("query", params.query);
+      if (params.category !== undefined) query.append("category", String(params.category));
+      if (params.from) query.append("from", params.from);
+      if (params.to) query.append("to", params.to);
+
+      const suffix = query.toString();
+      return request<ListNotificationsResponse>(
+        `${PREFIX}/me/notifications${suffix ? `?${suffix}` : ""}`,
+      );
+    },
+
+    get(id: string): Promise<NotificationDto> {
+      return request<NotificationDto>(`${PREFIX}/me/notifications/${encodeURIComponent(id)}`);
+    },
+
+    getBadge(): Promise<NotificationBadgeDto> {
+      return request<NotificationBadgeDto>(`${PREFIX}/me/notifications/badge`);
+    },
+
+    markRead(id: string): Promise<void> {
+      return stateAction(id, "read");
+    },
+
+    markUnread(id: string): Promise<void> {
+      return stateAction(id, "unread");
+    },
+
+    markSeen(id: string): Promise<void> {
+      return stateAction(id, "seen");
+    },
+
+    save(id: string): Promise<void> {
+      return stateAction(id, "save");
+    },
+
+    unsave(id: string): Promise<void> {
+      return stateAction(id, "unsave");
+    },
+
+    markDone(id: string): Promise<void> {
+      return stateAction(id, "done");
+    },
+
+    restore(id: string): Promise<void> {
+      return stateAction(id, "restore");
+    },
+
+    bulk(action: BulkNotificationAction): Promise<BulkNotificationActionResponse> {
+      return request<BulkNotificationActionResponse>(`${PREFIX}/me/notifications/bulk`, {
+        method: "POST",
+        body: JSON.stringify(action),
+      });
+    },
+  };
+}

--- a/src/Services/Notification/NotificationService.Api/Application/Services/BadgeService.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Services/BadgeService.cs
@@ -3,12 +3,38 @@ using Urfu.Link.Services.Notification.Realtime;
 
 namespace Urfu.Link.Services.Notification.Application.Services;
 
-public sealed class BadgeService(IBadgeStore store)
+public sealed class BadgeService
 {
+    private readonly IBadgeStore _store;
+    private readonly INotificationRepository? _repository;
+
+    public BadgeService(IBadgeStore store)
+    {
+        _store = store;
+    }
+
+    public BadgeService(IBadgeStore store, INotificationRepository repository)
+    {
+        _store = store;
+        _repository = repository;
+    }
+
     public async Task<BadgeSnapshotDto> GetSnapshotAsync(Guid userId, CancellationToken cancellationToken)
     {
-        var snapshot = await store.GetSnapshotAsync(userId, cancellationToken).ConfigureAwait(false);
+        var snapshot = await _store.GetSnapshotAsync(userId, cancellationToken).ConfigureAwait(false);
         var perCategory = snapshot.PerCategory.ToDictionary(kv => (int)kv.Key, kv => kv.Value);
-        return new BadgeSnapshotDto(snapshot.Total, perCategory);
+
+        if (_repository is null)
+        {
+            return new BadgeSnapshotDto(snapshot.Total, perCategory);
+        }
+
+        var counts = await _repository.CountBadgeAsync(userId, cancellationToken).ConfigureAwait(false);
+        return new BadgeSnapshotDto(
+            snapshot.Total,
+            perCategory,
+            counts.TotalUnseen,
+            counts.UrgentUnread,
+            counts.PerType);
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Application/Services/InAppChannel.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Services/InAppChannel.cs
@@ -17,6 +17,7 @@ public sealed class InAppChannel(INotificationBroadcaster broadcaster, BadgeServ
 
         var dto = NotificationDtoMapper.Map(notification);
         await broadcaster.NotifyReceivedAsync(dto, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyUpsertedAsync(dto, cancellationToken).ConfigureAwait(false);
 
         var snapshot = await badgeService.GetSnapshotAsync(notification.RecipientUserId, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Services/Notification/NotificationService.Api/Application/Services/MarkAsReadService.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Services/MarkAsReadService.cs
@@ -3,6 +3,7 @@ using Urfu.Link.Services.Notification.Domain.Enums;
 using Urfu.Link.Services.Notification.Domain.Interfaces;
 using Urfu.Link.Services.Notification.Infrastructure.Outbox;
 using Urfu.Link.Services.Notification.Realtime;
+using NotificationAggregate = Urfu.Link.Services.Notification.Domain.Aggregates.Notification;
 
 namespace Urfu.Link.Services.Notification.Application.Services;
 
@@ -38,8 +39,8 @@ public sealed class MarkAsReadService(
         await badgeStore.DecrementAsync(userId, notification.Category, cancellationToken).ConfigureAwait(false);
 
         await broadcaster.NotifyReadAsync(userId, notification.Id, cancellationToken).ConfigureAwait(false);
-        var snapshot = await badgeStore.GetSnapshotAsync(userId, cancellationToken).ConfigureAwait(false);
-        await broadcaster.NotifyBadgeUpdatedAsync(userId, MapSnapshot(snapshot), cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyStateChangedAsync(userId, MapChange(notification), cancellationToken).ConfigureAwait(false);
+        await BroadcastBadgeAsync(userId, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> MarkAllAsync(Guid userId, NotificationCategory? category, CancellationToken cancellationToken)
@@ -60,6 +61,143 @@ public sealed class MarkAsReadService(
         await broadcaster.NotifyBadgeUpdatedAsync(userId, MapSnapshot(snapshot), cancellationToken).ConfigureAwait(false);
         return updated;
     }
+
+    public async Task<bool> ApplyActionAsync(
+        Guid userId,
+        Guid notificationId,
+        string action,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+
+        var notification = await repository.GetByIdAsync(notificationId, userId, cancellationToken).ConfigureAwait(false);
+        if (notification is null)
+        {
+            return false;
+        }
+
+        var changed = Apply(notification, action, timeProvider.GetUtcNow(), out var badgeDelta);
+        if (!changed)
+        {
+            return false;
+        }
+
+        await repository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await ApplyBadgeDeltaAsync(userId, notification.Category, badgeDelta, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyStateChangedAsync(userId, MapChange(notification), cancellationToken).ConfigureAwait(false);
+        await BroadcastBadgeAsync(userId, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    public async Task<int> ApplyBulkAsync(
+        Guid userId,
+        IReadOnlyList<Guid>? ids,
+        NotificationListFilter filter,
+        string action,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+
+        var notifications = await repository.ListForBulkAsync(userId, filter, ids, 1000, cancellationToken)
+            .ConfigureAwait(false);
+        if (notifications.Count == 0)
+        {
+            return 0;
+        }
+
+        var now = timeProvider.GetUtcNow();
+        var changed = new List<NotificationAggregate>(notifications.Count);
+        foreach (var notification in notifications)
+        {
+            if (Apply(notification, action, now, out _))
+            {
+                changed.Add(notification);
+            }
+        }
+
+        if (changed.Count == 0)
+        {
+            return 0;
+        }
+
+        await repository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var unreadPerCategory = await repository.CountUnreadPerCategoryAsync(userId, cancellationToken).ConfigureAwait(false);
+        var total = unreadPerCategory.Values.Sum();
+        await badgeStore.SetSnapshotAsync(userId, new BadgeSnapshot(total, unreadPerCategory), cancellationToken).ConfigureAwait(false);
+
+        foreach (var notification in changed)
+        {
+            await broadcaster.NotifyStateChangedAsync(userId, MapChange(notification), cancellationToken).ConfigureAwait(false);
+        }
+
+        await BroadcastBadgeAsync(userId, cancellationToken).ConfigureAwait(false);
+        return changed.Count;
+    }
+
+    private static bool Apply(
+        NotificationAggregate notification,
+        string action,
+        DateTimeOffset now,
+        out int badgeDelta)
+    {
+        badgeDelta = 0;
+        var wasUnread = notification.ReadAtUtc is null && notification.DoneAtUtc is null && notification.ArchivedAtUtc is null;
+        var changed = action.Trim().ToUpperInvariant() switch
+        {
+            "READ" => notification.MarkRead(now),
+            "UNREAD" => notification.MarkUnread(),
+            "SEEN" => notification.MarkSeen(now),
+            "SAVE" => notification.Save(now),
+            "UNSAVE" => notification.Unsave(),
+            "DONE" => notification.MarkDone(now),
+            "RESTORE" => notification.Restore(),
+            "ARCHIVE" => notification.Archive(now),
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown notification action."),
+        };
+
+        var isUnread = notification.ReadAtUtc is null && notification.DoneAtUtc is null && notification.ArchivedAtUtc is null;
+        badgeDelta = (wasUnread, isUnread) switch
+        {
+            (true, false) => -1,
+            (false, true) => 1,
+            _ => 0,
+        };
+
+        return changed;
+    }
+
+    private async Task ApplyBadgeDeltaAsync(
+        Guid userId,
+        NotificationCategory category,
+        int badgeDelta,
+        CancellationToken cancellationToken)
+    {
+        if (badgeDelta < 0)
+        {
+            await badgeStore.DecrementAsync(userId, category, cancellationToken).ConfigureAwait(false);
+        }
+        else if (badgeDelta > 0)
+        {
+            await badgeStore.IncrementAsync(userId, category, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task BroadcastBadgeAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var snapshot = await badgeStore.GetSnapshotAsync(userId, cancellationToken).ConfigureAwait(false);
+        await broadcaster.NotifyBadgeUpdatedAsync(userId, MapSnapshot(snapshot), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static NotificationStateChangedDto MapChange(NotificationAggregate notification)
+        => new(
+            notification.Id,
+            notification.ReadAtUtc,
+            notification.SeenAtUtc,
+            notification.SavedAtUtc,
+            notification.DoneAtUtc,
+            notification.ArchivedAtUtc);
 
     private static BadgeSnapshotDto MapSnapshot(BadgeSnapshot snapshot)
     {

--- a/src/Services/Notification/NotificationService.Api/Application/Services/NotificationDtoMapper.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Services/NotificationDtoMapper.cs
@@ -12,6 +12,7 @@ internal static class NotificationDtoMapper
         return new NotificationDto(
             Id: notification.Id,
             RecipientUserId: notification.RecipientUserId,
+            Type: notification.Type,
             Category: notification.Category,
             Severity: notification.Severity,
             Title: notification.Content.Title,
@@ -19,8 +20,25 @@ internal static class NotificationDtoMapper
             ImageUrl: notification.Content.ImageUrl,
             DeepLink: notification.Content.DeepLink,
             Data: notification.Data.Values,
+            Actor: notification.Actor is null
+                ? null
+                : new NotificationActorDto(notification.Actor.Id, notification.Actor.DisplayName, notification.Actor.AvatarUrl),
+            Entity: notification.Entity is null
+                ? null
+                : new NotificationEntityDto(notification.Entity.Kind, notification.Entity.Id, notification.Entity.DisplayName),
+            Actions: notification.Actions
+                .Select(a => new NotificationActionDto(a.Id, a.Label, a.Kind, a.DeepLink))
+                .ToArray(),
             GroupKey: notification.GroupKey?.Value,
+            OccurrenceCount: notification.OccurrenceCount,
             CreatedAtUtc: notification.CreatedAtUtc,
-            ReadAtUtc: notification.ReadAtUtc);
+            LastOccurrenceAtUtc: notification.LastOccurrenceAtUtc,
+            ReadAtUtc: notification.ReadAtUtc,
+            SeenAtUtc: notification.SeenAtUtc,
+            SavedAtUtc: notification.SavedAtUtc,
+            DoneAtUtc: notification.DoneAtUtc,
+            ArchivedAtUtc: notification.ArchivedAtUtc,
+            SnoozedUntilUtc: notification.SnoozedUntilUtc,
+            ExpiresAtUtc: notification.ExpiresAtUtc);
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Domain/Aggregates/Notification.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/Aggregates/Notification.cs
@@ -20,9 +20,17 @@ public sealed class Notification
 
     public NotificationSeverity Severity { get; private set; }
 
+    public string Type { get; private set; } = null!;
+
     public NotificationContent Content { get; private set; } = null!;
 
     public NotificationData Data { get; private set; } = NotificationData.Empty;
+
+    public NotificationActor? Actor { get; private set; }
+
+    public NotificationEntity? Entity { get; private set; }
+
+    public IReadOnlyList<NotificationAction> Actions { get; private set; } = [];
 
     public GroupKey? GroupKey { get; private set; }
 
@@ -33,6 +41,22 @@ public sealed class Notification
     public DateTimeOffset CreatedAtUtc { get; private set; }
 
     public DateTimeOffset? ReadAtUtc { get; private set; }
+
+    public DateTimeOffset? SeenAtUtc { get; private set; }
+
+    public DateTimeOffset? SavedAtUtc { get; private set; }
+
+    public DateTimeOffset? DoneAtUtc { get; private set; }
+
+    public DateTimeOffset? ArchivedAtUtc { get; private set; }
+
+    public DateTimeOffset? SnoozedUntilUtc { get; private set; }
+
+    public DateTimeOffset? ExpiresAtUtc { get; private set; }
+
+    public int OccurrenceCount { get; private set; }
+
+    public DateTimeOffset LastOccurrenceAtUtc { get; private set; }
 
     public IReadOnlyList<Delivery> Deliveries => _deliveries;
 
@@ -51,7 +75,12 @@ public sealed class Notification
         GroupKey? groupKey,
         Guid sourceEventId,
         string sourceEventType,
-        DateTimeOffset createdAtUtc)
+        DateTimeOffset createdAtUtc,
+        string? type = null,
+        NotificationActor? actor = null,
+        NotificationEntity? entity = null,
+        IReadOnlyList<NotificationAction>? actions = null,
+        DateTimeOffset? expiresAtUtc = null)
     {
         if (recipientUserId == Guid.Empty)
         {
@@ -73,18 +102,36 @@ public sealed class Notification
             throw new ArgumentException($"Source event type exceeds {SourceEventTypeMaxLength} characters.", nameof(sourceEventType));
         }
 
+        var descriptor = string.IsNullOrWhiteSpace(type)
+            ? NotificationCatalog.GetByCategory(category)
+            : null;
+        var notificationType = string.IsNullOrWhiteSpace(type) ? descriptor!.Type : type.Trim();
+        if (notificationType.Length > NotificationTypeMaxLength)
+        {
+            throw new ArgumentException($"Notification type exceeds {NotificationTypeMaxLength} characters.", nameof(type));
+        }
+
         var notification = new Notification
         {
             Id = Guid.NewGuid(),
             RecipientUserId = recipientUserId,
             Category = category,
             Severity = severity,
+            Type = notificationType,
             Content = content,
             Data = data,
+            Actor = actor,
+            Entity = entity,
+            Actions = actions is null || actions.Count == 0
+                ? descriptor?.DefaultActions ?? []
+                : actions.ToArray(),
             GroupKey = groupKey,
             SourceEventId = sourceEventId,
             SourceEventType = trimmedType,
             CreatedAtUtc = createdAtUtc,
+            ExpiresAtUtc = expiresAtUtc,
+            OccurrenceCount = 1,
+            LastOccurrenceAtUtc = createdAtUtc,
         };
 
         notification._domainEvents.Add(new NotificationCreatedEvent(
@@ -99,6 +146,8 @@ public sealed class Notification
         return notification;
     }
 
+    public const int NotificationTypeMaxLength = 120;
+
     public bool MarkRead(DateTimeOffset readAtUtc)
     {
         if (ReadAtUtc.HasValue)
@@ -107,8 +156,125 @@ public sealed class Notification
         }
 
         ReadAtUtc = readAtUtc;
+        SeenAtUtc ??= readAtUtc;
         _domainEvents.Add(new NotificationReadEvent(Id, RecipientUserId, readAtUtc));
         return true;
+    }
+
+    public bool MarkUnread()
+    {
+        if (!ReadAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        ReadAtUtc = null;
+        return true;
+    }
+
+    public bool MarkSeen(DateTimeOffset seenAtUtc)
+    {
+        if (SeenAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        SeenAtUtc = seenAtUtc;
+        return true;
+    }
+
+    public bool Save(DateTimeOffset savedAtUtc)
+    {
+        if (SavedAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        SavedAtUtc = savedAtUtc;
+        return true;
+    }
+
+    public bool Unsave()
+    {
+        if (!SavedAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        SavedAtUtc = null;
+        return true;
+    }
+
+    public bool MarkDone(DateTimeOffset doneAtUtc)
+    {
+        if (DoneAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        DoneAtUtc = doneAtUtc;
+        ArchivedAtUtc = null;
+        ReadAtUtc ??= doneAtUtc;
+        SeenAtUtc ??= doneAtUtc;
+        return true;
+    }
+
+    public bool Archive(DateTimeOffset archivedAtUtc)
+    {
+        if (ArchivedAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        ArchivedAtUtc = archivedAtUtc;
+        ReadAtUtc ??= archivedAtUtc;
+        SeenAtUtc ??= archivedAtUtc;
+        return true;
+    }
+
+    public bool Restore()
+    {
+        if (!DoneAtUtc.HasValue && !ArchivedAtUtc.HasValue)
+        {
+            return false;
+        }
+
+        DoneAtUtc = null;
+        ArchivedAtUtc = null;
+        return true;
+    }
+
+    public bool SnoozeUntil(DateTimeOffset snoozedUntilUtc)
+    {
+        if (SnoozedUntilUtc == snoozedUntilUtc)
+        {
+            return false;
+        }
+
+        SnoozedUntilUtc = snoozedUntilUtc;
+        return true;
+    }
+
+    public void RegisterOccurrence(
+        NotificationContent content,
+        NotificationData data,
+        Guid sourceEventId,
+        string sourceEventType,
+        DateTimeOffset occurredAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceEventType);
+
+        Content = content;
+        Data = data;
+        SourceEventId = sourceEventId;
+        SourceEventType = sourceEventType.Trim();
+        OccurrenceCount++;
+        LastOccurrenceAtUtc = occurredAtUtc;
+        DoneAtUtc = null;
+        ArchivedAtUtc = null;
+        ReadAtUtc = null;
     }
 
     public void AddDelivery(Delivery delivery)

--- a/src/Services/Notification/NotificationService.Api/Domain/Aggregates/NotificationDedupKey.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/Aggregates/NotificationDedupKey.cs
@@ -1,0 +1,52 @@
+namespace Urfu.Link.Services.Notification.Domain.Aggregates;
+
+public sealed class NotificationDedupKey
+{
+    public Guid RecipientUserId { get; private set; }
+
+    public Guid SourceEventId { get; private set; }
+
+    public string NotificationType { get; private set; } = null!;
+
+    public Guid NotificationId { get; private set; }
+
+    public DateTimeOffset CreatedAtUtc { get; private set; }
+
+    private NotificationDedupKey()
+    {
+    }
+
+    public static NotificationDedupKey Create(
+        Guid recipientUserId,
+        Guid sourceEventId,
+        string notificationType,
+        Guid notificationId,
+        DateTimeOffset createdAtUtc)
+    {
+        if (recipientUserId == Guid.Empty)
+        {
+            throw new ArgumentException("Recipient user id is required.", nameof(recipientUserId));
+        }
+
+        if (sourceEventId == Guid.Empty)
+        {
+            throw new ArgumentException("Source event id is required.", nameof(sourceEventId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(notificationType);
+
+        if (notificationId == Guid.Empty)
+        {
+            throw new ArgumentException("Notification id is required.", nameof(notificationId));
+        }
+
+        return new NotificationDedupKey
+        {
+            RecipientUserId = recipientUserId,
+            SourceEventId = sourceEventId,
+            NotificationType = notificationType.Trim(),
+            NotificationId = notificationId,
+            CreatedAtUtc = createdAtUtc,
+        };
+    }
+}

--- a/src/Services/Notification/NotificationService.Api/Domain/Interfaces/INotificationRepository.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/Interfaces/INotificationRepository.cs
@@ -11,10 +11,16 @@ public interface INotificationRepository
 
     Task<IReadOnlyList<NotificationAggregate>> ListAsync(
         Guid recipientUserId,
-        NotificationCategory? category,
-        bool unreadOnly,
+        NotificationListFilter filter,
         DateTimeOffset? cursorCreatedAtUtc,
         Guid? cursorId,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<NotificationAggregate>> ListForBulkAsync(
+        Guid recipientUserId,
+        NotificationListFilter filter,
+        IReadOnlyList<Guid>? ids,
         int limit,
         CancellationToken cancellationToken);
 
@@ -30,5 +36,26 @@ public interface INotificationRepository
         Guid recipientUserId,
         CancellationToken cancellationToken);
 
+    Task<NotificationBadgeCounts> CountBadgeAsync(Guid recipientUserId, CancellationToken cancellationToken);
+
     Task SaveChangesAsync(CancellationToken cancellationToken);
 }
+
+public sealed record NotificationListFilter(
+    NotificationCategory? Category = null,
+    string? Type = null,
+    NotificationSeverity? Severity = null,
+    string? Status = null,
+    string? Query = null,
+    DateTimeOffset? From = null,
+    DateTimeOffset? To = null)
+{
+    public bool IsUnread => string.Equals(Status, "unread", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record NotificationBadgeCounts(
+    int TotalUnread,
+    int TotalUnseen,
+    int UrgentUnread,
+    IReadOnlyDictionary<NotificationCategory, int> PerCategory,
+    IReadOnlyDictionary<string, int> PerType);

--- a/src/Services/Notification/NotificationService.Api/Domain/NotificationCatalog.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/NotificationCatalog.cs
@@ -1,0 +1,128 @@
+using Urfu.Link.Services.Notification.Domain.Enums;
+using Urfu.Link.Services.Notification.Domain.ValueObjects;
+
+namespace Urfu.Link.Services.Notification.Domain;
+
+public sealed record NotificationDescriptor(
+    string Type,
+    NotificationCategory Category,
+    NotificationSeverity DefaultSeverity,
+    string Icon,
+    bool Groupable,
+    TimeSpan Retention,
+    IReadOnlyList<NotificationAction> DefaultActions);
+
+public static class NotificationCatalog
+{
+    private static readonly IReadOnlyDictionary<NotificationCategory, NotificationDescriptor> ByCategory =
+        new Dictionary<NotificationCategory, NotificationDescriptor>
+        {
+            [NotificationCategory.ChatMessageDirect] = Descriptor(
+                "chat.message.direct",
+                NotificationCategory.ChatMessageDirect,
+                NotificationSeverity.Normal,
+                "chat-circle",
+                groupable: true),
+            [NotificationCategory.ChatMessageMention] = Descriptor(
+                "chat.mention",
+                NotificationCategory.ChatMessageMention,
+                NotificationSeverity.High,
+                "at",
+                groupable: true),
+            [NotificationCategory.ChatMessageDiscipline] = Descriptor(
+                "chat.message.discipline",
+                NotificationCategory.ChatMessageDiscipline,
+                NotificationSeverity.Normal,
+                "chat-circle-text",
+                groupable: true),
+            [NotificationCategory.CallIncoming] = Descriptor(
+                "call.incoming",
+                NotificationCategory.CallIncoming,
+                NotificationSeverity.Urgent,
+                "phone-call",
+                groupable: false),
+            [NotificationCategory.CallMissed] = Descriptor(
+                "call.missed",
+                NotificationCategory.CallMissed,
+                NotificationSeverity.High,
+                "phone-x",
+                groupable: true),
+            [NotificationCategory.DisciplineAnnouncement] = Descriptor(
+                "discipline.announcement",
+                NotificationCategory.DisciplineAnnouncement,
+                NotificationSeverity.Normal,
+                "megaphone",
+                groupable: true),
+            [NotificationCategory.DisciplineMaterial] = Descriptor(
+                "discipline.material",
+                NotificationCategory.DisciplineMaterial,
+                NotificationSeverity.Normal,
+                "file-text",
+                groupable: true),
+            [NotificationCategory.DisciplineDeadline] = Descriptor(
+                "discipline.deadline",
+                NotificationCategory.DisciplineDeadline,
+                NotificationSeverity.High,
+                "clock-countdown",
+                groupable: true),
+            [NotificationCategory.SystemMaintenance] = Descriptor(
+                "system.maintenance",
+                NotificationCategory.SystemMaintenance,
+                NotificationSeverity.High,
+                "warning",
+                groupable: true),
+            [NotificationCategory.SystemUpdate] = Descriptor(
+                "system.update",
+                NotificationCategory.SystemUpdate,
+                NotificationSeverity.Normal,
+                "sparkle",
+                groupable: true),
+            [NotificationCategory.AdminChatInvite] = Descriptor(
+                "admin.chat.invite",
+                NotificationCategory.AdminChatInvite,
+                NotificationSeverity.High,
+                "user-plus",
+                groupable: false),
+            [NotificationCategory.AdminRoleChanged] = Descriptor(
+                "admin.role.changed",
+                NotificationCategory.AdminRoleChanged,
+                NotificationSeverity.High,
+                "shield-check",
+                groupable: true),
+        };
+
+    private static readonly Dictionary<string, NotificationDescriptor> ByType =
+        ByCategory.Values.ToDictionary(d => d.Type, StringComparer.Ordinal);
+
+    public static NotificationDescriptor GetByCategory(NotificationCategory category)
+        => ByCategory.TryGetValue(category, out var descriptor)
+            ? descriptor
+            : Descriptor(
+                $"category.{(int)category}",
+                category,
+                NotificationSeverity.Normal,
+                "bell",
+                groupable: false);
+
+    public static bool TryGet(string type, out NotificationDescriptor descriptor)
+        => ByType.TryGetValue(type, out descriptor!);
+
+    private static NotificationDescriptor Descriptor(
+        string type,
+        NotificationCategory category,
+        NotificationSeverity severity,
+        string icon,
+        bool groupable)
+        => new(
+            type,
+            category,
+            severity,
+            icon,
+            groupable,
+            Retention: TimeSpan.FromDays(90),
+            DefaultActions:
+            [
+                new NotificationAction("open", "Открыть", "deep-link", null),
+                new NotificationAction("done", "Готово", "state", null),
+            ]);
+}

--- a/src/Services/Notification/NotificationService.Api/Domain/ValueObjects/NotificationMetadata.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/ValueObjects/NotificationMetadata.cs
@@ -1,0 +1,17 @@
+namespace Urfu.Link.Services.Notification.Domain.ValueObjects;
+
+public sealed record NotificationActor(
+    Guid? Id,
+    string? DisplayName,
+    string? AvatarUrl);
+
+public sealed record NotificationEntity(
+    string Kind,
+    string Id,
+    string? DisplayName);
+
+public sealed record NotificationAction(
+    string Id,
+    string Label,
+    string Kind,
+    string? DeepLink);

--- a/src/Services/Notification/NotificationService.Api/Endpoints/BulkNotificationActionEndpoint.cs
+++ b/src/Services/Notification/NotificationService.Api/Endpoints/BulkNotificationActionEndpoint.cs
@@ -1,0 +1,66 @@
+using FastEndpoints;
+using Urfu.Link.Services.Notification.Application.Services;
+using Urfu.Link.Services.Notification.Domain.Enums;
+using Urfu.Link.Services.Notification.Domain.Interfaces;
+using Urfu.Link.Services.Notification.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Notification.Endpoints;
+
+public sealed record BulkNotificationActionRequest(
+    string Action,
+    IReadOnlyList<Guid>? Ids,
+    BulkNotificationFilter? Filter);
+
+public sealed record BulkNotificationFilter(
+    int? Category,
+    string? Type,
+    int? Severity,
+    string? Status,
+    string? Query,
+    DateTimeOffset? From,
+    DateTimeOffset? To);
+
+public sealed record BulkNotificationActionResponse(int Updated);
+
+public sealed class BulkNotificationActionEndpoint(MarkAsReadService service)
+    : Endpoint<BulkNotificationActionRequest, BulkNotificationActionResponse>
+{
+    public override void Configure()
+    {
+        Post("/me/notifications/bulk");
+        Summary(s => s.Summary = "Apply a notification state action to selected ids or a filter");
+    }
+
+    public override async Task HandleAsync(BulkNotificationActionRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+        var userId = HttpContext.User.GetUserId();
+        var filter = Map(req.Filter);
+
+        var updated = await service.ApplyBulkAsync(
+            userId,
+            req.Ids,
+            filter,
+            req.Action,
+            ct).ConfigureAwait(false);
+
+        await Send.OkAsync(new BulkNotificationActionResponse(updated), ct).ConfigureAwait(false);
+    }
+
+    private static NotificationListFilter Map(BulkNotificationFilter? filter)
+    {
+        if (filter is null)
+        {
+            return new NotificationListFilter();
+        }
+
+        return new NotificationListFilter(
+            filter.Category.HasValue ? (NotificationCategory)filter.Category.Value : null,
+            filter.Type,
+            filter.Severity.HasValue ? (NotificationSeverity)filter.Severity.Value : null,
+            filter.Status,
+            filter.Query,
+            filter.From,
+            filter.To);
+    }
+}

--- a/src/Services/Notification/NotificationService.Api/Endpoints/ListNotificationsEndpoint.cs
+++ b/src/Services/Notification/NotificationService.Api/Endpoints/ListNotificationsEndpoint.cs
@@ -11,7 +11,13 @@ public sealed record ListNotificationsRequest(
     string? Cursor,
     int? Limit,
     int? Category,
-    bool? UnreadOnly);
+    bool? UnreadOnly,
+    string? Status,
+    string? Type,
+    int? Severity,
+    string? Query,
+    DateTimeOffset? From,
+    DateTimeOffset? To);
 
 public sealed record ListNotificationsResponse(
     IReadOnlyList<NotificationDto> Items,
@@ -33,14 +39,22 @@ public sealed class ListNotificationsEndpoint(INotificationRepository repository
         var limit = Math.Clamp(req.Limit ?? 20, 1, 100);
         Cursor.TryDecode(req.Cursor, out var cursorTs, out var cursorId);
 
-        NotificationCategory? category = req.Category.HasValue
-            ? (NotificationCategory)req.Category.Value
+        var category = req.Category.HasValue
+            ? (NotificationCategory?)((NotificationCategory)req.Category.Value)
             : null;
+        var status = req.UnreadOnly == true ? "unread" : req.Status;
+        var severity = req.Severity.HasValue ? (NotificationSeverity)req.Severity.Value : (NotificationSeverity?)null;
 
         var notifications = await repository.ListAsync(
             userId,
-            category,
-            req.UnreadOnly ?? false,
+            new NotificationListFilter(
+                category,
+                req.Type,
+                severity,
+                status,
+                req.Query,
+                req.From,
+                req.To),
             cursorTs == default ? null : cursorTs,
             cursorId == Guid.Empty ? null : cursorId,
             limit,

--- a/src/Services/Notification/NotificationService.Api/Endpoints/NotificationStateEndpoint.cs
+++ b/src/Services/Notification/NotificationService.Api/Endpoints/NotificationStateEndpoint.cs
@@ -1,0 +1,42 @@
+using FastEndpoints;
+using Urfu.Link.Services.Notification.Application.Services;
+using Urfu.Link.Services.Notification.Infrastructure.Auth;
+
+namespace Urfu.Link.Services.Notification.Endpoints;
+
+public sealed class NotificationStateEndpoint(MarkAsReadService service)
+    : EndpointWithoutRequest
+{
+    private static readonly HashSet<string> AllowedActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "read",
+        "unread",
+        "seen",
+        "save",
+        "unsave",
+        "done",
+        "restore",
+        "archive",
+    };
+
+    public override void Configure()
+    {
+        Post("/me/notifications/{Id:guid}/{Action}");
+        Summary(s => s.Summary = "Apply a state transition to a notification");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var id = Route<Guid>("Id");
+        var action = Route<string>("Action") ?? string.Empty;
+        if (!AllowedActions.Contains(action))
+        {
+            await Send.NotFoundAsync(ct).ConfigureAwait(false);
+            return;
+        }
+
+        var userId = HttpContext.User.GetUserId();
+        await service.ApplyActionAsync(userId, id, action, ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Urfu.Link.Services.Notification.Domain.Enums;
@@ -32,6 +33,12 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
             .HasColumnName("severity")
             .HasConversion<short>();
 
+        builder.Property(n => n.Type)
+            .HasColumnName("type")
+            .HasMaxLength(NotificationAggregate.NotificationTypeMaxLength)
+            .HasDefaultValue("system.update")
+            .IsRequired();
+
         builder.OwnsOne(n => n.Content, content =>
         {
             content.Property(c => c.Title).HasColumnName("title").HasMaxLength(NotificationContent.TitleMaxLength).IsRequired();
@@ -46,6 +53,33 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
             .HasConversion(
                 value => Serialize(value),
                 json => Deserialize(json));
+
+        builder.Property(n => n.Actor)
+            .HasColumnName("actor")
+            .HasColumnType("jsonb")
+            .HasConversion(
+                value => SerializeNullable(value),
+                json => DeserializeNullable<NotificationActor>(json));
+
+        builder.Property(n => n.Entity)
+            .HasColumnName("entity")
+            .HasColumnType("jsonb")
+            .HasConversion(
+                value => SerializeNullable(value),
+                json => DeserializeNullable<NotificationEntity>(json));
+
+        var actionComparer = new ValueComparer<IReadOnlyList<NotificationAction>>(
+            (left, right) => SequenceEqual(left, right),
+            value => ComputeHash(value),
+            value => value.ToArray());
+
+        builder.Property(n => n.Actions)
+            .HasColumnName("actions")
+            .HasColumnType("jsonb")
+            .HasConversion(
+                value => JsonSerializer.Serialize(value, DataJsonOptions),
+                json => DeserializeActions(json))
+            .Metadata.SetValueComparer(actionComparer);
 
         builder.Property(n => n.GroupKey)
             .HasColumnName("group_key")
@@ -62,6 +96,16 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
 
         builder.Property(n => n.CreatedAtUtc).HasColumnName("created_at_utc");
         builder.Property(n => n.ReadAtUtc).HasColumnName("read_at_utc");
+        builder.Property(n => n.SeenAtUtc).HasColumnName("seen_at_utc");
+        builder.Property(n => n.SavedAtUtc).HasColumnName("saved_at_utc");
+        builder.Property(n => n.DoneAtUtc).HasColumnName("done_at_utc");
+        builder.Property(n => n.ArchivedAtUtc).HasColumnName("archived_at_utc");
+        builder.Property(n => n.SnoozedUntilUtc).HasColumnName("snoozed_until_utc");
+        builder.Property(n => n.ExpiresAtUtc).HasColumnName("expires_at_utc");
+        builder.Property(n => n.OccurrenceCount)
+            .HasColumnName("occurrence_count")
+            .HasDefaultValue(1);
+        builder.Property(n => n.LastOccurrenceAtUtc).HasColumnName("last_occurrence_at_utc");
 
         builder.Ignore(n => n.DomainEvents);
         builder.Ignore(n => n.Deliveries);
@@ -69,6 +113,16 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
 
     private static string Serialize(NotificationData data)
         => JsonSerializer.Serialize(data.Values, DataJsonOptions);
+
+    private static string? SerializeNullable<T>(T? value)
+        where T : class
+        => value is null ? null : JsonSerializer.Serialize(value, DataJsonOptions);
+
+    private static T? DeserializeNullable<T>(string? json)
+        where T : class
+        => string.IsNullOrWhiteSpace(json)
+            ? null
+            : JsonSerializer.Deserialize<T>(json, DataJsonOptions);
 
     private static NotificationData Deserialize(string json)
     {
@@ -79,5 +133,33 @@ public sealed class NotificationConfiguration : IEntityTypeConfiguration<Notific
 
         var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json, DataJsonOptions);
         return NotificationData.From(dict);
+    }
+
+    private static NotificationAction[] DeserializeActions(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        return JsonSerializer.Deserialize<NotificationAction[]>(json, DataJsonOptions) ?? [];
+    }
+
+    private static bool SequenceEqual(
+        IReadOnlyList<NotificationAction>? left,
+        IReadOnlyList<NotificationAction>? right)
+        => left is null
+            ? right is null
+            : right is not null && left.SequenceEqual(right);
+
+    private static int ComputeHash(IReadOnlyList<NotificationAction> value)
+    {
+        var hash = new HashCode();
+        foreach (var action in value)
+        {
+            hash.Add(action);
+        }
+
+        return hash.ToHashCode();
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Configurations/NotificationDedupKeyConfiguration.cs
+++ b/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Configurations/NotificationDedupKeyConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Urfu.Link.Services.Notification.Domain.Aggregates;
+using NotificationAggregate = Urfu.Link.Services.Notification.Domain.Aggregates.Notification;
+
+namespace Urfu.Link.Services.Notification.Infrastructure.Persistence.Configurations;
+
+public sealed class NotificationDedupKeyConfiguration : IEntityTypeConfiguration<NotificationDedupKey>
+{
+    public void Configure(EntityTypeBuilder<NotificationDedupKey> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("notification_dedup_keys");
+
+        builder.HasKey(k => new { k.RecipientUserId, k.SourceEventId, k.NotificationType });
+
+        builder.Property(k => k.RecipientUserId).HasColumnName("recipient_user_id");
+        builder.Property(k => k.SourceEventId).HasColumnName("source_event_id");
+        builder.Property(k => k.NotificationType)
+            .HasColumnName("notification_type")
+            .HasMaxLength(NotificationAggregate.NotificationTypeMaxLength)
+            .IsRequired();
+        builder.Property(k => k.NotificationId).HasColumnName("notification_id");
+        builder.Property(k => k.CreatedAtUtc).HasColumnName("created_at_utc");
+
+        builder.HasIndex(k => k.NotificationId)
+            .HasDatabaseName("ix_notification_dedup_keys_notification");
+    }
+}

--- a/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/NotificationDbContext.cs
+++ b/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/NotificationDbContext.cs
@@ -18,6 +18,8 @@ public sealed class NotificationDbContext(DbContextOptions<NotificationDbContext
 
     public DbSet<DisciplineConversation> DisciplineConversations => Set<DisciplineConversation>();
 
+    public DbSet<NotificationDedupKey> NotificationDedupKeys => Set<NotificationDedupKey>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);

--- a/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Repositories/NotificationRepository.cs
+++ b/src/Services/Notification/NotificationService.Api/Infrastructure/Persistence/Repositories/NotificationRepository.cs
@@ -18,6 +18,12 @@ public sealed class NotificationRepository(NotificationDbContext db) : INotifica
     {
         ArgumentNullException.ThrowIfNull(notification);
 
+        db.NotificationDedupKeys.Add(NotificationDedupKey.Create(
+            notification.RecipientUserId,
+            notification.SourceEventId,
+            notification.Type,
+            notification.Id,
+            notification.CreatedAtUtc));
         db.Notifications.Add(notification);
         foreach (var delivery in notification.Deliveries)
         {
@@ -45,26 +51,19 @@ public sealed class NotificationRepository(NotificationDbContext db) : INotifica
 
     public async Task<IReadOnlyList<NotificationAggregate>> ListAsync(
         Guid recipientUserId,
-        NotificationCategory? category,
-        bool unreadOnly,
+        NotificationListFilter filter,
         DateTimeOffset? cursorCreatedAtUtc,
         Guid? cursorId,
         int limit,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(filter);
+
         IQueryable<NotificationAggregate> query = db.Notifications
             .AsNoTracking()
             .Where(n => n.RecipientUserId == recipientUserId);
 
-        if (category.HasValue)
-        {
-            query = query.Where(n => n.Category == category.Value);
-        }
-
-        if (unreadOnly)
-        {
-            query = query.Where(n => n.ReadAtUtc == null);
-        }
+        query = ApplyFilter(query, filter);
 
         if (cursorCreatedAtUtc.HasValue && cursorId.HasValue)
         {
@@ -79,6 +78,36 @@ public sealed class NotificationRepository(NotificationDbContext db) : INotifica
             .OrderByDescending(n => n.CreatedAtUtc)
             .ThenByDescending(n => n.Id)
             .Take(Math.Clamp(limit, 1, 100))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<NotificationAggregate>> ListForBulkAsync(
+        Guid recipientUserId,
+        NotificationListFilter filter,
+        IReadOnlyList<Guid>? ids,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        IQueryable<NotificationAggregate> query = db.Notifications
+            .AsTracking()
+            .Where(n => n.RecipientUserId == recipientUserId);
+
+        if (ids is { Count: > 0 })
+        {
+            query = query.Where(n => ids.Contains(n.Id));
+        }
+        else
+        {
+            query = ApplyFilter(query, filter);
+        }
+
+        return await query
+            .OrderByDescending(n => n.CreatedAtUtc)
+            .ThenByDescending(n => n.Id)
+            .Take(Math.Clamp(limit, 1, 1000))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }
@@ -125,8 +154,108 @@ public sealed class NotificationRepository(NotificationDbContext db) : INotifica
         return grouped.ToDictionary(g => g.Key, g => g.Count);
     }
 
+    public async Task<NotificationBadgeCounts> CountBadgeAsync(Guid recipientUserId, CancellationToken cancellationToken)
+    {
+        var unreadQuery = db.Notifications
+            .AsNoTracking()
+            .Where(n =>
+                n.RecipientUserId == recipientUserId &&
+                n.ReadAtUtc == null &&
+                n.DoneAtUtc == null &&
+                n.ArchivedAtUtc == null);
+
+        var totalUnread = await unreadQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+        var totalUnseen = await unreadQuery.CountAsync(n => n.SeenAtUtc == null, cancellationToken).ConfigureAwait(false);
+        var urgentUnread = await unreadQuery.CountAsync(n => n.Severity == NotificationSeverity.Urgent, cancellationToken)
+            .ConfigureAwait(false);
+
+        var perCategory = await unreadQuery
+            .GroupBy(n => n.Category)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var perType = await unreadQuery
+            .GroupBy(n => n.Type)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new NotificationBadgeCounts(
+            totalUnread,
+            totalUnseen,
+            urgentUnread,
+            perCategory.ToDictionary(g => g.Key, g => g.Count),
+            perType.ToDictionary(g => g.Key, g => g.Count, StringComparer.Ordinal));
+    }
+
     public Task SaveChangesAsync(CancellationToken cancellationToken)
     {
         return db.SaveChangesAsync(cancellationToken);
+    }
+
+    private static IQueryable<NotificationAggregate> ApplyFilter(
+        IQueryable<NotificationAggregate> query,
+        NotificationListFilter filter)
+    {
+        if (filter.Category.HasValue)
+        {
+            query = query.Where(n => n.Category == filter.Category.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.Type))
+        {
+            var type = filter.Type.Trim();
+            query = query.Where(n => n.Type == type);
+        }
+
+        if (filter.Severity.HasValue)
+        {
+            query = query.Where(n => n.Severity == filter.Severity.Value);
+        }
+
+        if (filter.From.HasValue)
+        {
+            var from = filter.From.Value;
+            query = query.Where(n => n.CreatedAtUtc >= from);
+        }
+
+        if (filter.To.HasValue)
+        {
+            var to = filter.To.Value;
+            query = query.Where(n => n.CreatedAtUtc <= to);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.Query))
+        {
+            var term = filter.Query.Trim();
+            query = query.Where(n =>
+                EF.Functions.ILike(n.Content.Title, $"%{term}%") ||
+                EF.Functions.ILike(n.Content.Body, $"%{term}%"));
+        }
+
+        return NormalizeStatus(query, filter.Status);
+    }
+
+    private static IQueryable<NotificationAggregate> NormalizeStatus(
+        IQueryable<NotificationAggregate> query,
+        string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status) || string.Equals(status, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            return query.Where(n => n.DoneAtUtc == null && n.ArchivedAtUtc == null);
+        }
+
+        return status.Trim().ToUpperInvariant() switch
+        {
+            "UNREAD" => query.Where(n => n.ReadAtUtc == null && n.DoneAtUtc == null && n.ArchivedAtUtc == null),
+            "READ" => query.Where(n => n.ReadAtUtc != null && n.DoneAtUtc == null && n.ArchivedAtUtc == null),
+            "SEEN" => query.Where(n => n.SeenAtUtc != null && n.DoneAtUtc == null && n.ArchivedAtUtc == null),
+            "UNSEEN" => query.Where(n => n.SeenAtUtc == null && n.DoneAtUtc == null && n.ArchivedAtUtc == null),
+            "SAVED" => query.Where(n => n.SavedAtUtc != null && n.ArchivedAtUtc == null),
+            "DONE" => query.Where(n => n.DoneAtUtc != null),
+            "ARCHIVED" => query.Where(n => n.ArchivedAtUtc != null),
+            _ => query.Where(n => n.DoneAtUtc == null && n.ArchivedAtUtc == null),
+        };
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Migrations/20260525145314_EnterpriseInAppNotificationCenter.Designer.cs
+++ b/src/Services/Notification/NotificationService.Api/Migrations/20260525145314_EnterpriseInAppNotificationCenter.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Urfu.Link.Services.Notification.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Urfu.Link.Services.Notification.Infrastructure.Persistence;
 namespace NotificationService.Api.Migrations
 {
     [DbContext(typeof(NotificationDbContext))]
-    partial class NotificationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525145314_EnterpriseInAppNotificationCenter")]
+    partial class EnterpriseInAppNotificationCenter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/Notification/NotificationService.Api/Migrations/20260525145314_EnterpriseInAppNotificationCenter.cs
+++ b/src/Services/Notification/NotificationService.Api/Migrations/20260525145314_EnterpriseInAppNotificationCenter.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NotificationService.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnterpriseInAppNotificationCenter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.AddColumn<string>(
+                name: "actions",
+                schema: "notifications",
+                table: "notifications",
+                type: "jsonb",
+                nullable: false,
+                defaultValueSql: "'[]'::jsonb");
+
+            migrationBuilder.AddColumn<string>(
+                name: "actor",
+                schema: "notifications",
+                table: "notifications",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "archived_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "done_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "entity",
+                schema: "notifications",
+                table: "notifications",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "expires_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "last_occurrence_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "CURRENT_TIMESTAMP");
+
+            migrationBuilder.AddColumn<int>(
+                name: "occurrence_count",
+                schema: "notifications",
+                table: "notifications",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "saved_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "seen_at_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "snoozed_until_utc",
+                schema: "notifications",
+                table: "notifications",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "type",
+                schema: "notifications",
+                table: "notifications",
+                type: "character varying(120)",
+                maxLength: 120,
+                nullable: false,
+                defaultValue: "system.update");
+
+            migrationBuilder.Sql(
+                """
+                UPDATE notifications.notifications
+                SET last_occurrence_at_utc = created_at_utc,
+                    type = CASE category
+                        WHEN 1 THEN 'chat.message.direct'
+                        WHEN 2 THEN 'chat.mention'
+                        WHEN 3 THEN 'chat.message.discipline'
+                        WHEN 10 THEN 'call.incoming'
+                        WHEN 11 THEN 'call.missed'
+                        WHEN 20 THEN 'discipline.announcement'
+                        WHEN 21 THEN 'discipline.material'
+                        WHEN 22 THEN 'discipline.deadline'
+                        WHEN 30 THEN 'system.maintenance'
+                        WHEN 31 THEN 'system.update'
+                        WHEN 40 THEN 'admin.chat.invite'
+                        WHEN 41 THEN 'admin.role.changed'
+                        ELSE 'system.update'
+                    END;
+                """);
+
+            migrationBuilder.CreateTable(
+                name: "notification_dedup_keys",
+                schema: "notifications",
+                columns: table => new
+                {
+                    recipient_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    source_event_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    notification_type = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                    notification_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_notification_dedup_keys", x => new { x.recipient_user_id, x.source_event_id, x.notification_type });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notification_dedup_keys_notification",
+                schema: "notifications",
+                table: "notification_dedup_keys",
+                column: "notification_id");
+
+            migrationBuilder.Sql(
+                """
+                INSERT INTO notifications.notification_dedup_keys (
+                    recipient_user_id,
+                    source_event_id,
+                    notification_type,
+                    notification_id,
+                    created_at_utc)
+                SELECT DISTINCT ON (recipient_user_id, source_event_id, type)
+                    recipient_user_id,
+                    source_event_id,
+                    type,
+                    id,
+                    created_at_utc
+                FROM notifications.notifications
+                ORDER BY recipient_user_id, source_event_id, type, created_at_utc DESC
+                ON CONFLICT DO NOTHING;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                CREATE INDEX IF NOT EXISTS ix_notifications_recipient_status_created
+                    ON notifications.notifications (
+                        recipient_user_id,
+                        done_at_utc,
+                        archived_at_utc,
+                        read_at_utc,
+                        created_at_utc DESC);
+
+                CREATE INDEX IF NOT EXISTS ix_notifications_recipient_type_created
+                    ON notifications.notifications (
+                        recipient_user_id,
+                        type,
+                        created_at_utc DESC);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+            migrationBuilder.DropTable(
+                name: "notification_dedup_keys",
+                schema: "notifications");
+
+            migrationBuilder.Sql("DROP INDEX IF EXISTS notifications.ix_notifications_recipient_status_created;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS notifications.ix_notifications_recipient_type_created;");
+
+            migrationBuilder.DropColumn(
+                name: "actions",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "actor",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "archived_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "done_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "entity",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "expires_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "last_occurrence_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "occurrence_count",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "saved_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "seen_at_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "snoozed_until_utc",
+                schema: "notifications",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "type",
+                schema: "notifications",
+                table: "notifications");
+        }
+    }
+}

--- a/src/Services/Notification/NotificationService.Api/Realtime/INotificationBroadcaster.cs
+++ b/src/Services/Notification/NotificationService.Api/Realtime/INotificationBroadcaster.cs
@@ -4,9 +4,17 @@ public interface INotificationBroadcaster
 {
     Task NotifyReceivedAsync(NotificationDto notification, CancellationToken cancellationToken);
 
+    Task NotifyUpsertedAsync(NotificationDto notification, CancellationToken cancellationToken);
+
     Task NotifyReadAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken);
+
+    Task NotifyStateChangedAsync(Guid recipientUserId, NotificationStateChangedDto change, CancellationToken cancellationToken);
+
+    Task NotifyRemovedAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken);
 
     Task NotifyBadgeUpdatedAsync(Guid recipientUserId, BadgeSnapshotDto snapshot, CancellationToken cancellationToken);
 
     Task NotifyBatchReadAsync(Guid recipientUserId, IReadOnlyList<Guid> notificationIds, CancellationToken cancellationToken);
+
+    Task NotifyBackfillRequiredAsync(Guid recipientUserId, string reason, CancellationToken cancellationToken);
 }

--- a/src/Services/Notification/NotificationService.Api/Realtime/INotificationClient.cs
+++ b/src/Services/Notification/NotificationService.Api/Realtime/INotificationClient.cs
@@ -4,9 +4,25 @@ public interface INotificationClient
 {
     Task NotificationReceived(NotificationDto notification);
 
+    Task NotificationUpserted(NotificationDto notification);
+
     Task NotificationRead(Guid notificationId);
+
+    Task NotificationStateChanged(NotificationStateChangedDto change);
+
+    Task NotificationRemoved(Guid notificationId);
 
     Task BadgeUpdated(BadgeSnapshotDto snapshot);
 
     Task NotificationsBatchRead(IReadOnlyList<Guid> ids);
+
+    Task NotificationBackfillRequired(string reason);
 }
+
+public sealed record NotificationStateChangedDto(
+    Guid NotificationId,
+    DateTimeOffset? ReadAtUtc,
+    DateTimeOffset? SeenAtUtc,
+    DateTimeOffset? SavedAtUtc,
+    DateTimeOffset? DoneAtUtc,
+    DateTimeOffset? ArchivedAtUtc);

--- a/src/Services/Notification/NotificationService.Api/Realtime/NotificationBroadcaster.cs
+++ b/src/Services/Notification/NotificationService.Api/Realtime/NotificationBroadcaster.cs
@@ -15,11 +15,34 @@ public sealed class NotificationBroadcaster(IHubContext<NotificationHub, INotifi
             .NotificationReceived(notification);
     }
 
+    public Task NotifyUpsertedAsync(NotificationDto notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        _ = cancellationToken;
+        return _hub.Clients.Group(NotificationHub.GroupForUser(notification.RecipientUserId))
+            .NotificationUpserted(notification);
+    }
+
     public Task NotifyReadAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken)
     {
         _ = cancellationToken;
         return _hub.Clients.Group(NotificationHub.GroupForUser(recipientUserId))
             .NotificationRead(notificationId);
+    }
+
+    public Task NotifyStateChangedAsync(Guid recipientUserId, NotificationStateChangedDto change, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(change);
+        _ = cancellationToken;
+        return _hub.Clients.Group(NotificationHub.GroupForUser(recipientUserId))
+            .NotificationStateChanged(change);
+    }
+
+    public Task NotifyRemovedAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        return _hub.Clients.Group(NotificationHub.GroupForUser(recipientUserId))
+            .NotificationRemoved(notificationId);
     }
 
     public Task NotifyBadgeUpdatedAsync(Guid recipientUserId, BadgeSnapshotDto snapshot, CancellationToken cancellationToken)
@@ -36,5 +59,12 @@ public sealed class NotificationBroadcaster(IHubContext<NotificationHub, INotifi
         _ = cancellationToken;
         return _hub.Clients.Group(NotificationHub.GroupForUser(recipientUserId))
             .NotificationsBatchRead(notificationIds);
+    }
+
+    public Task NotifyBackfillRequiredAsync(Guid recipientUserId, string reason, CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        return _hub.Clients.Group(NotificationHub.GroupForUser(recipientUserId))
+            .NotificationBackfillRequired(reason);
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Realtime/NotificationDtos.cs
+++ b/src/Services/Notification/NotificationService.Api/Realtime/NotificationDtos.cs
@@ -5,6 +5,7 @@ namespace Urfu.Link.Services.Notification.Realtime;
 public sealed record NotificationDto(
     Guid Id,
     Guid RecipientUserId,
+    string Type,
     NotificationCategory Category,
     NotificationSeverity Severity,
     string Title,
@@ -12,8 +13,30 @@ public sealed record NotificationDto(
     string? ImageUrl,
     string? DeepLink,
     IReadOnlyDictionary<string, string> Data,
+    NotificationActorDto? Actor,
+    NotificationEntityDto? Entity,
+    IReadOnlyList<NotificationActionDto> Actions,
     string? GroupKey,
+    int OccurrenceCount,
     DateTimeOffset CreatedAtUtc,
-    DateTimeOffset? ReadAtUtc);
+    DateTimeOffset LastOccurrenceAtUtc,
+    DateTimeOffset? ReadAtUtc,
+    DateTimeOffset? SeenAtUtc,
+    DateTimeOffset? SavedAtUtc,
+    DateTimeOffset? DoneAtUtc,
+    DateTimeOffset? ArchivedAtUtc,
+    DateTimeOffset? SnoozedUntilUtc,
+    DateTimeOffset? ExpiresAtUtc);
 
-public sealed record BadgeSnapshotDto(int Total, IReadOnlyDictionary<int, int> PerCategory);
+public sealed record NotificationActorDto(Guid? Id, string? DisplayName, string? AvatarUrl);
+
+public sealed record NotificationEntityDto(string Kind, string Id, string? DisplayName);
+
+public sealed record NotificationActionDto(string Id, string Label, string Kind, string? DeepLink);
+
+public sealed record BadgeSnapshotDto(
+    int Total,
+    IReadOnlyDictionary<int, int> PerCategory,
+    int TotalUnseen = 0,
+    int UrgentUnread = 0,
+    IReadOnlyDictionary<string, int>? PerType = null);

--- a/tests/integration/NotificationService.IntegrationTests/Endpoints/EnterpriseNotificationCenterTests.cs
+++ b/tests/integration/NotificationService.IntegrationTests/Endpoints/EnterpriseNotificationCenterTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NotificationService.IntegrationTests.Infrastructure;
+using Urfu.Link.Services.Notification.Domain.Enums;
+using Urfu.Link.Services.Notification.Domain.Interfaces;
+using Urfu.Link.Services.Notification.Domain.ValueObjects;
+using Urfu.Link.Services.Notification.Endpoints;
+using Urfu.Link.Services.Notification.Infrastructure.Persistence;
+using Urfu.Link.Services.Notification.Realtime;
+using NotificationAggregate = Urfu.Link.Services.Notification.Domain.Aggregates.Notification;
+
+namespace NotificationService.IntegrationTests.Endpoints;
+
+[Collection(IntegrationCollection.Name)]
+public sealed class EnterpriseNotificationCenterTests(NotificationServiceFactory factory) : IAsyncLifetime
+{
+    public Task InitializeAsync() => factory.ResetDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Badge_IncludesUnreadUnseenUrgentAndTypeCounters()
+    {
+        var userId = Guid.NewGuid();
+        TestAuthHandler.CurrentPrincipal = TestAuthHandler.Principal(userId);
+        var urgent = await SeedAsync(userId, NotificationCategory.CallIncoming, NotificationSeverity.Urgent);
+        _ = urgent;
+        var seen = await SeedAsync(userId, NotificationCategory.ChatMessageDirect, NotificationSeverity.Normal);
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<NotificationDbContext>();
+            var storedSeen = await db.Notifications.SingleAsync(n => n.Id == seen);
+            storedSeen.MarkSeen(DateTimeOffset.UtcNow);
+            await db.SaveChangesAsync();
+
+            var badgeStore = scope.ServiceProvider.GetRequiredService<IBadgeStore>();
+            await badgeStore.IncrementAsync(userId, NotificationCategory.CallIncoming, default);
+            await badgeStore.IncrementAsync(userId, NotificationCategory.ChatMessageDirect, default);
+        }
+
+        using var client = factory.CreateClient();
+        var badge = await client.GetFromJsonAsync<BadgeSnapshotDto>("/api/v1/me/notifications/badge");
+
+        badge!.Total.Should().Be(2);
+        badge.TotalUnseen.Should().Be(1);
+        badge.UrgentUnread.Should().Be(1);
+        badge.PerType.Should().ContainKey("call.incoming");
+    }
+
+    [Fact]
+    public async Task ListNotifications_CanFilterByStatusTypeSeverityAndQuery()
+    {
+        var userId = Guid.NewGuid();
+        TestAuthHandler.CurrentPrincipal = TestAuthHandler.Principal(userId);
+        var savedId = await SeedAsync(
+            userId,
+            NotificationCategory.ChatMessageMention,
+            NotificationSeverity.High,
+            "Mention",
+            "Teacher mentioned you");
+        await SeedAsync(
+            userId,
+            NotificationCategory.DisciplineDeadline,
+            NotificationSeverity.Normal,
+            "Deadline",
+            "Lab closes soon");
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<NotificationDbContext>();
+            var saved = await db.Notifications.SingleAsync(n => n.Id == savedId);
+            saved.Save(DateTimeOffset.UtcNow);
+            await db.SaveChangesAsync();
+        }
+
+        using var client = factory.CreateClient();
+        var response = await client.GetFromJsonAsync<ListNotificationsResponse>(
+            "/api/v1/me/notifications?status=saved&type=chat.mention&severity=2&query=teacher");
+
+        response!.Items.Should().ContainSingle();
+        response.Items[0].Id.Should().Be(savedId);
+        response.Items[0].SavedAtUtc.Should().NotBeNull();
+        response.Items[0].Type.Should().Be("chat.mention");
+    }
+
+    [Fact]
+    public async Task IndividualStateActions_UpdateNotificationAndBadge()
+    {
+        var userId = Guid.NewGuid();
+        TestAuthHandler.CurrentPrincipal = TestAuthHandler.Principal(userId);
+        var notificationId = await SeedAsync(userId, NotificationCategory.ChatMessageDirect, NotificationSeverity.Normal);
+        await IncrementBadgeAsync(userId, NotificationCategory.ChatMessageDirect);
+
+        using var client = factory.CreateClient();
+
+        var seen = await client.PostAsync($"/api/v1/me/notifications/{notificationId}/seen", null);
+        var saved = await client.PostAsync($"/api/v1/me/notifications/{notificationId}/save", null);
+        var done = await client.PostAsync($"/api/v1/me/notifications/{notificationId}/done", null);
+
+        seen.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        saved.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        done.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<NotificationDbContext>();
+        var stored = await db.Notifications.AsNoTracking().SingleAsync(n => n.Id == notificationId);
+        stored.SeenAtUtc.Should().NotBeNull();
+        stored.SavedAtUtc.Should().NotBeNull();
+        stored.DoneAtUtc.Should().NotBeNull();
+        stored.ReadAtUtc.Should().NotBeNull();
+
+        var badge = await scope.ServiceProvider.GetRequiredService<IBadgeStore>().GetSnapshotAsync(userId, default);
+        badge.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BulkAction_CanMarkMatchingUnreadNotificationsDone()
+    {
+        var userId = Guid.NewGuid();
+        TestAuthHandler.CurrentPrincipal = TestAuthHandler.Principal(userId);
+        await SeedAsync(userId, NotificationCategory.ChatMessageDirect, NotificationSeverity.Normal);
+        await SeedAsync(userId, NotificationCategory.ChatMessageDirect, NotificationSeverity.Normal);
+        await SeedAsync(userId, NotificationCategory.DisciplineDeadline, NotificationSeverity.Normal);
+        await IncrementBadgeAsync(userId, NotificationCategory.ChatMessageDirect);
+        await IncrementBadgeAsync(userId, NotificationCategory.ChatMessageDirect);
+        await IncrementBadgeAsync(userId, NotificationCategory.DisciplineDeadline);
+
+        using var client = factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/v1/me/notifications/bulk",
+            new
+            {
+                Action = "done",
+                Filter = new
+                {
+                    Category = (int)NotificationCategory.ChatMessageDirect,
+                    Status = "unread",
+                },
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<BulkNotificationActionResponse>();
+        result!.Updated.Should().Be(2);
+
+        var badge = await client.GetFromJsonAsync<BadgeSnapshotDto>("/api/v1/me/notifications/badge");
+        badge!.Total.Should().Be(1);
+        badge.PerCategory.Should().ContainKey((int)NotificationCategory.DisciplineDeadline);
+    }
+
+    private async Task<Guid> SeedAsync(
+        Guid userId,
+        NotificationCategory category,
+        NotificationSeverity severity,
+        string title = "Title",
+        string body = "Body")
+    {
+        await using var scope = factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<NotificationDbContext>();
+        var notification = NotificationAggregate.Create(
+            recipientUserId: userId,
+            category: category,
+            severity: severity,
+            content: NotificationContent.Create(title, body),
+            data: NotificationData.Empty,
+            groupKey: null,
+            sourceEventId: Guid.NewGuid(),
+            sourceEventType: "test.v1",
+            createdAtUtc: DateTimeOffset.UtcNow);
+        db.Notifications.Add(notification);
+        await db.SaveChangesAsync();
+        return notification.Id;
+    }
+
+    private async Task IncrementBadgeAsync(Guid userId, NotificationCategory category)
+    {
+        await using var scope = factory.Services.CreateAsyncScope();
+        var badgeStore = scope.ServiceProvider.GetRequiredService<IBadgeStore>();
+        await badgeStore.IncrementAsync(userId, category, CancellationToken.None);
+    }
+}

--- a/tests/integration/NotificationService.IntegrationTests/Infrastructure/NoopNotificationBroadcaster.cs
+++ b/tests/integration/NotificationService.IntegrationTests/Infrastructure/NoopNotificationBroadcaster.cs
@@ -13,9 +13,17 @@ public sealed class NoopNotificationBroadcaster : INotificationBroadcaster
 {
     public Task NotifyReceivedAsync(NotificationDto notification, CancellationToken cancellationToken) => Task.CompletedTask;
 
+    public Task NotifyUpsertedAsync(NotificationDto notification, CancellationToken cancellationToken) => Task.CompletedTask;
+
     public Task NotifyReadAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task NotifyStateChangedAsync(Guid recipientUserId, NotificationStateChangedDto change, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task NotifyRemovedAsync(Guid recipientUserId, Guid notificationId, CancellationToken cancellationToken) => Task.CompletedTask;
 
     public Task NotifyBatchReadAsync(Guid recipientUserId, IReadOnlyList<Guid> notificationIds, CancellationToken cancellationToken) => Task.CompletedTask;
 
     public Task NotifyBadgeUpdatedAsync(Guid recipientUserId, BadgeSnapshotDto snapshot, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task NotifyBackfillRequiredAsync(Guid recipientUserId, string reason, CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/tests/unit/NotificationService.UnitTests/Domain/NotificationCatalogTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Domain/NotificationCatalogTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Urfu.Link.Services.Notification.Domain;
+using Urfu.Link.Services.Notification.Domain.Enums;
+
+namespace NotificationService.UnitTests.Domain;
+
+public sealed class NotificationCatalogTests
+{
+    [Theory]
+    [InlineData(NotificationCategory.ChatMessageDirect, "chat.message.direct")]
+    [InlineData(NotificationCategory.ChatMessageMention, "chat.mention")]
+    [InlineData(NotificationCategory.ChatMessageDiscipline, "chat.message.discipline")]
+    [InlineData(NotificationCategory.CallMissed, "call.missed")]
+    [InlineData(NotificationCategory.DisciplineDeadline, "discipline.deadline")]
+    [InlineData(NotificationCategory.SystemMaintenance, "system.maintenance")]
+    public void GetByCategory_ReturnsStableFrontendType(NotificationCategory category, string expectedType)
+    {
+        var descriptor = NotificationCatalog.GetByCategory(category);
+
+        descriptor.Type.Should().Be(expectedType);
+        descriptor.Category.Should().Be(category);
+        descriptor.Icon.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalseForUnknownType()
+    {
+        NotificationCatalog.TryGet("unknown.type", out _).Should().BeFalse();
+    }
+}

--- a/tests/unit/NotificationService.UnitTests/Domain/NotificationTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Domain/NotificationTests.cs
@@ -151,6 +151,88 @@ public sealed class NotificationTests
     }
 
     [Fact]
+    public void Create_AssignsEnterpriseDefaults()
+    {
+        var notification = NewNotification();
+
+        notification.Type.Should().Be("chat.message.direct");
+        notification.SeenAtUtc.Should().BeNull();
+        notification.SavedAtUtc.Should().BeNull();
+        notification.DoneAtUtc.Should().BeNull();
+        notification.ArchivedAtUtc.Should().BeNull();
+        notification.SnoozedUntilUtc.Should().BeNull();
+        notification.ExpiresAtUtc.Should().BeNull();
+        notification.OccurrenceCount.Should().Be(1);
+        notification.LastOccurrenceAtUtc.Should().Be(notification.CreatedAtUtc);
+        notification.Actions.Should().Contain(a => a.Id == "open");
+    }
+
+    [Fact]
+    public void MarkSeen_SetsSeenAtOnce()
+    {
+        var notification = NewNotification();
+        var first = DateTimeOffset.UtcNow;
+
+        notification.MarkSeen(first).Should().BeTrue();
+        notification.MarkSeen(first.AddMinutes(1)).Should().BeFalse();
+
+        notification.SeenAtUtc.Should().Be(first);
+    }
+
+    [Fact]
+    public void MarkUnread_ClearsReadStateButKeepsSeenState()
+    {
+        var notification = NewNotification();
+        var seenAt = DateTimeOffset.UtcNow;
+        notification.MarkSeen(seenAt);
+        notification.MarkRead(seenAt.AddMinutes(1));
+
+        notification.MarkUnread().Should().BeTrue();
+
+        notification.ReadAtUtc.Should().BeNull();
+        notification.SeenAtUtc.Should().Be(seenAt);
+    }
+
+    [Fact]
+    public void SaveAndUnsave_AreIdempotent()
+    {
+        var notification = NewNotification();
+        var savedAt = DateTimeOffset.UtcNow;
+
+        notification.Save(savedAt).Should().BeTrue();
+        notification.Save(savedAt.AddMinutes(1)).Should().BeFalse();
+        notification.Unsave().Should().BeTrue();
+        notification.Unsave().Should().BeFalse();
+
+        notification.SavedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarkDone_ReadsAndRemovesFromActiveInbox()
+    {
+        var notification = NewNotification();
+        var doneAt = DateTimeOffset.UtcNow;
+
+        notification.MarkDone(doneAt).Should().BeTrue();
+
+        notification.DoneAtUtc.Should().Be(doneAt);
+        notification.ReadAtUtc.Should().Be(doneAt);
+        notification.SeenAtUtc.Should().Be(doneAt);
+    }
+
+    [Fact]
+    public void Restore_ClearsDoneAndArchiveState()
+    {
+        var notification = NewNotification();
+        notification.MarkDone(DateTimeOffset.UtcNow);
+
+        notification.Restore().Should().BeTrue();
+
+        notification.DoneAtUtc.Should().BeNull();
+        notification.ArchivedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
     public void AddDelivery_AppendsToCollection()
     {
         var notification = NewNotification();


### PR DESCRIPTION
## Что изменилось
- расширена модель NotificationService для in-app notification center: типы, состояния seen/read/saved/done/archive, dedup keys, фильтры, bulk actions и расширенный badge
- добавлена миграция NotificationService для новых полей и таблицы dedup
- добавлен typed notifications API client, NotificationHub hook, глобальный колокольчик и экран /notifications

## Проверка прод-конфигурации
- gateway route /api/notifications/* уже корректно проксирует в /api/v1 NotificationService
- /hubs/notifications остается на существующем YARP/SignalR маршруте
- Helm prod notification-service рендерится с migrations job, secrets/env и портами 8080/8081

## Проверки
- dotnet test Urfu.Link.slnx --no-restore
- pnpm --filter @urfu-link/api-client test
- pnpm --filter @urfu-link/client test
- pnpm client:typecheck
- pnpm client:web:build
- helm lint deploy/helm/charts/urfu-service -f deploy/helm/services/notification-service/values-prod.yaml
- helm template notification-service deploy/helm/charts/urfu-service -f deploy/helm/services/notification-service/values-prod.yaml
