### PR TITLE
fix(notifications): обработать legacy media upload payload

### DIFF
--- a/src/Services/Notification/NotificationService.Api/Application/Handlers/Media/MediaAssetUploadedHandler.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Handlers/Media/MediaAssetUploadedHandler.cs
@@ -15,9 +15,21 @@ public sealed class MediaAssetUploadedHandler : INotificationHandler<MediaAssetU
         ArgumentNullException.ThrowIfNull(integrationEvent);
         _ = cancellationToken;
 
+        if (integrationEvent.OwnerId == Guid.Empty || integrationEvent.AssetId == Guid.Empty)
+        {
+            return Task.FromResult<IReadOnlyList<NotificationIntent>>([]);
+        }
+
+        var fileName = FirstNonBlank(
+            integrationEvent.OriginalFileName,
+            Path.GetFileName(integrationEvent.ObjectKey),
+            integrationEvent.ObjectKey,
+            "Файл");
+        var mimeType = FirstNonBlank(integrationEvent.MimeType, "application/octet-stream");
+
         var content = NotificationContent.Create(
             "Файл загружен",
-            integrationEvent.OriginalFileName,
+            fileName,
             imageUrl: null,
             deepLink: $"urfulink://media/{integrationEvent.AssetId:N}");
 
@@ -26,8 +38,8 @@ public sealed class MediaAssetUploadedHandler : INotificationHandler<MediaAssetU
             ["assetId"] = integrationEvent.AssetId.ToString("N", CultureInfo.InvariantCulture),
             ["kind"] = integrationEvent.Kind.ToString(),
             ["size"] = integrationEvent.Size.ToString(CultureInfo.InvariantCulture),
-            ["mimeType"] = integrationEvent.MimeType,
-            ["fileName"] = integrationEvent.OriginalFileName,
+            ["mimeType"] = mimeType,
+            ["fileName"] = fileName,
         });
 
         var intent = new NotificationIntent(
@@ -43,5 +55,18 @@ public sealed class MediaAssetUploadedHandler : INotificationHandler<MediaAssetU
             Priority: NotificationPriority.PinSystemAdmin);
 
         return Task.FromResult<IReadOnlyList<NotificationIntent>>([intent]);
+    }
+
+    private static string FirstNonBlank(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return "Файл";
     }
 }

--- a/tests/unit/NotificationService.UnitTests/Application/MediaAssetUploadedHandlerTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Application/MediaAssetUploadedHandlerTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Urfu.Link.BuildingBlocks.Contracts.Integration.Media;
+using Urfu.Link.Services.Notification.Application.Handlers.Media;
+using Urfu.Link.Services.Notification.Domain.Enums;
+
+namespace NotificationService.UnitTests.Application;
+
+public sealed class MediaAssetUploadedHandlerTests
+{
+    [Fact]
+    public async Task PrepareAsync_UsesOriginalFileNameAsNotificationBody()
+    {
+        var ownerId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        var evt = new MediaAssetUploadedEvent(
+            assetId,
+            ownerId,
+            MediaVisibility.Private,
+            MediaAssetKind.Image,
+            "media",
+            "uploads/photo.png",
+            1024,
+            "image/png",
+            "photo.png");
+
+        var intents = await new MediaAssetUploadedHandler().PrepareAsync(evt, default);
+
+        var intent = intents.Single();
+        intent.RecipientUserId.Should().Be(ownerId);
+        intent.Category.Should().Be(NotificationCategory.MediaUploadProcessed);
+        intent.Content.Body.Should().Be("photo.png");
+        intent.Data.Values["fileName"].Should().Be("photo.png");
+    }
+
+    [Fact]
+    public async Task PrepareAsync_UsesObjectKeyFileNameWhenLegacyPayloadHasNoOriginalFileName()
+    {
+        var ownerId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        var evt = new MediaAssetUploadedEvent(
+            assetId,
+            ownerId,
+            MediaVisibility.Private,
+            MediaAssetKind.Image,
+            "media",
+            "uploads/photo.png",
+            1024,
+            "image/png",
+            null!);
+
+        var intents = await new MediaAssetUploadedHandler().PrepareAsync(evt, default);
+
+        var intent = intents.Single();
+        intent.Content.Body.Should().Be("photo.png");
+        intent.Data.Values["fileName"].Should().Be("photo.png");
+    }
+
+    [Fact]
+    public async Task PrepareAsync_SkipsPayloadWithoutOwner()
+    {
+        var evt = new MediaAssetUploadedEvent(
+            Guid.NewGuid(),
+            Guid.Empty,
+            MediaVisibility.Private,
+            MediaAssetKind.Image,
+            "media",
+            "uploads/photo.png",
+            1024,
+            "image/png",
+            null!);
+
+        var intents = await new MediaAssetUploadedHandler().PrepareAsync(evt, default);
+
+        intents.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Что исправлено
- notification-service больше не падает на legacy `media.asset_uploaded.v1` без `OriginalFileName`.
- Для body/fileName используется `OriginalFileName`, затем имя из `ObjectKey`, затем безопасный fallback.
- Payload без `OwnerId` не создает уведомление, чтобы не писать bell item на пустого пользователя.

## Проверки
- dotnet test tests/unit/NotificationService.UnitTests/ --no-restore --filter "FullyQualifiedName~MediaAssetUploadedHandlerTests"
- dotnet test tests/unit/NotificationService.UnitTests/ --no-restore
- dotnet test Urfu.Link.slnx --no-restore -m:1
- git diff --check