### PR TITLE
release: file upload drag/drop UX

### DIFF
--- a/apps/client/src/features/attach-file/ui/FilesModal.tsx
+++ b/apps/client/src/features/attach-file/ui/FilesModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import {
     Modal,
-    Platform,
     Pressable,
     ScrollView,
     StyleSheet,
@@ -10,21 +9,14 @@ import {
 } from "react-native";
 import * as DocumentPicker from "expo-document-picker";
 import { useWindowSize } from "@/shared/lib/useWindowSize";
+import { useWebFileDrop } from "@/shared/lib/useWebFileDrop";
+import { ActivityIndicator } from "@/shared/ui/activity-indicator";
 import {
     FileIcon,
     ImageSquareIcon,
     UploadSimpleIcon,
     XIcon,
 } from "@/shared/ui/phosphor";
-
-type WebDragEvent = {
-    preventDefault?: () => void;
-    stopPropagation?: () => void;
-    dataTransfer?: DataTransfer;
-    nativeEvent?: {
-        dataTransfer?: DataTransfer;
-    };
-};
 
 interface FilesModalProps {
     visible: boolean;
@@ -35,17 +27,13 @@ interface FilesModalProps {
     onRemove: (index: number) => void;
     onSubmit: () => void | Promise<void>;
     isSubmitting?: boolean;
+    submitError?: string | null;
 }
 
 const formatFileSize = (size?: number) => {
     if (!size || size <= 0) return "0 KB";
     if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
     return `${(size / 1024 / 1024).toFixed(1)} MB`;
-};
-
-const getTransferFiles = (event: WebDragEvent) => {
-    const transfer = event.nativeEvent?.dataTransfer ?? event.dataTransfer;
-    return transfer?.files ? Array.from(transfer.files) : [];
 };
 
 export const FilesModal = ({
@@ -57,41 +45,28 @@ export const FilesModal = ({
     onRemove,
     onSubmit,
     isSubmitting = false,
+    submitError = null,
 }: FilesModalProps) => {
     const { width, isMobile } = useWindowSize();
     const canSubmit = attachments.length > 0 && !isSubmitting;
+    const { dropRef, isDragging } = useWebFileDrop({
+        enabled: visible && !isSubmitting,
+        onFiles: onAddDroppedFiles,
+    });
     const panelWidth = useMemo(() => {
         if (isMobile) return width;
-        return Math.min(Math.max(width - 20, 320), 878);
+        return Math.min(Math.max(width - 32, 320), 660);
     }, [isMobile, width]);
-
-    const preventDefaultDrag = useCallback((event: WebDragEvent) => {
-        event.preventDefault?.();
-        event.stopPropagation?.();
-    }, []);
-
-    const handleDrop = useCallback(
-        (event: WebDragEvent) => {
-            preventDefaultDrag(event);
-            const files = getTransferFiles(event);
-            if (files.length > 0) onAddDroppedFiles(files);
-        },
-        [onAddDroppedFiles, preventDefaultDrag],
-    );
-
-    const dropZoneWebProps =
-        Platform.OS === "web"
-            ? ({
-                  onDragEnter: preventDefaultDrag,
-                  onDragOver: preventDefaultDrag,
-                  onDrop: handleDrop,
-              } as Record<string, unknown>)
-            : {};
+    const handleClose = useCallback(() => {
+        if (isSubmitting) return;
+        onClose();
+    }, [isSubmitting, onClose]);
 
     return (
-        <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+        <Modal visible={visible} animationType="fade" transparent onRequestClose={handleClose}>
             <View className="flex-1 justify-center items-center bg-black/70">
                 <View
+                    testID="files-modal-panel"
                     className="bg-app-card overflow-hidden border border-white/10"
                     style={[
                         styles.panel,
@@ -107,9 +82,10 @@ export const FilesModal = ({
                             Загрузить файлы
                         </Text>
                         <Pressable
-                            onPress={onClose}
+                            onPress={handleClose}
+                            disabled={isSubmitting}
                             hitSlop={10}
-                            className="active:opacity-60 p-1"
+                            className={`p-1 ${isSubmitting ? "opacity-40" : "active:opacity-60"}`}
                         >
                             <XIcon size={26} className="text-text-muted" />
                         </Pressable>
@@ -121,26 +97,37 @@ export const FilesModal = ({
                         keyboardShouldPersistTaps="handled"
                     >
                         <Pressable
+                            ref={dropRef}
                             testID="files-modal-drop-zone"
                             onPress={onPickFiles}
-                            className="items-center justify-center active:opacity-90"
-                            style={styles.dropZone}
-                            {...dropZoneWebProps}
+                            disabled={isSubmitting}
+                            className={`items-center justify-center ${isSubmitting ? "opacity-70" : "active:opacity-90"}`}
+                            style={[
+                                styles.dropZone,
+                                isDragging ? styles.dropZoneActive : null,
+                            ]}
                         >
-                            <View className="items-center justify-center mb-6" style={styles.uploadIconTile}>
-                                <UploadSimpleIcon size={38} className="text-text-muted" />
+                            <View className="items-center justify-center mb-4" style={styles.uploadIconTile}>
+                                <UploadSimpleIcon size={26} className="text-text-muted" />
                             </View>
-                            <Text className="text-white text-[23px] font-semibold text-center">
+                            <Text className="text-white text-[18px] font-semibold text-center">
                                 Перетащите файлы сюда
                             </Text>
-                            <Text className="text-text-placeholder text-[18px] mt-2 text-center">
+                            <Text className="text-text-placeholder text-[14px] mt-1 text-center">
                                 или нажмите для выбора файлов
                             </Text>
                         </Pressable>
 
-                        <Text className="text-text-muted text-[18px] font-semibold mt-8 mb-4">
-                            Выбрано файлов: {attachments.length}
-                        </Text>
+                        <View className="flex-row items-center justify-between mt-5 mb-3">
+                            <Text className="text-text-muted text-[15px] font-semibold">
+                                Выбрано файлов: {attachments.length}
+                            </Text>
+                            {isSubmitting ? (
+                                <Text className="text-brand-400 text-[13px] font-medium">
+                                    Загрузка файлов и отправка сообщения...
+                                </Text>
+                            ) : null}
+                        </View>
 
                         <View style={styles.fileList}>
                             {attachments.map((file, index) => {
@@ -157,31 +144,38 @@ export const FilesModal = ({
                                             className="items-center justify-center mr-4"
                                             style={styles.fileIconTile}
                                         >
-                                            <Icon size={24} className="text-brand-400" />
+                                            <Icon size={20} className="text-brand-400" />
                                         </View>
                                         <View className="flex-1 min-w-0">
                                             <Text
-                                                className="text-white text-[18px] font-semibold"
+                                                className="text-white text-[15px] font-semibold"
                                                 numberOfLines={1}
                                             >
                                                 {file.name}
                                             </Text>
-                                            <Text className="text-text-muted text-[15px] mt-1">
+                                            <Text className="text-text-muted text-[13px] mt-0.5">
                                                 {formatFileSize(file.size)}
                                             </Text>
                                         </View>
                                         <Pressable
                                             testID={`files-modal-remove-${index}`}
                                             onPress={() => onRemove(index)}
+                                            disabled={isSubmitting}
                                             hitSlop={10}
-                                            className="active:opacity-60 p-2"
+                                            className={`p-2 ${isSubmitting ? "opacity-35" : "active:opacity-60"}`}
                                         >
-                                            <XIcon size={22} className="text-text-muted" />
+                                            <XIcon size={18} className="text-text-muted" />
                                         </Pressable>
                                     </View>
                                 );
                             })}
                         </View>
+
+                        {submitError ? (
+                            <Text className="text-danger-300 text-[13px] font-medium mt-4">
+                                {submitError}
+                            </Text>
+                        ) : null}
                     </ScrollView>
 
                     <View
@@ -189,10 +183,11 @@ export const FilesModal = ({
                         style={styles.footer}
                     >
                         <Pressable
-                            onPress={onClose}
-                            className="active:opacity-60 px-6 py-3 mr-4"
+                            onPress={handleClose}
+                            disabled={isSubmitting}
+                            className={`px-5 py-2.5 mr-3 ${isSubmitting ? "opacity-40" : "active:opacity-60"}`}
                         >
-                            <Text className="text-text-muted text-[18px] font-semibold">
+                            <Text className="text-text-muted text-[15px] font-semibold">
                                 Отмена
                             </Text>
                         </Pressable>
@@ -200,12 +195,21 @@ export const FilesModal = ({
                             testID="files-modal-submit"
                             onPress={onSubmit}
                             disabled={!canSubmit}
-                            className={`items-center justify-center ${canSubmit ? "bg-brand-650 active:opacity-85" : "bg-brand-650/40"}`}
+                            className={`items-center justify-center ${isSubmitting ? "bg-brand-650/70" : canSubmit ? "bg-brand-650 active:opacity-85" : "bg-brand-650/40"}`}
                             style={styles.submitButton}
                         >
-                            <Text className="text-white text-[18px] font-semibold">
-                                Отправить ({attachments.length})
-                            </Text>
+                            {isSubmitting ? (
+                                <View className="flex-row items-center">
+                                    <ActivityIndicator size="small" className="text-white" />
+                                    <Text className="text-white text-[15px] font-semibold ml-2">
+                                        Отправка...
+                                    </Text>
+                                </View>
+                            ) : (
+                                <Text className="text-white text-[15px] font-semibold">
+                                    Отправить ({attachments.length})
+                                </Text>
+                            )}
                         </Pressable>
                     </View>
                 </View>
@@ -216,8 +220,8 @@ export const FilesModal = ({
 
 const styles = StyleSheet.create({
     panel: {
-        borderRadius: 30,
-        maxHeight: "92%",
+        borderRadius: 22,
+        maxHeight: "80%",
     },
     mobilePanel: {
         borderRadius: 0,
@@ -225,52 +229,56 @@ const styles = StyleSheet.create({
         maxHeight: "100%",
     },
     header: {
-        minHeight: 100,
-        paddingHorizontal: 32,
-        paddingVertical: 22,
+        minHeight: 72,
+        paddingHorizontal: 24,
+        paddingVertical: 18,
     },
     content: {
-        paddingHorizontal: 32,
-        paddingTop: 32,
-        paddingBottom: 32,
+        paddingHorizontal: 24,
+        paddingTop: 20,
+        paddingBottom: 20,
     },
     dropZone: {
-        minHeight: 298,
+        minHeight: 164,
         borderWidth: 2,
         borderColor: "#34415D",
-        borderRadius: 20,
+        borderRadius: 16,
         backgroundColor: "#172033",
     },
+    dropZoneActive: {
+        borderColor: "#51A2FF",
+        backgroundColor: "rgba(43, 127, 255, 0.12)",
+    },
     uploadIconTile: {
-        width: 84,
-        height: 84,
-        borderRadius: 20,
+        width: 54,
+        height: 54,
+        borderRadius: 14,
         backgroundColor: "#283147",
     },
     fileList: {
         gap: 12,
     },
     fileRow: {
-        minHeight: 86,
-        borderRadius: 14,
-        paddingHorizontal: 16,
+        minHeight: 64,
+        borderRadius: 12,
+        paddingHorizontal: 12,
         backgroundColor: "#172033",
     },
     fileIconTile: {
-        width: 52,
-        height: 52,
-        borderRadius: 10,
+        width: 40,
+        height: 40,
+        borderRadius: 8,
         backgroundColor: "#202A40",
     },
     footer: {
-        minHeight: 90,
-        paddingHorizontal: 32,
-        paddingVertical: 16,
+        minHeight: 72,
+        paddingHorizontal: 24,
+        paddingVertical: 12,
         backgroundColor: "#151E31",
     },
     submitButton: {
-        minWidth: 186,
-        height: 56,
-        borderRadius: 14,
+        minWidth: 156,
+        height: 46,
+        borderRadius: 12,
     },
 });

--- a/apps/client/src/features/attach-file/ui/__tests__/FilesModal.test.tsx
+++ b/apps/client/src/features/attach-file/ui/__tests__/FilesModal.test.tsx
@@ -5,8 +5,29 @@ import type { DocumentPickerAsset } from "expo-document-picker";
 
 import { FilesModal } from "../FilesModal";
 
+let mockDropHandler: ((files: File[]) => void) | null = null;
+let mockIsDragging = false;
+
 jest.mock("@/shared/lib/useWindowSize", () => ({
     useWindowSize: () => ({ width: 1024, isDesktop: true, isMobile: false }),
+}));
+
+jest.mock("@/shared/lib/useWebFileDrop", () => ({
+    useWebFileDrop: ({
+        onFiles,
+    }: {
+        onFiles: (files: File[]) => void;
+    }) => {
+        mockDropHandler = onFiles;
+        return { dropRef: jest.fn(), isDragging: mockIsDragging };
+    },
+}));
+
+jest.mock("@/shared/ui/activity-indicator", () => ({
+    ActivityIndicator: () => {
+        const { Text } = require("react-native");
+        return <Text testID="files-modal-submit-spinner">loading</Text>;
+    },
 }));
 
 jest.mock("@/shared/ui/phosphor", () => {
@@ -38,9 +59,14 @@ const attachment: DocumentPickerAsset = {
     lastModified: 1,
 };
 
+const isDisabled = (node: ReturnType<typeof screen.getByTestId>) =>
+    node.props.accessibilityState?.disabled ?? node.props.disabled;
+
 describe("FilesModal", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockDropHandler = null;
+        mockIsDragging = false;
         Object.defineProperty(Platform, "OS", { configurable: true, value: "web" });
     });
 
@@ -55,6 +81,18 @@ describe("FilesModal", () => {
         expect(screen.getByText("185.0 KB")).toBeTruthy();
     });
 
+    it("uses compact desktop dimensions", () => {
+        render(<FilesModal {...baseProps} attachments={[attachment]} />);
+
+        const panel = screen.getByTestId("files-modal-panel");
+        const panelStyle = Array.isArray(panel?.props.style)
+            ? Object.assign({}, ...panel!.props.style)
+            : panel?.props.style;
+
+        expect(panelStyle.width).toBe(660);
+        expect(panelStyle.maxHeight).toBe("80%");
+    });
+
     it("opens the document picker from the drop zone", () => {
         render(<FilesModal {...baseProps} attachments={[]} />);
 
@@ -67,11 +105,7 @@ describe("FilesModal", () => {
         const dropped = { name: "dropped.pdf" } as File;
         render(<FilesModal {...baseProps} attachments={[]} />);
 
-        fireEvent(screen.getByTestId("files-modal-drop-zone"), "drop", {
-            dataTransfer: { files: [dropped] },
-            preventDefault: jest.fn(),
-            stopPropagation: jest.fn(),
-        });
+        mockDropHandler?.([dropped]);
 
         expect(baseProps.onAddDroppedFiles).toHaveBeenCalledWith([dropped]);
     });
@@ -91,7 +125,25 @@ describe("FilesModal", () => {
 
         const submit = screen.getByTestId("files-modal-submit");
 
-        expect(submit.props.accessibilityState?.disabled ?? submit.props.disabled).toBe(true);
+        expect(isDisabled(submit)).toBe(true);
         expect(baseProps.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("blocks controls and shows sending feedback while submitting", () => {
+        render(
+            <FilesModal
+                {...baseProps}
+                attachments={[attachment]}
+                isSubmitting
+                submitError="Не удалось отправить. Попробуйте ещё раз."
+            />,
+        );
+
+        expect(screen.getByText("Загрузка файлов и отправка сообщения...")).toBeTruthy();
+        expect(screen.getByText("Отправка...")).toBeTruthy();
+        expect(screen.getByTestId("files-modal-submit-spinner")).toBeTruthy();
+        expect(screen.getByText("Не удалось отправить. Попробуйте ещё раз.")).toBeTruthy();
+        expect(isDisabled(screen.getByTestId("files-modal-submit"))).toBe(true);
+        expect(isDisabled(screen.getByTestId("files-modal-remove-0"))).toBe(true);
     });
 });

--- a/apps/client/src/shared/lib/__tests__/useWebFileDrop.test.ts
+++ b/apps/client/src/shared/lib/__tests__/useWebFileDrop.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { Platform } from "react-native";
+
+import { useWebFileDrop } from "../useWebFileDrop";
+
+type ListenerMap = Record<string, EventListener>;
+
+const createTarget = () => {
+    const listeners: ListenerMap = {};
+    const target = {
+        addEventListener: jest.fn((event: string, listener: EventListener) => {
+            listeners[event] = listener;
+        }),
+        removeEventListener: jest.fn((event: string, listener: EventListener) => {
+            if (listeners[event] === listener) delete listeners[event];
+        }),
+    };
+
+    return { target, listeners };
+};
+
+const createDragEvent = (files: File[] = []) => ({
+    dataTransfer: {
+        files,
+        types: files.length > 0 ? ["Files"] : [],
+        dropEffect: "none",
+    },
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+}) as unknown as DragEvent & {
+    dataTransfer: DataTransfer & { dropEffect: string };
+    preventDefault: jest.Mock;
+    stopPropagation: jest.Mock;
+};
+
+describe("useWebFileDrop", () => {
+    const originalPlatformOS = Platform.OS;
+
+    beforeEach(() => {
+        Object.defineProperty(Platform, "OS", { configurable: true, value: "web" });
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatformOS });
+    });
+
+    it("attaches DOM drop listeners and forwards files", () => {
+        const onFiles = jest.fn();
+        const onDragStateChange = jest.fn();
+        const { target, listeners } = createTarget();
+        const { result } = renderHook(() =>
+            useWebFileDrop({ enabled: true, onFiles, onDragStateChange }),
+        );
+
+        act(() => {
+            result.current.dropRef(target);
+        });
+
+        expect(target.addEventListener).toHaveBeenCalledWith("dragenter", expect.any(Function));
+        expect(target.addEventListener).toHaveBeenCalledWith("dragover", expect.any(Function));
+        expect(target.addEventListener).toHaveBeenCalledWith("dragleave", expect.any(Function));
+        expect(target.addEventListener).toHaveBeenCalledWith("drop", expect.any(Function));
+
+        const file = { name: "lecture.pdf" } as File;
+        const dragOver = createDragEvent([file]);
+        act(() => {
+            listeners.dragover(dragOver);
+        });
+        expect(dragOver.preventDefault).toHaveBeenCalled();
+        expect(dragOver.stopPropagation).toHaveBeenCalled();
+        expect(dragOver.dataTransfer.dropEffect).toBe("copy");
+
+        const drop = createDragEvent([file]);
+        act(() => {
+            listeners.drop(drop);
+        });
+        expect(onFiles).toHaveBeenCalledWith([file]);
+        expect(result.current.isDragging).toBe(false);
+
+        const dragEnter = createDragEvent([file]);
+        act(() => {
+            listeners.dragenter(dragEnter);
+        });
+        expect(result.current.isDragging).toBe(true);
+        expect(onDragStateChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it("removes DOM listeners on cleanup", () => {
+        const { target } = createTarget();
+        const { result, unmount } = renderHook(() =>
+            useWebFileDrop({ enabled: true, onFiles: jest.fn() }),
+        );
+
+        act(() => {
+            result.current.dropRef(target);
+        });
+
+        unmount();
+
+        expect(target.removeEventListener).toHaveBeenCalledWith("dragenter", expect.any(Function));
+        expect(target.removeEventListener).toHaveBeenCalledWith("dragover", expect.any(Function));
+        expect(target.removeEventListener).toHaveBeenCalledWith("dragleave", expect.any(Function));
+        expect(target.removeEventListener).toHaveBeenCalledWith("drop", expect.any(Function));
+    });
+
+    it("does not attach listeners outside web or when disabled", () => {
+        Object.defineProperty(Platform, "OS", { configurable: true, value: "ios" });
+        const { target } = createTarget();
+        const { result } = renderHook(() =>
+            useWebFileDrop({ enabled: true, onFiles: jest.fn() }),
+        );
+
+        act(() => {
+            result.current.dropRef(target);
+        });
+
+        expect(target.addEventListener).not.toHaveBeenCalled();
+    });
+});

--- a/apps/client/src/shared/lib/useWebFileDrop.ts
+++ b/apps/client/src/shared/lib/useWebFileDrop.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Platform } from "react-native";
+
+type FileDropTarget = {
+    addEventListener: EventTarget["addEventListener"];
+    removeEventListener: EventTarget["removeEventListener"];
+};
+
+type UseWebFileDropOptions = {
+    enabled: boolean;
+    onFiles: (files: File[]) => void;
+    onDragStateChange?: (isDragging: boolean) => void;
+};
+
+const hasFiles = (event: DragEvent) => {
+    const transfer = event.dataTransfer;
+    if (!transfer) return false;
+    if (transfer.files.length > 0) return true;
+    return Array.from(transfer.types ?? []).includes("Files");
+};
+
+const getFiles = (event: DragEvent) =>
+    event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
+
+export const useWebFileDrop = ({
+    enabled,
+    onFiles,
+    onDragStateChange,
+}: UseWebFileDropOptions) => {
+    const [target, setTarget] = useState<FileDropTarget | null>(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const dragDepthRef = useRef(0);
+    const onFilesRef = useRef(onFiles);
+    const onDragStateChangeRef = useRef(onDragStateChange);
+
+    useEffect(() => {
+        onFilesRef.current = onFiles;
+    }, [onFiles]);
+
+    useEffect(() => {
+        onDragStateChangeRef.current = onDragStateChange;
+    }, [onDragStateChange]);
+
+    const setDragging = useCallback((next: boolean) => {
+        setIsDragging(next);
+        onDragStateChangeRef.current?.(next);
+    }, []);
+
+    const dropRef = useCallback((node: unknown) => {
+        setTarget(node as FileDropTarget | null);
+    }, []);
+
+    useEffect(() => {
+        if (Platform.OS !== "web" || !enabled || !target) {
+            dragDepthRef.current = 0;
+            setDragging(false);
+            return;
+        }
+
+        const preventDefault = (event: DragEvent) => {
+            if (!hasFiles(event)) return false;
+            event.preventDefault();
+            event.stopPropagation();
+            if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+            return true;
+        };
+
+        const handleDragEnter: EventListener = (event) => {
+            const dragEvent = event as DragEvent;
+            if (!preventDefault(dragEvent)) return;
+            dragDepthRef.current += 1;
+            setDragging(true);
+        };
+
+        const handleDragOver: EventListener = (event) => {
+            preventDefault(event as DragEvent);
+        };
+
+        const handleDragLeave: EventListener = (event) => {
+            const dragEvent = event as DragEvent;
+            if (!preventDefault(dragEvent)) return;
+            dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+            if (dragDepthRef.current === 0) setDragging(false);
+        };
+
+        const handleDrop: EventListener = (event) => {
+            const dragEvent = event as DragEvent;
+            if (!preventDefault(dragEvent)) return;
+            dragDepthRef.current = 0;
+            setDragging(false);
+
+            const files = getFiles(dragEvent);
+            if (files.length > 0) onFilesRef.current(files);
+        };
+
+        target.addEventListener("dragenter", handleDragEnter);
+        target.addEventListener("dragover", handleDragOver);
+        target.addEventListener("dragleave", handleDragLeave);
+        target.addEventListener("drop", handleDrop);
+
+        return () => {
+            target.removeEventListener("dragenter", handleDragEnter);
+            target.removeEventListener("dragover", handleDragOver);
+            target.removeEventListener("dragleave", handleDragLeave);
+            target.removeEventListener("drop", handleDrop);
+            dragDepthRef.current = 0;
+            setDragging(false);
+        };
+    }, [enabled, setDragging, target]);
+
+    return { dropRef, isDragging };
+};

--- a/apps/client/src/widgets/chat/ui/MessagesList.tsx
+++ b/apps/client/src/widgets/chat/ui/MessagesList.tsx
@@ -31,6 +31,7 @@ import type { MessageDto } from "@urfu-link/api-client";
 import { useCurrentUserId } from "@/shared/store/auth-store";
 import { TypingIndicator } from "@/entities/presence";
 import { formatMessageDateLabel, getMessageDayKey } from "../lib/message-date-labels";
+import { useWebFileDrop } from "@/shared/lib/useWebFileDrop";
 
 interface MessagesListProps {
     chatId: string;
@@ -68,15 +69,6 @@ type MessageListDateItem = {
 };
 
 type MessageListItem = MessageListMessageItem | MessageListDateItem;
-
-type WebDragEvent = {
-    preventDefault?: () => void;
-    stopPropagation?: () => void;
-    dataTransfer?: DataTransfer;
-    nativeEvent?: {
-        dataTransfer?: DataTransfer;
-    };
-};
 
 const buildMessageListItems = (messages: MessageDto[]): MessageListItem[] => {
     const items: MessageListItem[] = [];
@@ -149,6 +141,9 @@ const styles = StyleSheet.create({
     messageAfterMessage: {
         marginTop: 12,
     },
+    fileDropActive: {
+        backgroundColor: "rgba(43, 127, 255, 0.08)",
+    },
 });
 
 export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
@@ -193,6 +188,16 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
 
         const currentUserId = useCurrentUserId();
         const readContextRef = useRef({ chatId, currentUserId, markRead });
+        const handleFilesDropped = useCallback(
+            (files: File[]) => {
+                onFilesDropped?.(files);
+            },
+            [onFilesDropped],
+        );
+        const { dropRef, isDragging: isFileDragging } = useWebFileDrop({
+            enabled: !!onFilesDropped,
+            onFiles: handleFilesDropped,
+        });
 
         useEffect(() => {
             readContextRef.current = { chatId, currentUserId, markRead };
@@ -372,30 +377,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
             loadMore(chatId, type);
         }, [chatId, loadMore, type]);
 
-        const preventDefaultDrag = useCallback((event: WebDragEvent) => {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-        }, []);
-
-        const handleDrop = useCallback(
-            (event: WebDragEvent) => {
-                preventDefaultDrag(event);
-                const transfer = event.nativeEvent?.dataTransfer ?? event.dataTransfer;
-                const files = transfer?.files ? Array.from(transfer.files) : [];
-                if (files.length > 0) onFilesDropped?.(files);
-            },
-            [onFilesDropped, preventDefaultDrag],
-        );
-
-        const dropTargetProps =
-            Platform.OS === "web" && onFilesDropped
-                ? ({
-                      onDragEnter: preventDefaultDrag,
-                      onDragOver: preventDefaultDrag,
-                      onDrop: handleDrop,
-                  } as Record<string, unknown>)
-                : {};
-
         const renderItem = useMemo(
             () =>
                 ({ item, index }: { item: MessageListItem; index: number }) => {
@@ -518,10 +499,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         if (isInitialLoading) {
             return (
                 <View
+                    ref={dropRef}
                     testID="messages-list-drop-target"
                     className="flex-1 px-6 py-6 justify-end overflow-hidden"
-                    style={{ gap: 24 }}
-                    {...dropTargetProps}
+                    style={[{ gap: 24 }, isFileDragging ? styles.fileDropActive : null]}
                 >
                     <ChatMessageSkeleton isOwn={false} showAvatar={shouldShowAvatars} />
                     <ChatMessageSkeleton isOwn={true} />
@@ -535,9 +516,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         if (messages.length === 0) {
             return (
                 <View
+                    ref={dropRef}
                     testID="messages-list-drop-target"
                     className="flex-1 px-6 py-6 justify-end overflow-hidden"
-                    {...dropTargetProps}
+                    style={isFileDragging ? styles.fileDropActive : null}
                 >
                     <EmptyState
                         size="full"
@@ -550,7 +532,12 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
         }
 
         return (
-            <View testID="messages-list-drop-target" className="flex-1" {...dropTargetProps}>
+            <View
+                ref={dropRef}
+                testID="messages-list-drop-target"
+                className="flex-1"
+                style={isFileDragging ? styles.fileDropActive : null}
+            >
                 <FlatList
                     ref={listRef}
                     className="flex-1 px-6 py-6"

--- a/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
+++ b/apps/client/src/widgets/chat/ui/__tests__/MessagesList.test.tsx
@@ -11,6 +11,7 @@ const mockAddReaction = jest.fn();
 const mockRemoveReaction = jest.fn();
 const mockTypingIndicator = jest.fn();
 const originalPlatformOS = Platform.OS;
+let mockDropHandler: ((files: File[]) => void) | null = null;
 
 let mockChatState = {
     messagesByConversation: {},
@@ -109,9 +110,21 @@ jest.mock("@/entities/presence", () => ({
     },
 }));
 
+jest.mock("@/shared/lib/useWebFileDrop", () => ({
+    useWebFileDrop: ({
+        onFiles,
+    }: {
+        onFiles: (files: File[]) => void;
+    }) => {
+        mockDropHandler = onFiles;
+        return { dropRef: jest.fn(), isDragging: false };
+    },
+}));
+
 describe("MessagesList loading state", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockDropHandler = null;
         Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatformOS });
         mockChatState = {
             messagesByConversation: {},
@@ -167,8 +180,6 @@ describe("MessagesList loading state", () => {
         Object.defineProperty(Platform, "OS", { configurable: true, value: "web" });
         const file = { name: "materials.pdf" } as File;
         const onFilesDropped = jest.fn();
-        const preventDefault = jest.fn();
-        const stopPropagation = jest.fn();
 
         render(
             <MessagesList
@@ -178,14 +189,8 @@ describe("MessagesList loading state", () => {
             />,
         );
 
-        fireEvent(screen.getByTestId("messages-list-drop-target"), "drop", {
-            dataTransfer: { files: [file] },
-            preventDefault,
-            stopPropagation,
-        });
+        mockDropHandler?.([file]);
 
-        expect(preventDefault).toHaveBeenCalled();
-        expect(stopPropagation).toHaveBeenCalled();
         expect(onFilesDropped).toHaveBeenCalledWith([file]);
     });
 

--- a/apps/client/src/widgets/chat/ui/chat-input/AttachmentsPreview.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/AttachmentsPreview.tsx
@@ -7,9 +7,10 @@ interface Props {
     attachments: DocumentPicker.DocumentPickerAsset[];
     onRemove: (index: number) => void;
     onOpenModal: () => void;
+    disabled?: boolean;
 }
 
-export const AttachmentsPreview = ({ attachments, onRemove, onOpenModal }: Props) => {
+export const AttachmentsPreview = ({ attachments, onRemove, onOpenModal, disabled = false }: Props) => {
     if (attachments.length === 0) return null;
 
     return (
@@ -21,13 +22,21 @@ export const AttachmentsPreview = ({ attachments, onRemove, onOpenModal }: Props
                         <Text className="text-white text-xs font-medium flex-1" numberOfLines={1}>
                             {file.name}
                         </Text>
-                        <Pressable onPress={() => onRemove(index)} className="p-1 active:opacity-60">
+                        <Pressable
+                            onPress={() => onRemove(index)}
+                            disabled={disabled}
+                            className={`p-1 ${disabled ? "opacity-40" : "active:opacity-60"}`}
+                        >
                             <XIcon size={14} className="text-text-subtle" />
                         </Pressable>
                     </View>
                 ))
             ) : (
-                <Pressable onPress={onOpenModal} className="flex-row items-center bg-white/10 px-4 py-2 rounded-xl gap-2 active:opacity-80">
+                <Pressable
+                    onPress={onOpenModal}
+                    disabled={disabled}
+                    className={`flex-row items-center bg-white/10 px-4 py-2 rounded-xl gap-2 ${disabled ? "opacity-60" : "active:opacity-80"}`}
+                >
                     <FileIcon size={16} className="text-brand-400" />
                     <Text className="text-white text-xs font-medium">
                         Прикреплено {attachments.length} файлов

--- a/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
@@ -27,6 +27,7 @@ import { useParticipantsStore, useConversationParticipants } from "@/entities/co
 import { findMentionAtCursor, MentionSuggestions } from "@/features/mentions";
 import { useCurrentUserId } from "@/shared/store/auth-store";
 import type { ConversationParticipantDto } from "@urfu-link/api-client";
+import { ActivityIndicator } from "@/shared/ui/activity-indicator";
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window");
 const MIN_INPUT_CONTENT_HEIGHT = 24;
@@ -103,6 +104,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     );
     const [isEmojiVisible, setIsEmojiVisible] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
     const [inputHeight, setInputHeight] = useState(MIN_INPUT_CONTENT_HEIGHT);
     const [selectedMentions, setSelectedMentions] = useState<SelectedMention[]>([]);
     // Курсор: позиция точки вставки в тексте. Нужен для детекта @-токена.
@@ -230,6 +232,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         () => ({
             addFilesAndOpenModal: (files: File[]) => {
                 if (files.length === 0 || editing) return;
+                setSubmitError(null);
                 animate(false);
                 addAttachments(files, { openModal: true });
             },
@@ -255,12 +258,13 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             }
 
             setQuery(text);
+            if (submitError) setSubmitError(null);
             setSelectedMentions((prev) =>
                 prev.filter((mention) => text.includes(mentionTextFor(mention.label))),
             );
             if (!editing) notifyTyping(text);
         },
-        [editing, notifyTyping],
+        [editing, notifyTyping, submitError],
     );
 
     const handleInputContentSizeChange = useCallback(
@@ -324,6 +328,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             .filter((mention) => trimmed.includes(mentionTextFor(mention.label)))
             .map((mention) => mention.userId);
 
+        setSubmitError(null);
         setIsSubmitting(true);
         try {
             if (mentionUserIds.length > 0) {
@@ -334,6 +339,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             resetInput();
         } catch (error) {
             console.error("Failed to submit composer", error);
+            setSubmitError("Не удалось отправить. Попробуйте ещё раз.");
         } finally {
             setIsSubmitting(false);
         }
@@ -379,6 +385,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         if (editing) {
             resetComposer();
             setQuery("");
+            setSubmitError(null);
         } else {
             setReply(null);
         }
@@ -411,9 +418,25 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
 
             <AttachmentsPreview
                 attachments={attachments}
-                onRemove={removeAttachment}
+                onRemove={(index) => {
+                    setSubmitError(null);
+                    removeAttachment(index);
+                }}
                 onOpenModal={() => setIsFilesModalVisible(true)}
+                disabled={isSubmitting}
             />
+
+            {submitError ? (
+                <Text className="text-danger-300 text-xs font-medium mb-2 pl-1">
+                    {submitError}
+                </Text>
+            ) : null}
+
+            {isSubmitting ? (
+                <Text className="text-brand-400 text-xs font-medium mb-2 pl-1">
+                    Загрузка файлов и отправка сообщения...
+                </Text>
+            ) : null}
 
             <View className="flex-row items-end gap-3">
                 <Pressable
@@ -421,8 +444,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                         animate(false);
                         setIsFilesModalVisible(true);
                     }}
-                    className={`active:opacity-60 mb-2 ${attachments.length >= MAX_FILES_LIMIT || !!editing ? "opacity-30" : ""}`}
-                    disabled={attachments.length >= MAX_FILES_LIMIT || !!editing}
+                    className={`mb-2 ${attachments.length >= MAX_FILES_LIMIT || !!editing || isSubmitting ? "opacity-30" : "active:opacity-60"}`}
+                    disabled={attachments.length >= MAX_FILES_LIMIT || !!editing || isSubmitting}
                 >
                     <PlusCircleIcon size={28} className="text-text-subtle" />
                 </Pressable>
@@ -437,6 +460,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                         value={query}
                         onChangeText={handleQueryChange}
                         onKeyPress={handleInputKeyPress}
+                        editable={!isSubmitting}
                         selection={pendingSelection ?? undefined}
                         onSelectionChange={(e) => {
                             const next = e.nativeEvent.selection;
@@ -464,13 +488,14 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                     />
                     <Pressable
                         testID="chat-input-emoji-button"
+                        disabled={isSubmitting}
                         onPress={() => {
                             Keyboard.dismiss();
                             const willShow = !isEmojiVisible;
                             setIsEmojiVisible(willShow);
                             animate(willShow);
                         }}
-                        className="py-2.5 ml-2"
+                        className={`py-2.5 ml-2 ${isSubmitting ? "opacity-40" : ""}`}
                         style={{ alignSelf: "flex-end" }}
                     >
                         <SmileyIcon
@@ -482,15 +507,20 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 </View>
 
                 <Pressable
+                    testID="chat-input-send-button"
                     onPress={submitComposer}
                     disabled={!canSend}
-                    className={`w-11 h-11 rounded-full items-center justify-center ${canSend ? "bg-brand-600 active:opacity-80" : "bg-brand-600/30"}`}
+                    className={`w-11 h-11 rounded-full items-center justify-center ${isSubmitting ? "bg-brand-600/70" : canSend ? "bg-brand-600 active:opacity-80" : "bg-brand-600/30"}`}
                 >
-                    <PaperPlaneRightIcon
-                        size={22}
-                        className={canSend ? "text-white" : "text-white/40"}
-                        weight="fill"
-                    />
+                    {isSubmitting ? (
+                        <ActivityIndicator testID="chat-input-send-spinner" size="small" className="text-white" />
+                    ) : (
+                        <PaperPlaneRightIcon
+                            size={22}
+                            className={canSend ? "text-white" : "text-white/40"}
+                            weight="fill"
+                        />
+                    )}
                 </Pressable>
             </View>
 
@@ -508,11 +538,21 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 visible={isFilesModalVisible}
                 onClose={() => setIsFilesModalVisible(false)}
                 attachments={attachments}
-                onPickFiles={handleAttachFiles}
-                onAddDroppedFiles={(files) => addAttachments(files, { openModal: true })}
-                onRemove={removeAttachment}
+                onPickFiles={() => {
+                    setSubmitError(null);
+                    void handleAttachFiles();
+                }}
+                onAddDroppedFiles={(files) => {
+                    setSubmitError(null);
+                    addAttachments(files, { openModal: true });
+                }}
+                onRemove={(index) => {
+                    setSubmitError(null);
+                    removeAttachment(index);
+                }}
                 onSubmit={submitComposer}
                 isSubmitting={isSubmitting}
+                submitError={submitError}
             />
         </View>
     );

--- a/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
@@ -27,6 +27,9 @@ let mockMentionSuggestions = ({
     onSelect: (item: { userId: string; displayName: string }) => void;
 }) => null as ReactElement | null;
 
+const isDisabled = (node: ReturnType<typeof screen.getByTestId>) =>
+    node.props.accessibilityState?.disabled ?? node.props.disabled;
+
 jest.mock("@/entities/conversation/model/chat-store", () => ({
     useChatStore: (selector: (state: { editMessage: jest.Mock }) => unknown) =>
         selector({ editMessage: jest.fn() }),
@@ -44,17 +47,42 @@ jest.mock("@/features/attach-file", () => {
         FilesModal: ({
             onSubmit,
             attachments,
+            isSubmitting,
+            submitError,
+            onPickFiles,
+            onRemove,
         }: {
             onSubmit: () => void;
             attachments: unknown[];
+            isSubmitting?: boolean;
+            submitError?: string | null;
+            onPickFiles?: () => void;
+            onRemove?: (index: number) => void;
         }) => (
-            <Pressable
-                testID="files-modal-submit"
-                onPress={onSubmit}
-                disabled={attachments.length === 0}
-            >
-                <Text>modal submit</Text>
-            </Pressable>
+            <>
+                <Pressable
+                    testID="files-modal-submit"
+                    onPress={onSubmit}
+                    disabled={attachments.length === 0 || isSubmitting}
+                >
+                    <Text>{isSubmitting ? "Отправка..." : "modal submit"}</Text>
+                </Pressable>
+                <Pressable
+                    testID="files-modal-pick"
+                    onPress={onPickFiles}
+                    disabled={isSubmitting}
+                >
+                    <Text>pick</Text>
+                </Pressable>
+                <Pressable
+                    testID="files-modal-remove"
+                    onPress={() => onRemove?.(0)}
+                    disabled={isSubmitting}
+                >
+                    <Text>remove</Text>
+                </Pressable>
+                {submitError ? <Text>{submitError}</Text> : null}
+            </>
         ),
         useAttachments: () => ({
             attachments: mockAttachments,
@@ -70,6 +98,13 @@ jest.mock("@/features/attach-file", () => {
 
 jest.mock("@/features/emoji-picker", () => ({
     EmojiPicker: () => null,
+}));
+
+jest.mock("@/shared/ui/activity-indicator", () => ({
+    ActivityIndicator: ({ testID }: { testID?: string }) => {
+        const { Text } = require("react-native");
+        return <Text testID={testID ?? "activity-indicator"}>loading</Text>;
+    },
 }));
 
 jest.mock("@/features/message-actions", () => ({
@@ -326,5 +361,72 @@ describe("ChatInput", () => {
 
         expect(onSend).toHaveBeenCalledWith("materials", [attachment], undefined);
         expect(mockClearAttachments).toHaveBeenCalled();
+    });
+
+    it("blocks composer controls and shows progress while sending", async () => {
+        const attachment: DocumentPickerAsset = {
+            name: "lecture.pdf",
+            uri: "file://lecture.pdf",
+            size: 2048,
+            mimeType: "application/pdf",
+            lastModified: 1,
+        };
+        mockAttachments = [attachment];
+        let resolveSend!: () => void;
+        const onSend = jest.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveSend = resolve;
+                }),
+        );
+
+        render(<ChatInput conversationId="conversation-1" onSend={onSend} />);
+        fireEvent.changeText(screen.getByTestId("chat-input-text"), "materials");
+
+        await act(async () => {
+            fireEvent.press(screen.getByTestId("chat-input-send-button"));
+        });
+
+        expect(onSend).toHaveBeenCalledWith("materials", [attachment], undefined);
+        expect(screen.getByTestId("chat-input-send-spinner")).toBeTruthy();
+        expect(screen.getByText("Загрузка файлов и отправка сообщения...")).toBeTruthy();
+        expect(screen.getByTestId("chat-input-text").props.editable).toBe(false);
+        expect(isDisabled(screen.getByTestId("files-modal-submit"))).toBe(true);
+        expect(isDisabled(screen.getByTestId("files-modal-pick"))).toBe(true);
+        expect(isDisabled(screen.getByTestId("files-modal-remove"))).toBe(true);
+
+        await act(async () => {
+            resolveSend();
+        });
+
+        expect(mockClearAttachments).toHaveBeenCalled();
+    });
+
+    it("keeps text and attachments visible after a send failure", async () => {
+        const attachment: DocumentPickerAsset = {
+            name: "lecture.pdf",
+            uri: "file://lecture.pdf",
+            size: 2048,
+            mimeType: "application/pdf",
+            lastModified: 1,
+        };
+        mockAttachments = [attachment];
+        const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const onSend = jest.fn(async () => {
+            throw new Error("network");
+        });
+
+        render(<ChatInput conversationId="conversation-1" onSend={onSend} />);
+        fireEvent.changeText(screen.getByTestId("chat-input-text"), "materials");
+
+        await act(async () => {
+            fireEvent.press(screen.getByTestId("chat-input-send-button"));
+        });
+
+        expect(screen.getByTestId("chat-input-text").props.value).toBe("materials");
+        expect(screen.getByText("lecture.pdf")).toBeTruthy();
+        expect(mockClearAttachments).not.toHaveBeenCalled();
+        expect(screen.getAllByText("Не удалось отправить. Попробуйте ещё раз.").length).toBeGreaterThan(0);
+        consoleErrorSpy.mockRestore();
     });
 });


### PR DESCRIPTION
## Summary
- promote latest develop into master
- includes compact file upload modal, working web drag/drop for modal and messages area, and sending spinner/error UX

## Scope
- frontend client only
- expected prod follow-up: master push triggers Frontend Web Image and automated frontend-web prod promotion

## Validation already run on source PR
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test --runTestsByPath src/shared/lib/__tests__/useWebFileDrop.test.ts src/features/attach-file/ui/__tests__/FilesModal.test.tsx src/features/attach-file/lib/__tests__/useAttachments.test.ts src/widgets/chat/ui/chat-input/__tests__/input.test.tsx src/widgets/chat/ui/__tests__/MessagesList.test.tsx
- pnpm --filter @urfu-link/client web:local; entry bundle returned 200