### PR TITLE
fix(presence): retain session payload for last seen sweep

### DIFF
--- a/src/Services/Presence/PresenceService.Api/Infrastructure/Redis/RedisPresenceSessionStore.cs
+++ b/src/Services/Presence/PresenceService.Api/Infrastructure/Redis/RedisPresenceSessionStore.cs
@@ -62,18 +62,17 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
     };
 
     private readonly IConnectionMultiplexer _redis;
-    private readonly TimeProvider _clock;
-    private readonly TimeSpan _sessionTtl;
+    private readonly TimeSpan _sessionKeyTtl;
 
     public RedisPresenceSessionStore(
         IConnectionMultiplexer redis,
         TimeProvider clock,
         IOptions<PresenceOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         ArgumentNullException.ThrowIfNull(options);
         _redis = redis;
-        _clock = clock;
-        _sessionTtl = options.Value.SessionTtl;
+        _sessionKeyTtl = ComputeSessionKeyTtl(options.Value);
     }
 
     public async Task<bool> AddSessionAsync(PresenceSession session, CancellationToken cancellationToken)
@@ -103,7 +102,7 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
                 session.DeviceId,
                 json,
                 nowMs,
-                (long)_sessionTtl.TotalSeconds,
+                (long)Math.Ceiling(_sessionKeyTtl.TotalSeconds),
                 member,
             ]).ConfigureAwait(false);
 
@@ -174,7 +173,7 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
 
         var batch = db.CreateBatch();
         var hset = batch.HashSetAsync(sessionsKey, deviceId, json);
-        var expire = batch.KeyExpireAsync(sessionsKey, _sessionTtl);
+        var expire = batch.KeyExpireAsync(sessionsKey, _sessionKeyTtl);
         var zadd = batch.SortedSetAddAsync(RedisKeys.Heartbeats, member, utcNow.ToUnixTimeMilliseconds());
         batch.Execute();
         await Task.WhenAll(hset, expire, zadd).ConfigureAwait(false);
@@ -201,7 +200,7 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
         var updated = stored with { Status = status, CustomActivity = customActivity };
         var json = JsonSerializer.Serialize(updated, JsonOptions);
         await db.HashSetAsync(sessionsKey, deviceId, json).ConfigureAwait(false);
-        await db.KeyExpireAsync(sessionsKey, _sessionTtl).ConfigureAwait(false);
+        await db.KeyExpireAsync(sessionsKey, _sessionKeyTtl).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<PresenceSession>> GetSessionsAsync(
@@ -258,5 +257,20 @@ public sealed class RedisPresenceSessionStore : IPresenceSessionStore
             if (p is { } v) parsed.Add(v);
         }
         return parsed;
+    }
+
+    private static TimeSpan ComputeSessionKeyTtl(PresenceOptions options)
+    {
+        var heartbeatGrace = options.HeartbeatExpectedInterval > TimeSpan.Zero
+            ? options.HeartbeatExpectedInterval
+            : TimeSpan.FromSeconds(15);
+        var sweeperGrace = options.SweeperInterval > TimeSpan.Zero
+            ? options.SweeperInterval
+            : TimeSpan.FromSeconds(10);
+        var grace = heartbeatGrace > sweeperGrace ? heartbeatGrace : sweeperGrace;
+
+        // The sweeper needs the hash payload after SessionTtl elapses so it can
+        // remove the session and persist last_seen. Redis TTL is only a backstop.
+        return options.SessionTtl + grace + TimeSpan.FromSeconds(5);
     }
 }

--- a/tests/integration/PresenceService.IntegrationTests/Workers/PresenceSweeperWorkerTests.cs
+++ b/tests/integration/PresenceService.IntegrationTests/Workers/PresenceSweeperWorkerTests.cs
@@ -3,11 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using PresenceService.IntegrationTests.Infrastructure;
+using StackExchange.Redis;
 using Urfu.Link.Services.Presence.Domain.Enums;
 using Urfu.Link.Services.Presence.Domain.Events;
 using Urfu.Link.Services.Presence.Domain.Interfaces;
 using Urfu.Link.Services.Presence.Domain.ValueObjects;
 using Urfu.Link.Services.Presence.Infrastructure;
+using Urfu.Link.Services.Presence.Infrastructure.Redis;
 using Urfu.Link.Services.Presence.Workers;
 
 namespace PresenceService.IntegrationTests.Workers;
@@ -85,6 +87,41 @@ public class PresenceSweeperWorkerTests : IAsyncLifetime
         var ls = await repo.GetAsync(userId, CancellationToken.None);
         ls.Should().NotBeNull();
         ls!.LastPlatform.Should().Be(Platform.Mobile);
+    }
+
+    [Fact]
+    public async Task Sweep_WhenHeartbeatTtlElapsed_PersistsLastSeenBeforeRedisBackstopExpires()
+    {
+        var options = Options.Create(new PresenceOptions
+        {
+            SessionTtl = TimeSpan.FromMilliseconds(300),
+            HeartbeatExpectedInterval = TimeSpan.FromMilliseconds(100),
+            SweeperInterval = TimeSpan.FromMilliseconds(100),
+        });
+        var sessions = new RedisPresenceSessionStore(
+            _factory.Services.GetRequiredService<IConnectionMultiplexer>(),
+            TimeProvider.System,
+            options);
+        var userId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        await sessions.AddSessionAsync(new PresenceSession(
+            userId, "d1", Platform.Web, PresenceStatus.Online, null, now, now),
+            CancellationToken.None);
+
+        await Task.Delay(options.Value.SessionTtl + TimeSpan.FromMilliseconds(150));
+
+        using var worker = new PresenceSweeperWorker(
+            _factory.Services.GetRequiredService<IServiceScopeFactory>(),
+            sessions,
+            options,
+            TimeProvider.System,
+            NullLogger<PresenceSweeperWorker>.Instance);
+        await worker.SweepAsync(CancellationToken.None);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ILastSeenRepository>();
+        var ls = await repo.GetAsync(userId, CancellationToken.None);
+        ls.Should().NotBeNull("Redis must retain the session payload long enough for the sweeper to persist last_seen");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep Redis presence session hashes longer than the business session TTL so the sweeper can persist last_seen
- add a regression test for the heartbeat-expired path before the Redis backstop expires

## Tests
- dotnet test tests/integration/PresenceService.IntegrationTests/PresenceService.IntegrationTests.csproj --filter "FullyQualifiedName~PresenceSweeperWorkerTests|FullyQualifiedName~RedisPresenceSessionStoreTests|FullyQualifiedName~MultiDeviceTests"
- dotnet test tests/unit/PresenceService.UnitTests/PresenceService.UnitTests.csproj