### PR TITLE
fix: разобрать kafka envelope в notification-service

### DIFF
--- a/src/Services/Notification/NotificationService.Api/Messaging/KafkaConsumerBase.cs
+++ b/src/Services/Notification/NotificationService.Api/Messaging/KafkaConsumerBase.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Confluent.Kafka;
@@ -98,22 +97,16 @@ public abstract class KafkaConsumerBase(
 
     private async Task ProcessAsync(string raw, CancellationToken cancellationToken)
     {
-        var envelope = JsonNode.Parse(raw)
-            ?? throw new JsonException("Envelope is null");
-
-        var messageId = ReadStringOrThrow(envelope, "messageId");
-        var payloadNode = envelope["payload"]
-            ?? throw new JsonException("Envelope payload missing");
-        var eventType = ReadStringOrThrow(payloadNode, "eventType");
+        var envelope = KafkaEnvelopeReader.Read(raw);
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var idempotency = scope.ServiceProvider.GetRequiredService<IIdempotencyStore>();
-        var dedupKey = $"{DedupKeyPrefix}:{messageId}";
+        var dedupKey = $"{DedupKeyPrefix}:{envelope.MessageId}";
         if (!await idempotency.TryRegisterAsync(dedupKey, cancellationToken).ConfigureAwait(false))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("Duplicate envelope {MessageId} on {Topic} — skipped", messageId, Topic);
+                _logger.LogDebug("Duplicate envelope {MessageId} on {Topic} — skipped", envelope.MessageId, Topic);
             }
 
             return;
@@ -121,11 +114,11 @@ public abstract class KafkaConsumerBase(
 
         try
         {
-            await HandleEventAsync(eventType, payloadNode, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            await HandleEventAsync(envelope.EventType, envelope.Payload, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogError(ex, "Handler for {EventType} on {Topic} failed", eventType, Topic);
+            _logger.LogError(ex, "Handler for {EventType} on {Topic} failed", envelope.EventType, Topic);
             throw;
         }
     }
@@ -163,17 +156,5 @@ public abstract class KafkaConsumerBase(
         }
 
         return consumerConfig;
-    }
-
-    private static string ReadStringOrThrow(JsonNode node, string property)
-    {
-        var value = node[property]?.GetValue<string>();
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            throw new JsonException(
-                string.Create(CultureInfo.InvariantCulture, $"Missing or empty '{property}' on Kafka envelope."));
-        }
-
-        return value;
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Messaging/KafkaEnvelopeReader.cs
+++ b/src/Services/Notification/NotificationService.Api/Messaging/KafkaEnvelopeReader.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Urfu.Link.Services.Notification.Messaging;
+
+public sealed record KafkaEnvelopeReadResult(
+    string MessageId,
+    string EventType,
+    JsonNode Payload);
+
+public static class KafkaEnvelopeReader
+{
+    public static KafkaEnvelopeReadResult Read(string raw)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(raw);
+
+        var envelope = JsonNode.Parse(raw)
+            ?? throw new JsonException("Envelope is null");
+
+        var messageId = ReadStringOrThrow(envelope, "messageId", "MessageId");
+        var payloadNode = ReadNodeOrThrow(envelope, "payload", "Payload");
+        var eventType = ReadStringOrThrow(payloadNode, "eventType", "EventType");
+
+        return new KafkaEnvelopeReadResult(messageId, eventType, payloadNode);
+    }
+
+    private static JsonNode ReadNodeOrThrow(JsonNode node, string camelCaseProperty, string pascalCaseProperty)
+    {
+        var value = node[camelCaseProperty] ?? node[pascalCaseProperty];
+        if (value is null)
+        {
+            throw new JsonException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Missing '{camelCaseProperty}'/'{pascalCaseProperty}' on Kafka envelope."));
+        }
+
+        return value;
+    }
+
+    private static string ReadStringOrThrow(JsonNode node, string camelCaseProperty, string pascalCaseProperty)
+    {
+        var value = node[camelCaseProperty]?.GetValue<string>()
+            ?? node[pascalCaseProperty]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Missing or empty '{camelCaseProperty}'/'{pascalCaseProperty}' on Kafka envelope."));
+        }
+
+        return value;
+    }
+}

--- a/tests/unit/NotificationService.UnitTests/Messaging/KafkaEnvelopeReaderTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Messaging/KafkaEnvelopeReaderTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
+using Urfu.Link.Services.Notification.Messaging;
+
+namespace NotificationService.UnitTests.Messaging;
+
+public sealed class KafkaEnvelopeReaderTests
+{
+    private static readonly JsonSerializerOptions WebJsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Read_AcceptsDefaultSerializedIntegrationEnvelope()
+    {
+        var envelope = CreateEnvelope();
+
+        var parsed = KafkaEnvelopeReader.Read(JsonSerializer.Serialize(envelope));
+
+        parsed.MessageId.Should().Be(envelope.MessageId.ToString("D"));
+        parsed.EventType.Should().Be("chat.message.sent.v1");
+        parsed.Payload["ConversationId"]!.GetValue<string>().Should().Be("direct-1");
+        parsed.Payload.Deserialize<ChatMessageSentEvent>(WebJsonOptions)!.ConversationId.Should().Be("direct-1");
+    }
+
+    [Fact]
+    public void Read_AcceptsWebSerializedIntegrationEnvelope()
+    {
+        var envelope = CreateEnvelope();
+
+        var parsed = KafkaEnvelopeReader.Read(JsonSerializer.Serialize(envelope, WebJsonOptions));
+
+        parsed.MessageId.Should().Be(envelope.MessageId.ToString("D"));
+        parsed.EventType.Should().Be("chat.message.sent.v1");
+        parsed.Payload["conversationId"]!.GetValue<string>().Should().Be("direct-1");
+    }
+
+    private static IntegrationEnvelope<ChatMessageSentEvent> CreateEnvelope()
+    {
+        var payload = new ChatMessageSentEvent(
+            ConversationId: "direct-1",
+            MessageId: Guid.NewGuid(),
+            SenderId: Guid.NewGuid(),
+            Recipients: [Guid.NewGuid()],
+            Preview: "hello",
+            HasAttachments: false,
+            OccurredAtUtc: DateTimeOffset.UtcNow);
+
+        return new IntegrationEnvelope<ChatMessageSentEvent>(
+            MessageId: Guid.NewGuid(),
+            TraceId: "trace",
+            Source: "chat-service",
+            CreatedAtUtc: DateTimeOffset.UtcNow,
+            Payload: payload);
+    }
+}


### PR DESCRIPTION
## Что исправлено

- `notification-service` теперь читает Kafka envelope в текущем production-формате `MessageId/Payload/EventType`.
- Сохранена совместимость с camelCase-форматом `messageId/payload/eventType`.
- Это возвращает обработку `chat.message.sent.v1`, из-за которой не создавались in-app уведомления для прямых сообщений.

## Проверки

- `dotnet test tests/unit/NotificationService.UnitTests/ --no-restore`
- `dotnet test tests/integration/NotificationService.IntegrationTests/ --no-restore`
- `dotnet test Urfu.Link.slnx --no-restore`
