### PR TITLE
fix(frontend): include patches in web image build

### DIFF
--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /workspace
 
 FROM base AS build
 COPY .npmrc package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches patches
 COPY apps/client/package.json apps/client/package.json
 COPY packages/api-client/package.json packages/api-client/package.json
 COPY packages/ui/package.json packages/ui/package.json


### PR DESCRIPTION
## Summary
- Copy pnpm patch files before Docker dependency install in the frontend web image build.

## Validation
- docker build -f apps/client/Dockerfile -t urfu-link/frontend-web:ci-fix .

## Context
Unblocks the v0.6.0 production release after Frontend Web Image failed on missing `patches/rn-emoji-keyboard@1.7.0.patch`.
