### PR TITLE
Fix logout flow

### DIFF
--- a/apps/client/src/features/auth/model/auth-gate.tsx
+++ b/apps/client/src/features/auth/model/auth-gate.tsx
@@ -51,7 +51,7 @@ async function startPKCEFlow(): Promise<void> {
 async function handleCallback(
     code: string,
     state: string
-): Promise<{ accessToken: string; refreshToken: string; expiresAt: number } | null> {
+): Promise<{ accessToken: string; refreshToken: string; expiresAt: number; idToken: string | null } | null> {
     const storedVerifier = sessionStorage.getItem("pkce_code_verifier");
     const storedState = sessionStorage.getItem("pkce_state");
 
@@ -81,6 +81,7 @@ async function handleCallback(
         accessToken: data.access_token,
         refreshToken: data.refresh_token ?? "",
         expiresAt: Date.now() + data.expires_in * 1000,
+        idToken: typeof data.id_token === "string" ? data.id_token : null,
     };
 }
 
@@ -100,7 +101,7 @@ function DevAuthGate({ children }: PropsWithChildren) {
             handleCallback(code, state)
                 .then((result) => {
                     if (result) {
-                        setTokens(result.accessToken, result.refreshToken, result.expiresAt);
+                        setTokens(result.accessToken, result.refreshToken, result.expiresAt, result.idToken);
                     }
                 })
                 .finally(() => setExchanging(false));

--- a/apps/client/src/features/logout/model/__tests__/logout.test.ts
+++ b/apps/client/src/features/logout/model/__tests__/logout.test.ts
@@ -1,0 +1,48 @@
+import {
+    createKeycloakLogoutUrl,
+    createPomeriumSignOutUrl,
+} from "../logout";
+
+jest.mock("@/shared/lib/config", () => ({
+    appConfig: {
+        appEnv: "dev",
+        apiUrl: "http://localhost:5080",
+        keycloakUrl: "http://localhost:8080",
+    },
+}));
+
+jest.mock("@/shared/store/auth-store", () => ({
+    useAuthStore: {
+        getState: () => ({
+            clearTokens: jest.fn(),
+            idToken: null,
+        }),
+    },
+}));
+
+describe("logout urls", () => {
+    it("builds a same-origin Pomerium sign-out url with the current page as return target", () => {
+        const currentHref = "https://urfu-link.ghjc.ru/profile/devices?from=settings";
+        const url = new URL(createPomeriumSignOutUrl(currentHref));
+
+        expect(url.origin).toBe("https://urfu-link.ghjc.ru");
+        expect(url.pathname).toBe("/.pomerium/sign_out");
+        expect(url.searchParams.get("pomerium_redirect_uri")).toBe(currentHref);
+    });
+
+    it("builds a Keycloak end-session url for the dev PKCE flow", () => {
+        const url = new URL(
+            createKeycloakLogoutUrl({
+                keycloakUrl: "http://localhost:8080/",
+                redirectUri: "http://localhost:3000/",
+                idToken: "id-token",
+            }),
+        );
+
+        expect(url.origin).toBe("http://localhost:8080");
+        expect(url.pathname).toBe("/realms/urfu-link/protocol/openid-connect/logout");
+        expect(url.searchParams.get("client_id")).toBe("urfu-link-web");
+        expect(url.searchParams.get("post_logout_redirect_uri")).toBe("http://localhost:3000/");
+        expect(url.searchParams.get("id_token_hint")).toBe("id-token");
+    });
+});

--- a/apps/client/src/features/logout/model/logout.ts
+++ b/apps/client/src/features/logout/model/logout.ts
@@ -1,0 +1,65 @@
+import { KEYCLOAK_CLIENT_ID, KEYCLOAK_REALM } from "@/features/auth/keycloak-constants";
+import { appConfig } from "@/shared/lib/config";
+import { useAuthStore } from "@/shared/store/auth-store";
+import { Platform } from "react-native";
+
+type KeycloakLogoutUrlParams = {
+    keycloakUrl: string;
+    redirectUri: string;
+    idToken?: string | null;
+};
+
+const trimTrailingSlash = (value: string) => value.replace(/\/$/, "");
+
+export function createPomeriumSignOutUrl(currentHref: string): string {
+    const url = new URL("/.pomerium/sign_out", currentHref);
+    url.searchParams.set("pomerium_redirect_uri", currentHref);
+    return url.toString();
+}
+
+export function createKeycloakLogoutUrl({
+    keycloakUrl,
+    redirectUri,
+    idToken,
+}: KeycloakLogoutUrlParams): string {
+    const url = new URL(
+        `${trimTrailingSlash(keycloakUrl)}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/logout`,
+    );
+    url.searchParams.set("client_id", KEYCLOAK_CLIENT_ID);
+    url.searchParams.set("post_logout_redirect_uri", redirectUri);
+
+    if (idToken) {
+        url.searchParams.set("id_token_hint", idToken);
+    }
+
+    return url.toString();
+}
+
+function clearPkceState(): void {
+    if (typeof window === "undefined") return;
+
+    window.sessionStorage.removeItem("pkce_code_verifier");
+    window.sessionStorage.removeItem("pkce_state");
+}
+
+export function performLogout(): void {
+    const { clearTokens, idToken } = useAuthStore.getState();
+
+    clearTokens();
+    clearPkceState();
+
+    if (Platform.OS !== "web" || typeof window === "undefined") return;
+
+    if (appConfig.appEnv === "dev") {
+        window.location.assign(
+            createKeycloakLogoutUrl({
+                keycloakUrl: appConfig.keycloakUrl,
+                redirectUri: `${window.location.origin}/`,
+                idToken,
+            }),
+        );
+        return;
+    }
+
+    window.location.assign(createPomeriumSignOutUrl(window.location.href));
+}

--- a/apps/client/src/features/logout/ui/Logout.tsx
+++ b/apps/client/src/features/logout/ui/Logout.tsx
@@ -1,13 +1,14 @@
 import { useWindowSize } from "@/shared/lib/useWindowSize";
 import { Button } from "@/shared/ui";
 import { SignOutIcon } from "@/shared/ui/phosphor";
+import { performLogout } from "../model/logout";
 
 export const Logout = () => {
     const { isMobile } = useWindowSize();
     return (
         <Button
             label="Выйти"
-            onPress={() => {}}
+            onPress={performLogout}
             variant="danger"
             className={`
               justify-start

--- a/apps/client/src/features/logout/ui/__tests__/Logout.test.tsx
+++ b/apps/client/src/features/logout/ui/__tests__/Logout.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { Logout } from "../Logout";
+import { performLogout } from "../../model/logout";
+
+jest.mock("@/shared/lib/useWindowSize", () => ({
+    useWindowSize: () => ({ isMobile: false }),
+}));
+
+jest.mock("@/shared/ui", () => {
+    const { Pressable, Text } = require("react-native");
+
+    return {
+        Button: ({ label, onPress }: { label?: string; onPress: () => void }) => (
+            <Pressable onPress={onPress}>
+                <Text>{label}</Text>
+            </Pressable>
+        ),
+    };
+});
+
+jest.mock("@/shared/ui/phosphor", () => ({
+    SignOutIcon: () => null,
+}));
+
+jest.mock("../../model/logout", () => ({
+    performLogout: jest.fn(),
+}));
+
+describe("Logout", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("starts logout when the button is pressed", () => {
+        render(<Logout />);
+
+        fireEvent.press(screen.getByText("Выйти"));
+
+        expect(performLogout).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/client/src/providers/auth-provider.tsx
+++ b/apps/client/src/providers/auth-provider.tsx
@@ -8,7 +8,7 @@ import { KEYCLOAK_CLIENT_ID, KEYCLOAK_REALM } from "@/features/auth/keycloak-con
 async function refreshAccessToken(
     keycloakUrl: string,
     refreshToken: string,
-): Promise<{ accessToken: string; refreshToken: string; expiresAt: number } | null> {
+): Promise<{ accessToken: string; refreshToken: string; expiresAt: number; idToken?: string } | null> {
     try {
         const res = await fetch(
             `${keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
@@ -28,6 +28,7 @@ async function refreshAccessToken(
             accessToken: data.access_token,
             refreshToken: data.refresh_token ?? refreshToken,
             expiresAt: Date.now() + data.expires_in * 1000,
+            idToken: typeof data.id_token === "string" ? data.id_token : undefined,
         };
     } catch {
         return null;
@@ -49,7 +50,7 @@ export default function AuthProvider({ children }: PropsWithChildren) {
                 if (!currentRefreshToken) return;
                 const result = await refreshAccessToken(appConfig.keycloakUrl, currentRefreshToken);
                 if (result) {
-                    setTokens(result.accessToken, result.refreshToken, result.expiresAt);
+                    setTokens(result.accessToken, result.refreshToken, result.expiresAt, result.idToken);
                     scheduleRefresh(result.expiresAt);
                 } else {
                     clearTokens();
@@ -73,7 +74,7 @@ export default function AuthProvider({ children }: PropsWithChildren) {
             if (rt) {
                 const result = await refreshAccessToken(appConfig.keycloakUrl, rt);
                 if (result) {
-                    set(result.accessToken, result.refreshToken, result.expiresAt);
+                    set(result.accessToken, result.refreshToken, result.expiresAt, result.idToken);
                     scheduleRefresh(result.expiresAt);
                 } else {
                     clear();

--- a/apps/client/src/shared/store/auth-store.ts
+++ b/apps/client/src/shared/store/auth-store.ts
@@ -4,10 +4,11 @@ import { createJSONStorage, persist } from "zustand/middleware";
 
 type AuthState = {
     accessToken: string | null;
+    idToken: string | null;
     refreshToken: string | null;
     expiresAt: number | null; // Unix ms
     userId: string | null;
-    setTokens: (accessToken: string, refreshToken: string, expiresAt: number) => void;
+    setTokens: (accessToken: string, refreshToken: string, expiresAt: number, idToken?: string | null) => void;
     setUserId: (userId: string | null) => void;
     clearTokens: () => void;
     isTokenValid: () => boolean;
@@ -36,20 +37,23 @@ export const useAuthStore = create<AuthState>()(
     persist(
         (set, get) => ({
             accessToken: null,
+            idToken: null,
             refreshToken: null,
             expiresAt: null,
             userId: null,
-            setTokens: (accessToken, refreshToken, expiresAt) =>
-                set({
+            setTokens: (accessToken, refreshToken, expiresAt, idToken) =>
+                set((state) => ({
                     accessToken,
+                    idToken: idToken === undefined ? state.idToken : idToken,
                     refreshToken,
                     expiresAt,
                     userId: extractUserId(accessToken),
-                }),
+                })),
             setUserId: (userId) => set({ userId }),
             clearTokens: () =>
                 set({
                     accessToken: null,
+                    idToken: null,
                     refreshToken: null,
                     expiresAt: null,
                     userId: null,
@@ -66,6 +70,7 @@ export const useAuthStore = create<AuthState>()(
             storage: createJSONStorage(() => appStorage),
             partialize: (state) => ({
                 accessToken: state.accessToken,
+                idToken: state.idToken,
                 refreshToken: state.refreshToken,
                 expiresAt: state.expiresAt,
                 userId: state.userId,

--- a/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
+++ b/deploy/k8s/platform/identity/keycloak-bootstrap-job.yaml
@@ -452,6 +452,18 @@ spec:
 
               # --- Frontend Web (public client for mobile) ---
               ensure_client "urfu-link-web" '["https://urfu-link.ghjc.ru/*","http://app.dev.127.0.0.1.nip.io/*"]' '["https://urfu-link.ghjc.ru","http://app.dev.127.0.0.1.nip.io"]' "true" "URFU Link" "https://urfu-link.ghjc.ru"
+              URFU_LINK_WEB_FULL="$(curl --silent --fail \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/clients/${CLIENT_UUID}")"
+              URFU_LINK_WEB_UPDATED="$(echo "$URFU_LINK_WEB_FULL" | \
+                jq '.attributes = (.attributes // {}) | .attributes["post.logout.redirect.uris"] = "https://urfu-link.ghjc.ru/*##http://app.dev.127.0.0.1.nip.io/*"')"
+              curl --fail --silent --show-error \
+                -X PUT \
+                -H "Authorization: Bearer ${KC_TOKEN}" \
+                -H "Content-Type: application/json" \
+                "${KEYCLOAK_URL}/admin/realms/urfu-link/clients/${CLIENT_UUID}" \
+                -d "$URFU_LINK_WEB_UPDATED" >/dev/null
+              echo "Post-logout redirect URIs set for urfu-link-web."
 
               # --- Pomerium (centralized auth proxy) ---
               ensure_client "pomerium" '["https://auth.ghjc.ru/oauth2/callback","https://auth.ghjc.ru/.pomerium/callback","https://auth.ghjc.ru/.pomerium/signed_out"]' '["https://*.ghjc.ru"]' "false" "Pomerium Auth Proxy" "https://auth.ghjc.ru"

--- a/platform/dev/keycloak/realm-urfu-link.json
+++ b/platform/dev/keycloak/realm-urfu-link.json
@@ -67,6 +67,9 @@
       "protocol": "openid-connect",
       "redirectUris": ["http://localhost:3000/*", "http://localhost:8081/*"],
       "webOrigins": ["http://localhost:3000", "http://localhost:8081"],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/##http://localhost:8081/"
+      },
       "protocolMappers": [
         {
           "name": "urfu-link-api audience",


### PR DESCRIPTION
## Summary
- wire the logout button to shared logout logic
- support prod Pomerium sign-out and dev Keycloak end-session logout
- persist id_token for OIDC logout and configure post-logout redirects

## Tests
- pnpm --filter @urfu-link/client exec jest --watchAll=false --runTestsByPath src/features/logout/model/__tests__/logout.test.ts src/features/logout/ui/__tests__/Logout.test.tsx
- pnpm --filter @urfu-link/client typecheck
- jq empty platform/dev/keycloak/realm-urfu-link.json
- git diff --check