### PR TITLE
Remove duplicate chat input upload status

### DIFF
--- a/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/Input.tsx
@@ -432,12 +432,6 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 </Text>
             ) : null}
 
-            {isSubmitting ? (
-                <Text className="text-brand-400 text-xs font-medium mb-2 pl-1">
-                    Загрузка файлов и отправка сообщения...
-                </Text>
-            ) : null}
-
             <View className="flex-row items-end gap-3">
                 <Pressable
                     onPress={() => {

--- a/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-input/__tests__/input.test.tsx
@@ -389,7 +389,6 @@ describe("ChatInput", () => {
 
         expect(onSend).toHaveBeenCalledWith("materials", [attachment], undefined);
         expect(screen.getByTestId("chat-input-send-spinner")).toBeTruthy();
-        expect(screen.getByText("Загрузка файлов и отправка сообщения...")).toBeTruthy();
         expect(screen.getByTestId("chat-input-text").props.editable).toBe(false);
         expect(isDisabled(screen.getByTestId("files-modal-submit"))).toBe(true);
         expect(isDisabled(screen.getByTestId("files-modal-pick"))).toBe(true);


### PR DESCRIPTION
## Summary
- removed the duplicate submitting status above the chat input
- kept the file upload status inside the files modal
- updated the chat input test expectation

## Tests
- pnpm --dir apps/client test -- chat-input/__tests__/input.test.tsx --runInBand
- pnpm --dir apps/client test -- attach-file/ui/__tests__/FilesModal.test.tsx --runInBand