### PR TITLE
fix(chat): route mention notifications only

### DIFF
--- a/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
+++ b/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
@@ -247,6 +247,56 @@ describe("chat store direct draft sending", () => {
         expect(conversation.lastMessageAtUtc).toBe("2026-05-24T10:00:00.000Z");
     });
 
+    it("passes selected mention user ids to the hub payload", async () => {
+        const invoke = jest.fn(async (_method: string, payload: { clientMessageId: string; mentionUserIds: string[] }) => ({
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "user-1",
+            body: "@Mikhail Mikhailets привет",
+            attachments: [],
+            state: "Sent",
+            createdAtUtc: "2026-05-24T10:00:00.000Z",
+            deliveredAtUtc: null,
+            readAtUtc: null,
+            clientMessageId: payload.clientMessageId,
+            editedAtUtc: null,
+            replyTo: null,
+            reactionsSummary: {},
+            mentions: payload.mentionUserIds,
+            forwardedFrom: null,
+        }));
+
+        useChatStore.setState({
+            connection: { state: "Connected", invoke } as never,
+            isConnected: true,
+            conversations: [
+                {
+                    id: "direct-1",
+                    type: "Direct",
+                    participants: ["peer-1", "user-1"],
+                    createdAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessageAtUtc: "2026-05-24T09:59:00.000Z",
+                    lastMessagePreview: null,
+                },
+            ],
+        });
+
+        await useChatStore.getState().sendMessage(
+            "direct-1",
+            "@Mikhail Mikhailets привет",
+            [],
+            undefined,
+            ["peer-1"],
+        );
+
+        expect(invoke).toHaveBeenCalledWith(
+            "SendMessage",
+            expect.objectContaining({
+                mentionUserIds: ["peer-1"],
+            }),
+        );
+    });
+
     it("hydrates the current user before sending when the auth store has no jwt user", async () => {
         mockAuthState.userId = null;
         const invoke = jest.fn(async (_method: string, payload: { clientMessageId: string }) => ({

--- a/apps/client/src/entities/conversation/model/chat-store.ts
+++ b/apps/client/src/entities/conversation/model/chat-store.ts
@@ -81,6 +81,7 @@ type ChatState = {
         text: string,
         attachments?: string[],
         replyToMessageId?: string,
+        mentionUserIds?: string[],
     ) => Promise<void>;
     markRead: (chatId: string, messageId: string) => Promise<void>;
 
@@ -778,7 +779,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
     },
 
-    sendMessage: async (chatId, text, attachments = [], replyToMessageId) => {
+    sendMessage: async (chatId, text, attachments = [], replyToMessageId, mentionUserIds = []) => {
         const { connection } = get();
         if (connection?.state !== HubConnectionState.Connected) {
             throw new Error("ChatHub is not connected");
@@ -819,7 +820,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             editedAtUtc: null,
             replyTo,
             reactions: {},
-            mentions: [],
+            mentions: mentionUserIds,
             forwardedFrom: null,
             _localStatus: "sending",
         };
@@ -836,6 +837,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 attachmentAssetIds: attachments,
                 clientMessageId,
                 replyToMessageId: replyToMessageId ?? null,
+                mentionUserIds,
                 peerUserId:
                     get().conversations
                         .find((c) => c.id === chatId && c.type === "Direct")

--- a/apps/client/src/widgets/chat/ui/ChatView.tsx
+++ b/apps/client/src/widgets/chat/ui/ChatView.tsx
@@ -67,7 +67,12 @@ export const ChatView = () => {
     const shouldSkipRemoteConversationLoads = isDirectDraft || isUnknownDirectDraft;
 
     const handleSend = useCallback(
-        async (text: string, files: DocumentPickerAsset[], replyToMessageId?: string) => {
+        async (
+            text: string,
+            files: DocumentPickerAsset[],
+            replyToMessageId?: string,
+            mentionUserIds?: string[],
+        ) => {
             try {
                 const assetIds: string[] = [];
 
@@ -89,7 +94,7 @@ export const ChatView = () => {
                     assetIds.push(initRes.assetId);
                 }
 
-                await sendMessage(chatId, text, assetIds, replyToMessageId);
+                await sendMessage(chatId, text, assetIds, replyToMessageId, mentionUserIds);
             } catch (error) {
                 console.error("Failed to send message", error);
                 throw error;

--- a/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
@@ -26,6 +26,7 @@ import { useChatStore } from "@/entities/conversation/model/chat-store";
 import { useParticipantsStore, useConversationParticipants } from "@/entities/conversation/model/participants-store";
 import { findMentionAtCursor, MentionSuggestions } from "@/features/mentions";
 import { useCurrentUserId } from "@/shared/store/auth-store";
+import type { ConversationParticipantDto } from "@urfu-link/api-client";
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window");
 const MIN_INPUT_CONTENT_HEIGHT = 24;
@@ -74,6 +75,7 @@ interface ChatInputProps {
         text: string,
         files: DocumentPickerAsset[],
         replyToMessageId?: string,
+        mentionUserIds?: string[],
     ) => void | Promise<void>;
     typingEnabled?: boolean;
 }
@@ -81,6 +83,16 @@ interface ChatInputProps {
 export type ChatInputHandle = {
     addFilesAndOpenModal: (files: File[]) => void;
 };
+
+type SelectedMention = {
+    userId: string;
+    label: string;
+};
+
+const normalizeMentionLabel = (displayName: string | null | undefined) =>
+    displayName?.replace(/\s+/g, " ").trim() || "Пользователь";
+
+const mentionTextFor = (label: string) => `@${label}`;
 
 export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     ({ conversationId, onSend, typingEnabled = true }, ref) => {
@@ -92,6 +104,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     const [isEmojiVisible, setIsEmojiVisible] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_CONTENT_HEIGHT);
+    const [selectedMentions, setSelectedMentions] = useState<SelectedMention[]>([]);
     // Курсор: позиция точки вставки в тексте. Нужен для детекта @-токена.
     const [selection, setSelection] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
     // Программно проставляемая selection после вставки @mention. RN сбрасывает
@@ -129,12 +142,18 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     }, [mentionToken, participants, currentUserId]);
 
     const handleSelectMention = useCallback(
-        (item: { displayName: string }) => {
+        (item: ConversationParticipantDto) => {
             if (!mentionToken) return;
-            const insertion = `@${item.displayName.replace(/\s+/g, " ").trim()} `;
+            const label = normalizeMentionLabel(item.displayName);
+            const insertion = `${mentionTextFor(label)} `;
             const next = query.slice(0, mentionToken.start) + insertion + query.slice(mentionToken.end);
             const cursor = mentionToken.start + insertion.length;
             setQuery(next);
+            setSelectedMentions((prev) =>
+                prev.some((mention) => mention.userId === item.userId)
+                    ? prev
+                    : [...prev, { userId: item.userId, label }],
+            );
             previousLineCountRef.current = getExplicitLineCount(next);
             setPendingSelection({ start: cursor, end: cursor });
             // notifyTyping не дёргаем — это всё ещё ввод, useTypingIndicator
@@ -146,6 +165,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     useEffect(() => {
         if (editing) {
             setQuery(editing.body);
+            setSelectedMentions([]);
             previousLineCountRef.current = getExplicitLineCount(editing.body);
             setInputHeight(getExplicitLineContentHeight(editing.body));
         }
@@ -196,6 +216,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
 
     const resetInput = useCallback(() => {
         setQuery("");
+        setSelectedMentions([]);
         clearAttachments();
         if (replyTo) setReply(null);
         previousLineCountRef.current = 1;
@@ -234,6 +255,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             }
 
             setQuery(text);
+            setSelectedMentions((prev) =>
+                prev.filter((mention) => text.includes(mentionTextFor(mention.label))),
+            );
             if (!editing) notifyTyping(text);
         },
         [editing, notifyTyping],
@@ -287,6 +311,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 console.error("Failed to edit", e);
             }
             setQuery("");
+            setSelectedMentions([]);
             resetComposer();
             previousLineCountRef.current = 1;
             pendingLineChangeContentHeightRef.current = null;
@@ -295,9 +320,17 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             return;
         }
 
+        const mentionUserIds = selectedMentions
+            .filter((mention) => trimmed.includes(mentionTextFor(mention.label)))
+            .map((mention) => mention.userId);
+
         setIsSubmitting(true);
         try {
-            await onSend(trimmed, attachments, replyTo?.id);
+            if (mentionUserIds.length > 0) {
+                await onSend(trimmed, attachments, replyTo?.id, mentionUserIds);
+            } else {
+                await onSend(trimmed, attachments, replyTo?.id);
+            }
             resetInput();
         } catch (error) {
             console.error("Failed to submit composer", error);
@@ -315,6 +348,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         replyTo?.id,
         resetComposer,
         resetInput,
+        selectedMentions,
     ]);
 
     const handleInputKeyPress = (event: {

--- a/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from "@testing-library/react-native";
-import { Platform, StyleSheet } from "react-native";
-import type { ReactNode } from "react";
+import { Platform, Pressable, StyleSheet, Text } from "react-native";
+import type { ReactElement, ReactNode } from "react";
 import { ChatInput } from "../Input";
 import { useTypingIndicator } from "@/shared/lib/useTypingIndicator";
 import type { DocumentPickerAsset } from "expo-document-picker";
@@ -12,13 +12,28 @@ const mockHandleAttachFiles = jest.fn();
 const mockRemoveAttachment = jest.fn();
 const mockClearAttachments = jest.fn();
 
+let mockConversationParticipants: Array<{
+    userId: string;
+    role: string;
+    displayName: string;
+    avatarUrl: string;
+}> = [];
+let mockMentionToken: { start: number; end: number; query: string } | null = null;
+let mockMentionSuggestions = ({
+    items,
+    onSelect,
+}: {
+    items: Array<{ userId: string; displayName: string }>;
+    onSelect: (item: { userId: string; displayName: string }) => void;
+}) => null as ReactElement | null;
+
 jest.mock("@/entities/conversation/model/chat-store", () => ({
     useChatStore: (selector: (state: { editMessage: jest.Mock }) => unknown) =>
         selector({ editMessage: jest.fn() }),
 }));
 
 jest.mock("@/entities/conversation/model/participants-store", () => ({
-    useConversationParticipants: () => [],
+    useConversationParticipants: () => mockConversationParticipants,
     useParticipantsStore: jest.fn(),
 }));
 
@@ -75,8 +90,11 @@ jest.mock("@/features/message-actions", () => ({
 }));
 
 jest.mock("@/features/mentions", () => ({
-    MentionSuggestions: () => null,
-    findMentionAtCursor: () => null,
+    MentionSuggestions: (props: {
+        items: Array<{ userId: string; displayName: string }>;
+        onSelect: (item: { userId: string; displayName: string }) => void;
+    }) => mockMentionSuggestions(props),
+    findMentionAtCursor: () => mockMentionToken,
 }));
 
 jest.mock("@/shared/lib/useTypingIndicator", () => ({
@@ -114,6 +132,9 @@ describe("ChatInput", () => {
         mockHandleAttachFiles.mockClear();
         mockRemoveAttachment.mockClear();
         mockClearAttachments.mockClear();
+        mockConversationParticipants = [];
+        mockMentionToken = null;
+        mockMentionSuggestions = () => null;
     });
 
     it("keeps the placeholder vertically centered and removes the browser focus outline", () => {
@@ -218,6 +239,53 @@ describe("ChatInput", () => {
 
         expect(preventDefault).toHaveBeenCalled();
         expect(onSend).toHaveBeenCalledWith("hello", [], undefined);
+    });
+
+    it("passes selected mention ids when sending", async () => {
+        const onSend = jest.fn();
+        const preventDefault = jest.fn();
+        mockConversationParticipants = [
+            {
+                userId: "peer-1",
+                role: "Member",
+                displayName: "Mikhail Mikhailets",
+                avatarUrl: "",
+            },
+        ];
+        mockMentionToken = { start: 0, end: 3, query: "mik" };
+        mockMentionSuggestions = ({ items, onSelect }) => (
+            <>
+                {items.map((item) => (
+                    <Pressable
+                        key={item.userId}
+                        testID={`mention-suggestion-${item.userId}`}
+                        onPress={() => onSelect(item)}
+                    >
+                        <Text>{item.displayName}</Text>
+                    </Pressable>
+                ))}
+            </>
+        );
+
+        render(<ChatInput conversationId="conversation-1" onSend={onSend} />);
+
+        fireEvent.changeText(screen.getByTestId("chat-input-text"), "@mi");
+        fireEvent.press(screen.getByTestId("mention-suggestion-peer-1"));
+
+        await act(async () => {
+            fireEvent(screen.getByTestId("chat-input-text"), "keyPress", {
+                nativeEvent: { key: "Enter", shiftKey: false, preventDefault },
+                preventDefault,
+            });
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+        });
+
+        expect(onSend).toHaveBeenCalledWith(
+            "@Mikhail Mikhailets",
+            [],
+            undefined,
+            ["peer-1"],
+        );
     });
 
     it("keeps Shift+Enter available for line breaks on web", async () => {

--- a/src/Services/Chat/ChatService.Api/Application/Mentions/MentionResolver.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Mentions/MentionResolver.cs
@@ -30,30 +30,36 @@ public sealed partial class MentionResolver(IDisciplineServiceClient disciplineS
         string? body,
         Conversation conversation,
         int maxMentions,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyList<Guid>? explicitMentionUserIds = null)
     {
         ArgumentNullException.ThrowIfNull(conversation);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxMentions);
 
         // Step 1: explicit user ids and @everyone — purely synchronous, no gRPC.
-        var explicitMentions = MentionsParser.Parse(body, conversation.Participants, maxMentions);
+        var mentions = MentionsParser.Parse(body, conversation.Participants, maxMentions).ToList();
+        AddExplicitMentionIds(
+            mentions,
+            explicitMentionUserIds ?? Array.Empty<Guid>(),
+            conversation.Participants,
+            maxMentions);
 
-        if (explicitMentions.Count >= maxMentions || string.IsNullOrEmpty(body))
+        if (mentions.Count >= maxMentions || string.IsNullOrEmpty(body))
         {
-            return explicitMentions;
+            return mentions;
         }
 
         // Step 2: @teachers / @students — discipline-only, requires gRPC.
         if (conversation.GroupSubtype != GroupSubtype.Discipline ||
             conversation.DisciplineId is not Guid disciplineId)
         {
-            return explicitMentions;
+            return mentions;
         }
 
         var (mentionsTeachers, mentionsStudents) = ScanSpecialTokens(body);
         if (!mentionsTeachers && !mentionsStudents)
         {
-            return explicitMentions;
+            return mentions;
         }
 
         var members = await disciplineServiceClient
@@ -61,12 +67,11 @@ public sealed partial class MentionResolver(IDisciplineServiceClient disciplineS
             .ConfigureAwait(false);
 
         var participantSet = new HashSet<Guid>(conversation.Participants);
-        var combined = new List<Guid>(explicitMentions);
-        var seen = new HashSet<Guid>(combined);
+        var seen = new HashSet<Guid>(mentions);
 
         foreach (var member in members)
         {
-            if (combined.Count >= maxMentions)
+            if (mentions.Count >= maxMentions)
             {
                 break;
             }
@@ -83,11 +88,38 @@ public sealed partial class MentionResolver(IDisciplineServiceClient disciplineS
 
             if (roleMatches && seen.Add(member.UserId))
             {
-                combined.Add(member.UserId);
+                mentions.Add(member.UserId);
             }
         }
 
-        return combined;
+        return mentions;
+    }
+
+    private static void AddExplicitMentionIds(
+        List<Guid> mentions,
+        IReadOnlyList<Guid> explicitMentionUserIds,
+        IReadOnlyList<Guid> participants,
+        int maxMentions)
+    {
+        if (explicitMentionUserIds.Count == 0 || mentions.Count >= maxMentions)
+        {
+            return;
+        }
+
+        var participantSet = new HashSet<Guid>(participants);
+        var seen = new HashSet<Guid>(mentions);
+        foreach (var userId in explicitMentionUserIds)
+        {
+            if (mentions.Count >= maxMentions)
+            {
+                return;
+            }
+
+            if (participantSet.Contains(userId) && seen.Add(userId))
+            {
+                mentions.Add(userId);
+            }
+        }
     }
 
     /// <summary>Walks the body once to detect whether teachers/students tokens are present.</summary>

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageRequest.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageRequest.cs
@@ -8,4 +8,5 @@ public sealed record SendMessageRequest(
     string ClientMessageId,
     Guid? ReplyToMessageId = null,
     bool CallerIsAdmin = false,
-    Guid? PeerUserId = null);
+    Guid? PeerUserId = null,
+    IReadOnlyList<Guid>? MentionUserIds = null);

--- a/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
+++ b/src/Services/Chat/ChatService.Api/Application/Messages/SendMessageService.cs
@@ -97,7 +97,12 @@ public sealed class SendMessageService(
 
         var opts = options.Value;
         var mentions = await mentionResolver
-            .ResolveAsync(request.Body, conversation, opts.MaxMentionsPerMessage, cancellationToken)
+            .ResolveAsync(
+                request.Body,
+                conversation,
+                opts.MaxMentionsPerMessage,
+                cancellationToken,
+                request.MentionUserIds)
             .ConfigureAwait(false);
 
         var now = clock.GetUtcNow();

--- a/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
+++ b/src/Services/Chat/ChatService.Api/Realtime/ChatHub.cs
@@ -22,7 +22,8 @@ public sealed record SendMessageHubInput(
     IReadOnlyList<Guid> AttachmentAssetIds,
     string ClientMessageId,
     Guid? ReplyToMessageId = null,
-    Guid? PeerUserId = null);
+    Guid? PeerUserId = null,
+    IReadOnlyList<Guid>? MentionUserIds = null);
 
 public sealed record EditMessageHubInput(Guid MessageId, string NewBody);
 
@@ -155,7 +156,8 @@ public sealed class ChatHub(
                 input.ClientMessageId,
                 input.ReplyToMessageId,
                 principal.IsAdmin(),
-                input.PeerUserId),
+                input.PeerUserId,
+                input.MentionUserIds),
             Context.ConnectionAborted);
     }
 

--- a/src/Services/Notification/NotificationService.Api/Application/Handlers/Chat/ChatDisciplineConversationCreatedHandler.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Handlers/Chat/ChatDisciplineConversationCreatedHandler.cs
@@ -4,8 +4,8 @@ using Urfu.Link.Services.Notification.Domain.Interfaces;
 namespace Urfu.Link.Services.Notification.Application.Handlers.Chat;
 
 /// <summary>
-/// Stores the conversation→discipline mapping so subsequent <c>chat.message.sent.v1</c>
-/// events can be classified as <c>ChatMessageDiscipline</c>.
+/// Stores the conversation→discipline mapping for notification handlers that need
+/// discipline context.
 /// </summary>
 public sealed class ChatDisciplineConversationCreatedHandler(IDisciplineConversationLookup lookup)
 {

--- a/src/Services/Notification/NotificationService.Api/Application/Handlers/Chat/ChatMessageSentHandler.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Handlers/Chat/ChatMessageSentHandler.cs
@@ -1,103 +1,21 @@
-using System.Globalization;
 using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Notification.Application.Routing;
-using Urfu.Link.Services.Notification.Domain.Enums;
-using Urfu.Link.Services.Notification.Domain.Interfaces;
-using Urfu.Link.Services.Notification.Domain.ValueObjects;
 
 namespace Urfu.Link.Services.Notification.Application.Handlers.Chat;
 
 /// <summary>
-/// Maps <see cref="ChatMessageSentEvent"/> into per-recipient intents. Mentions are
-/// intentionally skipped here and are handled only from <c>chat.mention.created.v1</c>
-/// so one message action cannot create a generic and mention notification for the same user.
+/// Plain chat messages do not create notification-center items. Mentions are handled only
+/// from <c>chat.mention.created.v1</c> so a message action cannot be downgraded to a
+/// generic chat notification.
 /// </summary>
-public sealed class ChatMessageSentHandler(IDisciplineConversationLookup disciplineLookup)
-    : INotificationHandler<ChatMessageSentEvent>
+public sealed class ChatMessageSentHandler : INotificationHandler<ChatMessageSentEvent>
 {
-    public async Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
+    public Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
         ChatMessageSentEvent integrationEvent,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(integrationEvent);
-
-        var drafts = new List<NotificationIntent>(integrationEvent.Recipients.Count);
-        var mentions = new HashSet<Guid>(integrationEvent.Mentions ?? []);
-
-        var conversationId = integrationEvent.ConversationId;
-        if (!Guid.TryParse(conversationId, out var conversationGuid))
-        {
-            conversationGuid = StableGuids.From(conversationId);
-        }
-
-        var isDisciplineConversation = await disciplineLookup
-            .IsDisciplineConversationAsync(conversationId, cancellationToken)
-            .ConfigureAwait(false);
-
-        var preview = string.IsNullOrWhiteSpace(integrationEvent.Preview)
-            ? "Новое сообщение"
-            : integrationEvent.Preview;
-
-        foreach (var recipientId in integrationEvent.Recipients)
-        {
-            if (recipientId == integrationEvent.SenderId)
-            {
-                continue;
-            }
-
-            if (mentions.Contains(recipientId))
-            {
-                continue;
-            }
-
-            NotificationCategory category;
-            NotificationSeverity severity;
-            string title;
-            GroupKey groupKey;
-
-            if (isDisciplineConversation)
-            {
-                category = NotificationCategory.ChatMessageDiscipline;
-                severity = NotificationSeverity.Normal;
-                title = "Сообщение в дисциплине";
-                groupKey = GroupKey.ForDisciplineChat(conversationGuid);
-            }
-            else
-            {
-                category = NotificationCategory.ChatMessageDirect;
-                severity = NotificationSeverity.Normal;
-                title = "Новое сообщение";
-                groupKey = GroupKey.ForDirectChat(conversationGuid);
-            }
-
-            var content = NotificationContent.Create(
-                title: title,
-                body: preview,
-                imageUrl: null,
-                deepLink: $"urfulink://chat/conv/{conversationId}/msg/{integrationEvent.MessageId:N}");
-
-            var data = NotificationData.From(new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["conversationId"] = conversationId,
-                ["messageId"] = integrationEvent.MessageId.ToString("N", CultureInfo.InvariantCulture),
-                ["senderId"] = integrationEvent.SenderId.ToString("N", CultureInfo.InvariantCulture),
-            });
-
-            drafts.Add(new NotificationIntent(
-                RecipientUserId: recipientId,
-                Category: category,
-                Severity: severity,
-                Content: content,
-                Data: data,
-                GroupKey: groupKey,
-                SourceEventId: integrationEvent.EventId,
-                SourceEventType: integrationEvent.EventType,
-                SourceActionId: NotificationSourceActions.ChatMessage(conversationId, integrationEvent.MessageId),
-                Priority: NotificationPriority.ChatMessage,
-                Actor: new NotificationActor(integrationEvent.SenderId, null, null),
-                SuppressWhenViewingContextKey: NotificationViewingContexts.ChatConversation(conversationId)));
-        }
-
-        return drafts;
+        _ = cancellationToken;
+        return Task.FromResult<IReadOnlyList<NotificationIntent>>(Array.Empty<NotificationIntent>());
     }
 }

--- a/src/Services/Notification/NotificationService.Api/Domain/Aggregates/DisciplineConversation.cs
+++ b/src/Services/Notification/NotificationService.Api/Domain/Aggregates/DisciplineConversation.cs
@@ -2,8 +2,8 @@ namespace Urfu.Link.Services.Notification.Domain.Aggregates;
 
 /// <summary>
 /// Read model that maps a chat conversation id (string) to its parent discipline.
-/// Populated from <c>chat.discipline_conversation_created.v1</c> events. Used by
-/// ChatMessageSentHandler to classify direct vs discipline-group messages.
+/// Populated from <c>chat.discipline_conversation_created.v1</c> events for handlers
+/// that need discipline context.
 /// </summary>
 public sealed class DisciplineConversation
 {

--- a/tests/unit/ChatService.UnitTests/Application/MentionResolverTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/MentionResolverTests.cs
@@ -38,6 +38,39 @@ public sealed class MentionResolverTests
     }
 
     [Fact]
+    public async Task Direct_chat_accepts_explicit_mention_ids_from_client_selection()
+    {
+        var direct = Conversation.OpenDirect(TeacherA, StudentA, DateTimeOffset.UtcNow);
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync(
+            "@Student One please review",
+            direct,
+            maxMentions: 50,
+            cancellationToken: CancellationToken.None,
+            explicitMentionUserIds: [StudentA]);
+
+        mentions.Should().Equal(StudentA);
+    }
+
+    [Fact]
+    public async Task Explicit_mention_ids_are_validated_against_participants()
+    {
+        var direct = Conversation.OpenDirect(TeacherA, StudentA, DateTimeOffset.UtcNow);
+        var outsider = Guid.NewGuid();
+        var resolver = new MentionResolver(_discipline);
+
+        var mentions = await resolver.ResolveAsync(
+            "@Outsider",
+            direct,
+            maxMentions: 50,
+            cancellationToken: CancellationToken.None,
+            explicitMentionUserIds: [outsider]);
+
+        mentions.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Discipline_chat_expands_teachers_token_via_grpc()
     {
         var conv = OpenDisciplineConversation(TeacherA, [TeacherA, TeacherB, StudentA]);

--- a/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
+++ b/tests/unit/ChatService.UnitTests/Application/SendMessageServiceTests.cs
@@ -264,6 +264,27 @@ public class SendMessageServiceTests
     }
 
     [Fact]
+    public async Task SendAsync_WithExplicitMentionIds_PublishesMentionEvent()
+    {
+        var conv = SeedConversation();
+        var request = new SendMessageRequest(
+            conv.Id,
+            Sender,
+            "@Mikhail Mikhailets посмотри",
+            Array.Empty<Guid>(),
+            "c-mention",
+            MentionUserIds: [Peer]);
+
+        var dto = await Build().SendAsync(request, default);
+
+        dto.Mentions.Should().Equal(Peer);
+        _outbox.Captured.OfType<ChatMessageSentEvent>().Should().ContainSingle()
+            .Which.Mentions.Should().Equal(Peer);
+        _outbox.Captured.OfType<ChatMentionCreatedEvent>().Should().ContainSingle()
+            .Which.MentionedUserIds.Should().Equal(Peer);
+    }
+
+    [Fact]
     public async Task SendAsync_DuplicateClientMessageId_ReturnsPriorMessage_WithoutDoublePublish()
     {
         var conv = SeedConversation();

--- a/tests/unit/NotificationService.UnitTests/Application/ChatMessageSentHandlerTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Application/ChatMessageSentHandlerTests.cs
@@ -1,135 +1,44 @@
 using FluentAssertions;
-using NSubstitute;
 using Urfu.Link.BuildingBlocks.Contracts.Integration.Chat;
 using Urfu.Link.Services.Notification.Application.Handlers.Chat;
-using Urfu.Link.Services.Notification.Domain.Enums;
-using Urfu.Link.Services.Notification.Domain.Interfaces;
 
 namespace NotificationService.UnitTests.Application;
 
 public sealed class ChatMessageSentHandlerTests
 {
-    private static IDisciplineConversationLookup NoDisciplineLookup()
-    {
-        var lookup = Substitute.For<IDisciplineConversationLookup>();
-        lookup.IsDisciplineConversationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-        return lookup;
-    }
-
     [Fact]
-    public async Task PrepareAsync_SkipsSenderInRecipients()
+    public async Task PrepareAsync_PlainMessage_ReturnsNoDrafts()
     {
-        var sender = Guid.NewGuid();
-        var alice = Guid.NewGuid();
-        var bob = Guid.NewGuid();
         var evt = new ChatMessageSentEvent(
             ConversationId: Guid.NewGuid().ToString(),
             MessageId: Guid.NewGuid(),
-            SenderId: sender,
-            Recipients: [sender, alice, bob],
+            SenderId: Guid.NewGuid(),
+            Recipients: [Guid.NewGuid()],
             Preview: "Hello",
             HasAttachments: false,
             OccurredAtUtc: DateTimeOffset.UtcNow);
 
-        var drafts = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
+        var drafts = await new ChatMessageSentHandler().PrepareAsync(evt, default);
 
-        drafts.Should().HaveCount(2);
-        drafts.Select(d => d.RecipientUserId).Should().BeEquivalentTo([alice, bob]);
+        drafts.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task PrepareAsync_MentionedRecipients_AreSuppressedFromGenericMessage()
+    public async Task PrepareAsync_MessageWithMentions_ReturnsNoDrafts()
     {
-        var sender = Guid.NewGuid();
-        var alice = Guid.NewGuid();
-        var bob = Guid.NewGuid();
+        var mentioned = Guid.NewGuid();
         var evt = new ChatMessageSentEvent(
             ConversationId: Guid.NewGuid().ToString(),
             MessageId: Guid.NewGuid(),
-            SenderId: sender,
-            Recipients: [alice, bob],
-            Preview: "Hey @alice",
+            SenderId: Guid.NewGuid(),
+            Recipients: [mentioned],
+            Preview: "Hey @user",
             HasAttachments: false,
             OccurredAtUtc: DateTimeOffset.UtcNow,
-            Mentions: [alice]);
+            Mentions: [mentioned]);
 
-        var drafts = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
+        var drafts = await new ChatMessageSentHandler().PrepareAsync(evt, default);
 
-        var directDraft = drafts.Single();
-
-        directDraft.RecipientUserId.Should().Be(bob);
-        directDraft.Category.Should().Be(NotificationCategory.ChatMessageDirect);
-        directDraft.Severity.Should().Be(NotificationSeverity.Normal);
-        drafts.Should().NotContain(d => d.RecipientUserId == alice);
-    }
-
-    [Fact]
-    public async Task PrepareAsync_PopulatesDeepLinkAndDataMap()
-    {
-        var sender = Guid.NewGuid();
-        var bob = Guid.NewGuid();
-        var convId = Guid.NewGuid();
-        var msgId = Guid.NewGuid();
-        var evt = new ChatMessageSentEvent(
-            ConversationId: convId.ToString(),
-            MessageId: msgId,
-            SenderId: sender,
-            Recipients: [bob],
-            Preview: "Hello",
-            HasAttachments: false,
-            OccurredAtUtc: DateTimeOffset.UtcNow);
-
-        var drafts = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
-
-        var draft = drafts.Single();
-        draft.Content.DeepLink.Should().Contain(convId.ToString());
-        draft.Content.DeepLink.Should().Contain(msgId.ToString("N"));
-        draft.Data.Values["conversationId"].Should().Be(convId.ToString());
-        draft.Data.Values["messageId"].Should().Be(msgId.ToString("N"));
-        draft.Data.Values["senderId"].Should().Be(sender.ToString("N"));
-        draft.Actor.Should().NotBeNull();
-        draft.Actor!.Id.Should().Be(sender);
-        draft.SourceActionId.Should().Be($"chat:message:{convId}:{msgId:N}");
-        draft.Priority.Should().Be(NotificationPriority.ChatMessage);
-        draft.SuppressWhenViewingContextKey.Should().Be($"chat:conversation:{convId}");
-    }
-
-    [Fact]
-    public async Task PrepareAsync_PreviewFallbackForBlankBody()
-    {
-        var sender = Guid.NewGuid();
-        var bob = Guid.NewGuid();
-        var evt = new ChatMessageSentEvent(
-            ConversationId: Guid.NewGuid().ToString(),
-            MessageId: Guid.NewGuid(),
-            SenderId: sender,
-            Recipients: [bob],
-            Preview: "",
-            HasAttachments: true,
-            OccurredAtUtc: DateTimeOffset.UtcNow);
-
-        var drafts = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
-
-        drafts.Single().Content.Body.Should().Be("Новое сообщение");
-    }
-
-    [Fact]
-    public async Task PrepareAsync_NonGuidConversationId_ProducesStableGroupKey()
-    {
-        var sender = Guid.NewGuid();
-        var bob = Guid.NewGuid();
-        var evt = new ChatMessageSentEvent(
-            ConversationId: "stringy-conversation-id",
-            MessageId: Guid.NewGuid(),
-            SenderId: sender,
-            Recipients: [bob],
-            Preview: "Hi",
-            HasAttachments: false,
-            OccurredAtUtc: DateTimeOffset.UtcNow);
-
-        var firstRun = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
-        var secondRun = await new ChatMessageSentHandler(NoDisciplineLookup()).PrepareAsync(evt, default);
-
-        firstRun.Single().GroupKey.Should().Be(secondRun.Single().GroupKey);
+        drafts.Should().BeEmpty("mention notifications are produced from chat.mention.created.v1 only");
     }
 }

--- a/tests/unit/NotificationService.UnitTests/Application/NotificationRouterTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Application/NotificationRouterTests.cs
@@ -70,7 +70,7 @@ public sealed class NotificationRouterTests
             false,
             DateTimeOffset.UtcNow);
 
-        var outcome = await _router.RouteAsync(evt, new ChatMessageSentHandler(Substitute.For<IDisciplineConversationLookup>()), default);
+        var outcome = await _router.RouteAsync(evt, new ChatMessageSentHandler(), default);
 
         outcome.Should().Be(RoutingOutcome.NoDrafts);
         await _repository.DidNotReceive().UpsertAsync(Arg.Any<NotificationAggregate>(), Arg.Any<CancellationToken>());
@@ -81,24 +81,22 @@ public sealed class NotificationRouterTests
     {
         var sender = Guid.NewGuid();
         var bob = Guid.NewGuid();
-        var evt = new ChatMessageSentEvent(
+        var evt = new ChatMentionCreatedEvent(
             Guid.NewGuid().ToString(),
             Guid.NewGuid(),
             sender,
-            Recipients: [bob],
-            "Hi",
-            false,
+            [bob],
             DateTimeOffset.UtcNow);
 
-        var outcome = await _router.RouteAsync(evt, new ChatMessageSentHandler(Substitute.For<IDisciplineConversationLookup>()), default);
+        var outcome = await _router.RouteAsync(evt, new ChatMentionCreatedHandler(), default);
 
         outcome.Created.Should().Be(1);
         outcome.Skipped.Should().Be(0);
 
         await _repository.Received(1).UpsertAsync(
-            Arg.Is<NotificationAggregate>(n => n.RecipientUserId == bob && n.Category == NotificationCategory.ChatMessageDirect),
+            Arg.Is<NotificationAggregate>(n => n.RecipientUserId == bob && n.Category == NotificationCategory.ChatMessageMention),
             Arg.Any<CancellationToken>());
-        await _badgeStore.Received(1).IncrementAsync(bob, NotificationCategory.ChatMessageDirect, Arg.Any<CancellationToken>());
+        await _badgeStore.Received(1).IncrementAsync(bob, NotificationCategory.ChatMessageMention, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -108,16 +106,14 @@ public sealed class NotificationRouterTests
         var bob = Guid.NewGuid();
         _prefs.GetContactAsync(sender, Arg.Any<CancellationToken>())
             .Returns(new UserContact(string.Empty, "Иван Петров", "ru-RU"));
-        var evt = new ChatMessageSentEvent(
+        var evt = new ChatMentionCreatedEvent(
             Guid.NewGuid().ToString(),
             Guid.NewGuid(),
             sender,
-            Recipients: [bob],
-            "Привет",
-            false,
+            [bob],
             DateTimeOffset.UtcNow);
 
-        await _router.RouteAsync(evt, new ChatMessageSentHandler(Substitute.For<IDisciplineConversationLookup>()), default);
+        await _router.RouteAsync(evt, new ChatMentionCreatedHandler(), default);
 
         await _repository.Received(1).UpsertAsync(
             Arg.Is<NotificationAggregate>(n =>
@@ -133,16 +129,14 @@ public sealed class NotificationRouterTests
         _repository.UpsertAsync(Arg.Any<NotificationAggregate>(), Arg.Any<CancellationToken>())
             .Returns(NotificationUpsertResult.Skipped());
 
-        var evt = new ChatMessageSentEvent(
+        var evt = new ChatMentionCreatedEvent(
             Guid.NewGuid().ToString(),
             Guid.NewGuid(),
             Guid.NewGuid(),
-            Recipients: [Guid.NewGuid()],
-            "Hi",
-            false,
+            [Guid.NewGuid()],
             DateTimeOffset.UtcNow);
 
-        var outcome = await _router.RouteAsync(evt, new ChatMessageSentHandler(Substitute.For<IDisciplineConversationLookup>()), default);
+        var outcome = await _router.RouteAsync(evt, new ChatMentionCreatedHandler(), default);
 
         outcome.Created.Should().Be(0);
         outcome.Skipped.Should().Be(1);
@@ -195,7 +189,7 @@ public sealed class NotificationRouterTests
             {
                 Categories = new Dictionary<NotificationCategory, ChannelToggle>
                 {
-                    [NotificationCategory.ChatMessageDirect] = new(false, false, false),
+                    [NotificationCategory.ChatMessageMention] = new(false, false, false),
                 },
             });
 
@@ -203,16 +197,14 @@ public sealed class NotificationRouterTests
         _repository.UpsertAsync(Arg.Do<NotificationAggregate>(n => captured = n), Arg.Any<CancellationToken>())
             .Returns(call => NotificationUpsertResult.Created(call.Arg<NotificationAggregate>()));
 
-        var evt = new ChatMessageSentEvent(
+        var evt = new ChatMentionCreatedEvent(
             Guid.NewGuid().ToString(),
             Guid.NewGuid(),
             Guid.NewGuid(),
-            Recipients: [Guid.NewGuid()],
-            "Hi",
-            false,
+            [Guid.NewGuid()],
             DateTimeOffset.UtcNow);
 
-        await _router.RouteAsync(evt, new ChatMessageSentHandler(Substitute.For<IDisciplineConversationLookup>()), default);
+        await _router.RouteAsync(evt, new ChatMentionCreatedHandler(), default);
 
         captured.Should().NotBeNull();
         captured!.Deliveries.Should().BeEmpty();


### PR DESCRIPTION
## Summary
- stop creating notification drafts for ordinary chat.message.sent events
- send mention notifications only from chat.mention.created events
- pass explicit mention user ids from the chat UI through SignalR to backend mention resolution

## Checks
- dotnet test tests/unit/NotificationService.UnitTests/NotificationService.UnitTests.csproj --logger "console;verbosity=minimal"
- dotnet test tests/unit/ChatService.UnitTests/ChatService.UnitTests.csproj --logger "console;verbosity=minimal"
- pnpm --filter @urfu-link/client test -- --runTestsByPath src/entities/conversation/model/__tests__/chat-store.test.ts src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
- pnpm --filter @urfu-link/client typecheck
- git diff --check