### PR TITLE
Implement web chat notifications and mute controls

### DIFF
--- a/apps/client/app/(authorized)/_layout.tsx
+++ b/apps/client/app/(authorized)/_layout.tsx
@@ -12,6 +12,7 @@ import { useChatHub } from "@/shared/lib/useChatHub";
 import { useNotificationHub } from "@/features/notifications";
 import { useCurrentUser } from "@/entities/user";
 import { configureMessageSounds } from "@/shared/lib/message-sounds";
+import { configureBrowserNotifications } from "@/shared/lib/browser-notifications";
 
 export default function AuthLayout() {
     const segments = useSegments() as string[];
@@ -34,6 +35,7 @@ export default function AuthLayout() {
 
     useEffect(() => {
         configureMessageSounds(profile?.notifications);
+        configureBrowserNotifications(profile?.notifications);
     }, [profile?.notifications]);
 
     useEffect(() => {

--- a/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
+++ b/apps/client/src/entities/conversation/model/__tests__/chat-store.test.ts
@@ -2,6 +2,7 @@ import { mapMessageToProps, useChatStore } from "../chat-store";
 import { createHubConnection } from "@/shared/lib/signalr";
 import { apiClient } from "@/shared/lib/api";
 import { playMessageSound } from "@/shared/lib/message-sounds";
+import { showMessageBrowserNotification } from "@/shared/lib/browser-notifications";
 
 const mockAuthState: { userId: string | null; setUserId: jest.Mock } = {
     userId: "user-1",
@@ -41,6 +42,10 @@ jest.mock("@/shared/lib/signalr", () => ({
 
 jest.mock("@/shared/lib/message-sounds", () => ({
     playMessageSound: jest.fn(),
+}));
+
+jest.mock("@/shared/lib/browser-notifications", () => ({
+    showMessageBrowserNotification: jest.fn(),
 }));
 
 jest.mock("@/shared/store/auth-store", () => ({
@@ -96,6 +101,7 @@ describe("chat store direct draft sending", () => {
                 notificationSound: true,
                 disciplineChatMessages: true,
                 mentions: true,
+                mutedConversationIds: [],
             },
             soundVideo: {
                 playbackDeviceId: null,
@@ -456,6 +462,14 @@ describe("chat store direct draft sending", () => {
             conversationId: "direct-1",
             isDiscipline: false,
         });
+        expect(showMessageBrowserNotification).toHaveBeenCalledTimes(1);
+        expect(showMessageBrowserNotification).toHaveBeenCalledWith(
+            expect.objectContaining({ id: "message-2" }),
+            expect.objectContaining({
+                currentUserId: "user-1",
+                isDiscipline: false,
+            }),
+        );
     });
 
     it("does not play the receive sound for own realtime messages", async () => {
@@ -487,6 +501,7 @@ describe("chat store direct draft sending", () => {
         });
 
         expect(playMessageSound).not.toHaveBeenCalled();
+        expect(showMessageBrowserNotification).not.toHaveBeenCalled();
     });
 
     it("keeps media asset ids in mapped message attachments", () => {

--- a/apps/client/src/entities/conversation/model/chat-store.ts
+++ b/apps/client/src/entities/conversation/model/chat-store.ts
@@ -10,7 +10,9 @@ import { HubConnection, HubConnectionState } from "@microsoft/signalr";
 import { apiClient } from "@/shared/lib/api";
 import { resolveCurrentUserId } from "@/shared/lib/current-user";
 import { playMessageSound } from "@/shared/lib/message-sounds";
+import { showMessageBrowserNotification } from "@/shared/lib/browser-notifications";
 import { useAuthStore } from "@/shared/store/auth-store";
+import { lookupParticipantName } from "./participants-store";
 import {
     isDirectDraftConversation,
     normalizeConversationDraftStatus,
@@ -429,11 +431,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 const conversation = state.conversations.find(
                     (c) => c.id === normalized.conversationId,
                 );
+                const isDiscipline =
+                    conversation?.groupSubtype === "Discipline" ||
+                    normalized.conversationId.startsWith("discipline:");
                 void playMessageSound("receive", {
                     conversationId: normalized.conversationId,
-                    isDiscipline:
-                        conversation?.groupSubtype === "Discipline" ||
-                        normalized.conversationId.startsWith("discipline:"),
+                    isDiscipline,
+                });
+                showMessageBrowserNotification(normalized, {
+                    currentUserId,
+                    title:
+                        lookupParticipantName(normalized.conversationId, normalized.senderId) ??
+                        conversation?.title ??
+                        "Новое сообщение",
+                    isDiscipline,
                 });
             }
         });

--- a/apps/client/src/entities/user/index.ts
+++ b/apps/client/src/entities/user/index.ts
@@ -6,6 +6,8 @@ export {
   useDeleteAvatar,
   useUpdatePrivacy,
   useUpdateNotifications,
+  useMuteConversationNotifications,
+  useUnmuteConversationNotifications,
   useUpdateSoundVideo,
   useTerminateDevice,
   useTerminateAllDevices,

--- a/apps/client/src/entities/user/model/mutations.ts
+++ b/apps/client/src/entities/user/model/mutations.ts
@@ -5,6 +5,7 @@ import type {
   UpdateNotificationsDto,
   UpdatePrivacyDto,
   UpdateSoundVideoDto,
+  UserProfile,
 } from "@urfu-link/api-client";
 import { userKeys } from "./queries";
 
@@ -51,6 +52,53 @@ export function useUpdateNotifications() {
     mutationFn: (dto: UpdateNotificationsDto) =>
       apiClient.users.updateNotifications(dto),
     onSuccess: invalidateMe,
+  });
+}
+
+const updateMutedConversationCache = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  conversationId: string,
+  muted: boolean,
+) => {
+  queryClient.setQueryData<UserProfile>(userKeys.me, (current) => {
+    if (!current) return current;
+
+    const existing = current.notifications.mutedConversationIds ?? [];
+    const nextMuted = muted
+      ? Array.from(new Set([...existing, conversationId]))
+      : existing.filter((id) => id !== conversationId);
+
+    return {
+      ...current,
+      notifications: {
+        ...current.notifications,
+        mutedConversationIds: nextMuted,
+      },
+    };
+  });
+};
+
+export function useMuteConversationNotifications() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (conversationId: string) =>
+      apiClient.users.muteConversationNotifications(conversationId),
+    onSuccess: (_data, conversationId) => {
+      updateMutedConversationCache(queryClient, conversationId, true);
+      queryClient.invalidateQueries({ queryKey: userKeys.me });
+    },
+  });
+}
+
+export function useUnmuteConversationNotifications() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (conversationId: string) =>
+      apiClient.users.unmuteConversationNotifications(conversationId),
+    onSuccess: (_data, conversationId) => {
+      updateMutedConversationCache(queryClient, conversationId, false);
+      queryClient.invalidateQueries({ queryKey: userKeys.me });
+    },
   });
 }
 

--- a/apps/client/src/features/manage-notifications/config/settings.ts
+++ b/apps/client/src/features/manage-notifications/config/settings.ts
@@ -1,12 +1,7 @@
 export const NOTIFICATIONS_SETTINGS = {
-  directMessages: {
-    label: "Личные чаты",
+  general: {
+    label: "Общие",
     items: [
-      {
-        key: "newMessages",
-        label: "Новые сообщения",
-        description: "Уведомления о новых личных сообщениях",
-      },
       {
         key: "notificationSound",
         label: "Звук уведомлений",
@@ -32,5 +27,5 @@ export const NOTIFICATIONS_SETTINGS = {
 } as const;
 
 export type NotificationField =
-  | (typeof NOTIFICATIONS_SETTINGS.directMessages.items)[number]["key"]
+  | (typeof NOTIFICATIONS_SETTINGS.general.items)[number]["key"]
   | (typeof NOTIFICATIONS_SETTINGS.subjects.items)[number]["key"];

--- a/apps/client/src/features/manage-notifications/ui/ManageNotifications.tsx
+++ b/apps/client/src/features/manage-notifications/ui/ManageNotifications.tsx
@@ -1,11 +1,25 @@
 import { useCurrentUser, useUpdateNotifications } from "@/entities/user";
 import { Skeleton, SwitchCard, SwitchCardSkeleton } from "@/shared/ui";
-import { ScrollView, Text, View } from "react-native";
+import { Platform, ScrollView, Text, View } from "react-native";
+import { useEffect, useState } from "react";
+import {
+  getBrowserNotificationPermission,
+  requestBrowserNotificationPermission,
+} from "@/shared/lib/browser-notifications";
 import { NOTIFICATIONS_SETTINGS, type NotificationField } from "../config/settings";
 
 export const ManageNotifications = () => {
   const { data: profile, isLoading } = useCurrentUser();
   const updateNotifications = useUpdateNotifications();
+  const [browserPermission, setBrowserPermission] = useState<
+    NotificationPermission | "unsupported"
+  >("unsupported");
+  const [isPermissionRequesting, setIsPermissionRequesting] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "web") return;
+    setBrowserPermission(getBrowserNotificationPermission());
+  }, []);
 
   if (isLoading) {
     return (
@@ -29,15 +43,39 @@ export const ManageNotifications = () => {
   const handleToggle = (field: NotificationField) => (newValue: boolean) => {
     if (!notifications) return;
     updateNotifications.mutate({
-      newMessages: field === "newMessages" ? newValue : notifications.newMessages,
+      newMessages: notifications.newMessages,
       notificationSound: field === "notificationSound" ? newValue : notifications.notificationSound,
       disciplineChatMessages: field === "disciplineChatMessages" ? newValue : notifications.disciplineChatMessages,
       mentions: field === "mentions" ? newValue : notifications.mentions,
     });
   };
 
+  const handleBrowserPermissionRequest = async () => {
+    if (browserPermission !== "default") return;
+    setIsPermissionRequesting(true);
+    try {
+      setBrowserPermission(await requestBrowserNotificationPermission());
+    } finally {
+      setIsPermissionRequesting(false);
+    }
+  };
+
   return (
     <ScrollView contentContainerClassName="gap-4" showsVerticalScrollIndicator={false}>
+      {Platform.OS === "web" && browserPermission === "default" && (
+        <View className="gap-3">
+          <Text className="text-text-placeholder text-xs font-semibold uppercase">
+            Браузер
+          </Text>
+          <SwitchCard
+            label="Браузерные уведомления"
+            description="Показывать уведомления, когда вкладка не активна"
+            value={false}
+            onValueChange={handleBrowserPermissionRequest}
+            disabled={isPermissionRequesting}
+          />
+        </View>
+      )}
       {Object.values(NOTIFICATIONS_SETTINGS).map((section, sectionIndex) => (
         <View key={sectionIndex} className="gap-3">
           <Text className="text-text-placeholder text-xs font-semibold uppercase">

--- a/apps/client/src/features/manage-notifications/ui/__tests__/ManageNotifications.test.tsx
+++ b/apps/client/src/features/manage-notifications/ui/__tests__/ManageNotifications.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react-native";
+import { ManageNotifications } from "../ManageNotifications";
+
+const mockMutate = jest.fn();
+
+jest.mock("@/entities/user", () => ({
+    useCurrentUser: () => ({
+        data: {
+            notifications: {
+                newMessages: false,
+                notificationSound: true,
+                disciplineChatMessages: true,
+                mentions: true,
+                mutedConversationIds: [],
+            },
+        },
+        isLoading: false,
+    }),
+    useUpdateNotifications: () => ({
+        mutate: mockMutate,
+        isPending: false,
+    }),
+}));
+
+jest.mock("@/shared/lib/browser-notifications", () => ({
+    getBrowserNotificationPermission: () => "unsupported",
+    requestBrowserNotificationPermission: jest.fn(),
+}));
+
+jest.mock("@/shared/ui", () => {
+    const { Text, View, Pressable } = require("react-native");
+    return {
+        Skeleton: ({ testID }: { testID?: string }) => <View testID={testID} />,
+        SwitchCardSkeleton: () => <View testID="switch-card-skeleton" />,
+        SwitchCard: ({
+            label,
+            description,
+            value,
+            onValueChange,
+            disabled,
+        }: {
+            label: string;
+            description: string;
+            value: boolean;
+            onValueChange: (value: boolean) => void;
+            disabled?: boolean;
+        }) => (
+            <Pressable disabled={disabled} onPress={() => onValueChange(!value)}>
+                <Text>{label}</Text>
+                <Text>{description}</Text>
+            </Pressable>
+        ),
+    };
+});
+
+describe("ManageNotifications", () => {
+    beforeEach(() => {
+        mockMutate.mockClear();
+    });
+
+    it("does not render the removed direct message toggle", () => {
+        render(<ManageNotifications />);
+
+        expect(screen.queryByText("Новые сообщения")).toBeNull();
+        expect(screen.getByText("Звук уведомлений")).toBeTruthy();
+        expect(screen.getByText("Сообщения в чатах дисциплин")).toBeTruthy();
+        expect(screen.getByText("Упоминания")).toBeTruthy();
+    });
+});

--- a/apps/client/src/features/notifications/model/use-notification-hub.ts
+++ b/apps/client/src/features/notifications/model/use-notification-hub.ts
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { NotificationBadgeDto, NotificationDto } from "@urfu-link/api-client";
 import { createHubConnection } from "@/shared/lib/signalr";
 import { useNotificationStore } from "@/shared/store/notification-store";
+import { showServerBrowserNotification } from "@/shared/lib/browser-notifications";
 import { notificationKeys } from "./queries";
 
 export function useNotificationHub() {
@@ -24,11 +25,13 @@ export function useNotificationHub() {
             queryClient.setQueryData(notificationKeys.badge(), badge);
         });
 
-        connection.on("NotificationReceived", (_notification: NotificationDto) => {
+        connection.on("NotificationReceived", (notification: NotificationDto) => {
+            showServerBrowserNotification(notification);
             invalidateNotifications();
         });
 
-        connection.on("NotificationUpserted", (_notification: NotificationDto) => {
+        connection.on("NotificationUpserted", (notification: NotificationDto) => {
+            showServerBrowserNotification(notification);
             invalidateNotifications();
         });
 

--- a/apps/client/src/shared/lib/__tests__/browser-notifications.test.ts
+++ b/apps/client/src/shared/lib/__tests__/browser-notifications.test.ts
@@ -1,0 +1,271 @@
+import {
+    configureBrowserNotifications,
+    getBrowserNotificationPermission,
+    requestBrowserNotificationPermission,
+    resetBrowserNotificationsForTests,
+    setBrowserNotificationNavigationForTests,
+    showMessageBrowserNotification,
+    showServerBrowserNotification,
+} from "../browser-notifications";
+import type { NotificationDto } from "@urfu-link/api-client";
+
+type MockNotificationInstance = {
+    title: string;
+    options: NotificationOptions;
+    onclick: (() => void) | null;
+    close: jest.Mock;
+};
+
+const instances: MockNotificationInstance[] = [];
+
+class MockNotification {
+    static permission: NotificationPermission = "granted";
+    static requestPermission = jest.fn(async () => {
+        MockNotification.permission = "granted";
+        return MockNotification.permission;
+    });
+
+    onclick: (() => void) | null = null;
+    close = jest.fn();
+
+    constructor(public title: string, public options: NotificationOptions) {
+        instances.push(this);
+    }
+}
+
+const getTestDocument = () => globalThis.document as Document;
+const getTestWindow = () => globalThis.window as Window & typeof globalThis;
+
+const setPageState = (visibilityState: DocumentVisibilityState, focused: boolean) => {
+    Object.defineProperty(getTestDocument(), "visibilityState", {
+        configurable: true,
+        value: visibilityState,
+    });
+    Object.defineProperty(getTestDocument(), "hasFocus", {
+        configurable: true,
+        value: jest.fn(() => focused),
+    });
+};
+
+describe("browser notifications", () => {
+    beforeEach(() => {
+        instances.length = 0;
+        MockNotification.permission = "granted";
+        MockNotification.requestPermission.mockClear();
+        Object.defineProperty(globalThis, "document", {
+            configurable: true,
+            value: {},
+        });
+        Object.defineProperty(globalThis, "window", {
+            configurable: true,
+            value: {
+                location: { assign: jest.fn() },
+                focus: jest.fn(),
+            },
+        });
+        Object.defineProperty(getTestWindow(), "Notification", {
+            configurable: true,
+            value: MockNotification,
+        });
+        setPageState("hidden", false);
+        resetBrowserNotificationsForTests();
+    });
+
+    it("reports and requests browser permission", async () => {
+        MockNotification.permission = "default";
+
+        expect(getBrowserNotificationPermission()).toBe("default");
+        await expect(requestBrowserNotificationPermission()).resolves.toBe("granted");
+        expect(MockNotification.requestPermission).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show messages while the page is active", () => {
+        setPageState("visible", true);
+
+        const shown = showMessageBrowserNotification({
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "peer-1",
+            body: "hello",
+            attachments: [],
+            state: "Sent",
+            createdAt: "2026-05-24T10:03:00.000Z",
+            deliveredAt: null,
+            readAt: null,
+        });
+
+        expect(shown).toBe(false);
+        expect(instances).toHaveLength(0);
+    });
+
+    it("shows hidden-tab message notifications and routes clicks", () => {
+        const navigate = jest.fn();
+        setBrowserNotificationNavigationForTests(navigate);
+
+        const shown = showMessageBrowserNotification(
+            {
+                id: "message-1",
+                conversationId: "direct-1",
+                senderId: "peer-1",
+                body: "hello",
+                attachments: [],
+                state: "Sent",
+                createdAt: "2026-05-24T10:03:00.000Z",
+                deliveredAt: null,
+                readAt: null,
+            },
+            { currentUserId: "user-1", title: "Peer" },
+        );
+
+        expect(shown).toBe(true);
+        expect(instances).toHaveLength(1);
+        expect(instances[0].title).toBe("Peer");
+        expect(instances[0].options.body).toBe("hello");
+
+        instances[0].onclick?.();
+
+        expect(getTestWindow().focus).toHaveBeenCalled();
+        expect(navigate).toHaveBeenCalledWith("/chats/direct-1?message=message-1");
+        expect(instances[0].close).toHaveBeenCalled();
+    });
+
+    it("deduplicates and skips own or muted message notifications", () => {
+        configureBrowserNotifications({
+            newMessages: true,
+            notificationSound: true,
+            disciplineChatMessages: true,
+            mentions: true,
+            mutedConversationIds: ["muted-1"],
+        });
+
+        const message = {
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "peer-1",
+            body: "hello",
+            attachments: [],
+            state: "Sent" as const,
+            createdAt: "2026-05-24T10:03:00.000Z",
+            deliveredAt: null,
+            readAt: null,
+        };
+
+        expect(showMessageBrowserNotification(message, { currentUserId: "user-1" })).toBe(true);
+        expect(showMessageBrowserNotification(message, { currentUserId: "user-1" })).toBe(false);
+        expect(
+            showMessageBrowserNotification(
+                { ...message, id: "own-1", senderId: "user-1" },
+                { currentUserId: "user-1" },
+            ),
+        ).toBe(false);
+        expect(
+            showMessageBrowserNotification(
+                { ...message, id: "muted-message", conversationId: "muted-1" },
+                { currentUserId: "user-1" },
+            ),
+        ).toBe(false);
+
+        expect(instances).toHaveLength(1);
+    });
+
+    it("shows server notifications with deep-link routing and mute checks", () => {
+        configureBrowserNotifications({
+            newMessages: true,
+            notificationSound: true,
+            disciplineChatMessages: true,
+            mentions: true,
+            mutedConversationIds: ["muted-1"],
+        });
+
+        const baseNotification: NotificationDto = {
+            id: "notification-1",
+            recipientUserId: "user-1",
+            type: "chat.mention",
+            category: 2,
+            severity: 2,
+            title: "Вас упомянули",
+            body: "Вас упомянули в чате",
+            imageUrl: null,
+            deepLink: "urfulink://chat/conv/direct-1/msg/aaaaaaaa111122223333bbbbbbbbbbbb",
+            data: {
+                conversationId: "direct-1",
+                messageId: "aaaaaaaa111122223333bbbbbbbbbbbb",
+            },
+            actor: null,
+            entity: null,
+            actions: [],
+            groupKey: null,
+            occurrenceCount: 1,
+            createdAtUtc: "2026-05-24T10:03:00.000Z",
+            lastOccurrenceAtUtc: "2026-05-24T10:03:00.000Z",
+            readAtUtc: null,
+            seenAtUtc: null,
+            savedAtUtc: null,
+            doneAtUtc: null,
+            archivedAtUtc: null,
+            snoozedUntilUtc: null,
+            expiresAtUtc: null,
+        };
+
+        expect(showServerBrowserNotification(baseNotification)).toBe(true);
+        expect(
+            showServerBrowserNotification({
+                ...baseNotification,
+                id: "notification-2",
+                data: { conversationId: "muted-1", messageId: "message-2" },
+            }),
+        ).toBe(false);
+
+        expect(instances).toHaveLength(1);
+        expect(instances[0].options.tag).toContain("notification:notification-1");
+    });
+
+    it("deduplicates chat and server notifications for the same message", () => {
+        const message = {
+            id: "message-1",
+            conversationId: "direct-1",
+            senderId: "peer-1",
+            body: "hello",
+            attachments: [],
+            state: "Sent" as const,
+            createdAt: "2026-05-24T10:03:00.000Z",
+            deliveredAt: null,
+            readAt: null,
+        };
+
+        const notification: NotificationDto = {
+            id: "notification-1",
+            recipientUserId: "user-1",
+            type: "chat.mention",
+            category: 2,
+            severity: 2,
+            title: "Вас упомянули",
+            body: "hello",
+            imageUrl: null,
+            deepLink: "urfulink://chat/conv/direct-1/msg/message-1",
+            data: {
+                conversationId: "direct-1",
+                messageId: "message-1",
+            },
+            actor: null,
+            entity: null,
+            actions: [],
+            groupKey: null,
+            occurrenceCount: 1,
+            createdAtUtc: "2026-05-24T10:03:00.000Z",
+            lastOccurrenceAtUtc: "2026-05-24T10:03:00.000Z",
+            readAtUtc: null,
+            seenAtUtc: null,
+            savedAtUtc: null,
+            doneAtUtc: null,
+            archivedAtUtc: null,
+            snoozedUntilUtc: null,
+            expiresAtUtc: null,
+        };
+
+        expect(showMessageBrowserNotification(message, { currentUserId: "user-1" })).toBe(true);
+        expect(showServerBrowserNotification(notification)).toBe(false);
+        expect(showServerBrowserNotification({ ...notification, id: "notification-2" })).toBe(false);
+        expect(instances).toHaveLength(1);
+    });
+});

--- a/apps/client/src/shared/lib/__tests__/message-sounds.test.ts
+++ b/apps/client/src/shared/lib/__tests__/message-sounds.test.ts
@@ -63,6 +63,7 @@ describe("message sounds", () => {
             notificationSound: false,
             disciplineChatMessages: true,
             mentions: true,
+            mutedConversationIds: [],
         });
 
         await expect(playMessageSound("send")).resolves.toBe(false);
@@ -73,19 +74,42 @@ describe("message sounds", () => {
         expect(createAudioPlayer).not.toHaveBeenCalled();
     });
 
-    it("respects direct and discipline message notification preferences", async () => {
+    it("keeps direct receive sounds independent from the hidden direct-message toggle", async () => {
         configureMessageSounds({
             newMessages: false,
             notificationSound: true,
             disciplineChatMessages: true,
             mentions: true,
+            mutedConversationIds: [],
         });
 
         await expect(
             playMessageSound("receive", { conversationId: "direct-1", now: 1000 }),
-        ).resolves.toBe(false);
+        ).resolves.toBe(true);
+        await expect(
+            playMessageSound("receive", { conversationId: "discipline:math", now: 1400 }),
+        ).resolves.toBe(true);
+
+        expect(createAudioPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    it("respects discipline and muted conversation preferences", async () => {
+        configureMessageSounds({
+            newMessages: true,
+            notificationSound: true,
+            disciplineChatMessages: false,
+            mentions: true,
+            mutedConversationIds: ["direct-muted"],
+        });
+
         await expect(
             playMessageSound("receive", { conversationId: "discipline:math", now: 1000 }),
+        ).resolves.toBe(false);
+        await expect(
+            playMessageSound("receive", { conversationId: "direct-muted", now: 1000 }),
+        ).resolves.toBe(false);
+        await expect(
+            playMessageSound("receive", { conversationId: "direct-1", now: 1000 }),
         ).resolves.toBe(true);
 
         expect(createAudioPlayer).toHaveBeenCalledTimes(1);

--- a/apps/client/src/shared/lib/browser-notifications.ts
+++ b/apps/client/src/shared/lib/browser-notifications.ts
@@ -1,0 +1,155 @@
+import type { MessageDto, NotificationDto, UserNotifications } from "@urfu-link/api-client";
+import { inferNotificationScope, resolveNotificationDeepLink } from "./notificationDeepLink";
+
+type BrowserNotificationInput = {
+    key: string;
+    dedupeKeys?: string[];
+    title: string;
+    body: string;
+    href?: string | null;
+    conversationId?: string | null;
+};
+
+const DEFAULT_PREFERENCES: Pick<UserNotifications, "mutedConversationIds"> = {
+    mutedConversationIds: [],
+};
+
+let preferences = DEFAULT_PREFERENCES;
+const shownKeys = new Set<string>();
+let navigateToHref = (href: string) => window.location.assign(href);
+
+const isSupported = () =>
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    "Notification" in window;
+
+const isPageActive = () =>
+    typeof document !== "undefined" &&
+    document.visibilityState === "visible" &&
+    (typeof document.hasFocus !== "function" || document.hasFocus());
+
+const isMuted = (conversationId?: string | null) =>
+    !!conversationId && preferences.mutedConversationIds.includes(conversationId);
+
+const getNotificationCtor = () =>
+    isSupported() ? (window as unknown as { Notification: typeof Notification }).Notification : null;
+
+const buildConversationHref = (
+    conversationId: string,
+    messageId: string | null | undefined,
+    isDiscipline: boolean,
+) => {
+    const tab = isDiscipline || conversationId.startsWith("discipline:") ? "subjects" : "chats";
+    const path = `/${tab}/${encodeURIComponent(conversationId)}`;
+    return messageId ? `${path}?message=${encodeURIComponent(messageId)}` : path;
+};
+
+const buildConversationMessageKey = (
+    conversationId?: string | null,
+    messageId?: string | null,
+) => conversationId && messageId ? `message:${conversationId}:${messageId}` : null;
+
+const showBrowserNotification = (input: BrowserNotificationInput): boolean => {
+    const NotificationCtor = getNotificationCtor();
+    if (!NotificationCtor || NotificationCtor.permission !== "granted") return false;
+    if (isPageActive()) return false;
+    if (isMuted(input.conversationId)) return false;
+
+    const dedupeKeys = [
+        input.key,
+        ...(input.dedupeKeys ?? []),
+    ].filter((key, index, keys): key is string => !!key && keys.indexOf(key) === index);
+
+    if (dedupeKeys.some((key) => shownKeys.has(key))) return false;
+    dedupeKeys.forEach((key) => shownKeys.add(key));
+
+    const notification = new NotificationCtor(input.title, {
+        body: input.body,
+        icon: "/favicon.png",
+        tag: input.key,
+    });
+
+    notification.onclick = () => {
+        notification.close();
+        window.focus?.();
+        if (input.href) {
+            navigateToHref(input.href);
+        }
+    };
+
+    return true;
+};
+
+export const configureBrowserNotifications = (
+    nextPreferences: UserNotifications | null | undefined,
+) => {
+    preferences = {
+        mutedConversationIds: nextPreferences?.mutedConversationIds ?? [],
+    };
+};
+
+export const getBrowserNotificationPermission = (): NotificationPermission | "unsupported" => {
+    const NotificationCtor = getNotificationCtor();
+    return NotificationCtor?.permission ?? "unsupported";
+};
+
+export const requestBrowserNotificationPermission = async (): Promise<
+    NotificationPermission | "unsupported"
+> => {
+    const NotificationCtor = getNotificationCtor();
+    if (!NotificationCtor) return "unsupported";
+    if (NotificationCtor.permission !== "default") return NotificationCtor.permission;
+    return NotificationCtor.requestPermission();
+};
+
+export const showMessageBrowserNotification = (
+    message: MessageDto,
+    context: {
+        currentUserId?: string | null;
+        title?: string | null;
+        isDiscipline?: boolean;
+    } = {},
+) => {
+    if (context.currentUserId && message.senderId === context.currentUserId) return false;
+
+    return showBrowserNotification({
+        key: buildConversationMessageKey(message.conversationId, message.id) ?? `message:${message.id}`,
+        title: context.title || "Новое сообщение",
+        body: message.body || (message.attachments.length > 0 ? "Вложение" : "Новое сообщение"),
+        href: buildConversationHref(
+            message.conversationId,
+            message.id,
+            context.isDiscipline ?? false,
+        ),
+        conversationId: message.conversationId,
+    });
+};
+
+export const showServerBrowserNotification = (notification: NotificationDto) => {
+    const scope = inferNotificationScope(notification);
+    const target = resolveNotificationDeepLink(notification.deepLink, scope);
+    const conversationId = notification.data.conversationId;
+    const messageId = notification.data.messageId;
+    const conversationMessageKey = buildConversationMessageKey(conversationId, messageId);
+
+    return showBrowserNotification({
+        key: `notification:${notification.id}`,
+        dedupeKeys: conversationMessageKey ? [conversationMessageKey] : [],
+        title: notification.title,
+        body: notification.body,
+        href: typeof target?.href === "string" ? target.href : null,
+        conversationId,
+    });
+};
+
+export const resetBrowserNotificationsForTests = () => {
+    preferences = DEFAULT_PREFERENCES;
+    shownKeys.clear();
+    navigateToHref = (href: string) => window.location.assign(href);
+};
+
+export const setBrowserNotificationNavigationForTests = (
+    navigate: ((href: string) => void) | null,
+) => {
+    navigateToHref = navigate ?? ((href: string) => window.location.assign(href));
+};

--- a/apps/client/src/shared/lib/message-sounds.ts
+++ b/apps/client/src/shared/lib/message-sounds.ts
@@ -19,6 +19,7 @@ const DEFAULT_PREFERENCES: UserNotifications = {
     notificationSound: true,
     disciplineChatMessages: true,
     mentions: true,
+    mutedConversationIds: [],
 };
 
 let preferences: UserNotifications = DEFAULT_PREFERENCES;
@@ -44,6 +45,9 @@ const getSoundSource = (kind: SoundKind) =>
 const isDisciplineConversation = (context?: MessageSoundContext) =>
     context?.isDiscipline ?? context?.conversationId?.startsWith("discipline:") ?? false;
 
+const isMutedConversation = (conversationId?: string | null) =>
+    !!conversationId && preferences.mutedConversationIds.includes(conversationId);
+
 const configureAudioMode = async (audio: AudioRuntime) => {
     if (audioModeConfigured) return;
 
@@ -61,10 +65,10 @@ const shouldPlaySound = (kind: SoundKind, context?: MessageSoundContext) => {
     if (!preferences.notificationSound) return false;
 
     if (kind === "send") return true;
+    if (isMutedConversation(context?.conversationId)) return false;
 
     const isDiscipline = isDisciplineConversation(context);
     if (isDiscipline && !preferences.disciplineChatMessages) return false;
-    if (!isDiscipline && !preferences.newMessages) return false;
 
     const now = context?.now ?? Date.now();
     if (now - lastReceivePlayedAt < RECEIVE_THROTTLE_MS) return false;
@@ -86,8 +90,10 @@ const getPlayer = async (kind: SoundKind) => {
 };
 
 export const configureMessageSounds = (nextPreferences: UserNotifications | null | undefined) => {
-    if (!nextPreferences) return;
-    preferences = nextPreferences;
+    preferences = {
+        ...(nextPreferences ?? DEFAULT_PREFERENCES),
+        mutedConversationIds: nextPreferences?.mutedConversationIds ?? [],
+    };
 };
 
 export const playMessageSound = async (

--- a/apps/client/src/shared/ui/Menu.tsx
+++ b/apps/client/src/shared/ui/Menu.tsx
@@ -12,6 +12,7 @@ export interface MenuItem {
     label?: string;
     command?: () => void;
     danger?: boolean;
+    disabled?: boolean;
 }
 interface MenuProps {
     model: MenuItem[];
@@ -29,10 +30,11 @@ export const Menu = forwardRef<MenuRef, MenuProps>(({ model }, ref) => {
             if (item.separator) {
                 return (<View key={index} className="h-[1px] bg-white/5 my-1 mx-2"/>);
             }
-            return (<Pressable key={index} className="px-4 py-[11px] flex-row gap-3 items-center hover:bg-white/5 active:bg-white/10 transition-colors duration-200" onPress={() => {
-                    if (item.command)
+            return (<Pressable key={index} disabled={item.disabled} className={`px-4 py-[11px] flex-row gap-3 items-center hover:bg-white/5 active:bg-white/10 transition-colors duration-200 ${item.disabled ? "opacity-50" : ""}`} onPress={() => {
+                    if (!item.disabled && item.command)
                         item.command();
-                    setIsVisible(false);
+                    if (!item.disabled)
+                        setIsVisible(false);
                 }}>
                 {item.icon && (<item.icon className={item.iconClassName} size={item.iconSize ?? 18}/>)}
                 {item.label && (<Text className={`text-sm leading-none select-none ${item.danger ? "text-danger-300" : "text-text-secondary"}`}>

--- a/apps/client/src/widgets/chat/config/__tests__/headerActions.test.ts
+++ b/apps/client/src/widgets/chat/config/__tests__/headerActions.test.ts
@@ -9,6 +9,8 @@ describe("chat header action menus", () => {
             getChatHeaderActions({
                 onOpenProfile: jest.fn(),
                 onOpenPinned: jest.fn(),
+                onToggleNotifications: jest.fn(),
+                notificationsMuted: false,
             }),
         );
 
@@ -27,6 +29,8 @@ describe("chat header action menus", () => {
             getSubjectHeaderActions({
                 onOpenMembers: jest.fn(),
                 onOpenPinned: jest.fn(),
+                onToggleNotifications: jest.fn(),
+                notificationsMuted: false,
             }) as ReturnType<typeof getChatHeaderActions>,
         );
 
@@ -39,10 +43,26 @@ describe("chat header action menus", () => {
         const item = getChatHeaderActions({
             onOpenProfile: jest.fn(),
             onOpenPinned,
+            onToggleNotifications: jest.fn(),
+            notificationsMuted: false,
         }).find((action) => action.label === "Закрепленные");
 
         item?.command?.();
 
         expect(onOpenPinned).toHaveBeenCalled();
+    });
+
+    it("wires notification toggle and reflects muted state", () => {
+        const onToggleNotifications = jest.fn();
+        const item = getChatHeaderActions({
+            onOpenProfile: jest.fn(),
+            onOpenPinned: jest.fn(),
+            onToggleNotifications,
+            notificationsMuted: true,
+        }).find((action) => action.label === "Включить уведомления");
+
+        item?.command?.();
+
+        expect(onToggleNotifications).toHaveBeenCalled();
     });
 });

--- a/apps/client/src/widgets/chat/config/headerActions.ts
+++ b/apps/client/src/widgets/chat/config/headerActions.ts
@@ -1,8 +1,11 @@
-import { BellSlashIcon, PushPinIcon, UserCircleIcon } from "@/shared/ui/phosphor";
+import { BellIcon, BellSlashIcon, PushPinIcon, UserCircleIcon } from "@/shared/ui/phosphor";
 
 export const getChatHeaderActions = (callbacks: {
     onOpenProfile: () => void;
     onOpenPinned?: () => void;
+    onToggleNotifications: () => void;
+    notificationsMuted: boolean;
+    notificationsPending?: boolean;
 }) => [
     {
         icon: UserCircleIcon,
@@ -18,16 +21,20 @@ export const getChatHeaderActions = (callbacks: {
     },
     { separator: true },
     {
-        icon: BellSlashIcon,
+        icon: callbacks.notificationsMuted ? BellIcon : BellSlashIcon,
         iconClassName: "text-text-muted",
-        label: "Отключить уведомления",
-        command: () => console.log("Уведомления..."),
+        label: callbacks.notificationsMuted ? "Включить уведомления" : "Отключить уведомления",
+        command: callbacks.onToggleNotifications,
+        disabled: callbacks.notificationsPending,
     },
 ];
 
 export const getSubjectHeaderActions = (callbacks: {
     onOpenMembers: () => void;
     onOpenPinned?: () => void;
+    onToggleNotifications: () => void;
+    notificationsMuted: boolean;
+    notificationsPending?: boolean;
 }) => [
     {
         icon: UserCircleIcon,
@@ -43,9 +50,10 @@ export const getSubjectHeaderActions = (callbacks: {
     },
     { separator: true },
     {
-        icon: BellSlashIcon,
+        icon: callbacks.notificationsMuted ? BellIcon : BellSlashIcon,
         iconClassName: "text-text-muted",
-        label: "Отключить уведомления",
-        command: () => console.log("Уведомления..."),
+        label: callbacks.notificationsMuted ? "Включить уведомления" : "Отключить уведомления",
+        command: callbacks.onToggleNotifications,
+        disabled: callbacks.notificationsPending,
     },
 ];

--- a/apps/client/src/widgets/chat/ui/chat-header/ChatHeader.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-header/ChatHeader.tsx
@@ -4,6 +4,11 @@ import { Avatar, Skeleton, StatusIndicator } from "@/shared/ui";
 import { useChatStore } from "@/entities/conversation/model/chat-store";
 import { useConversationParticipants } from "@/entities/conversation/model/participants-store";
 import { useCurrentUserId } from "@/shared/store/auth-store";
+import {
+    useCurrentUser,
+    useMuteConversationNotifications,
+    useUnmuteConversationNotifications,
+} from "@/entities/user";
 import { CaretLeftIcon } from "@/shared/ui/phosphor";
 import React, { useMemo, useState } from "react";
 import { Pressable, Text, View } from "react-native";
@@ -43,6 +48,13 @@ export const ChatHeader = ({ chatId, onOpenSearch, onOpenPinned }: ChatHeaderPro
 
     const participants = useConversationParticipants(chatId);
     const currentUserId = useCurrentUserId();
+    const { data: profile } = useCurrentUser();
+    const muteNotifications = useMuteConversationNotifications();
+    const unmuteNotifications = useUnmuteConversationNotifications();
+    const notificationsMuted =
+        profile?.notifications.mutedConversationIds?.includes(chatId) ?? false;
+    const notificationsPending =
+        muteNotifications.isPending || unmuteNotifications.isPending;
 
     // Для direct-чата peerUserId — тот, кто не равен currentUserId.
     // Заголовок и аватар берём из participants (lookup-кэш TTL 5 мин,
@@ -203,6 +215,15 @@ export const ChatHeader = ({ chatId, onOpenSearch, onOpenPinned }: ChatHeaderPro
                     onOpenProfile={() => setIsProfileOpen(true)}
                     onOpenPinned={() => onOpenPinned?.()}
                     onSearchPress={() => onOpenSearch?.()}
+                    notificationsMuted={notificationsMuted}
+                    notificationsPending={notificationsPending}
+                    onToggleNotifications={() => {
+                        if (notificationsMuted) {
+                            unmuteNotifications.mutate(chatId);
+                        } else {
+                            muteNotifications.mutate(chatId);
+                        }
+                    }}
                 />
             </View>
 

--- a/apps/client/src/widgets/chat/ui/chat-header/ChatHeaderActions.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-header/ChatHeaderActions.tsx
@@ -8,9 +8,19 @@ interface ChatHeaderActionsProps {
     onOpenProfile: () => void;
     onOpenPinned: () => void;
     onSearchPress: () => void;
+    notificationsMuted: boolean;
+    notificationsPending?: boolean;
+    onToggleNotifications: () => void;
 }
 
-export const ChatHeaderActions = ({ onOpenProfile, onOpenPinned, onSearchPress }: ChatHeaderActionsProps) => {
+export const ChatHeaderActions = ({
+    onOpenProfile,
+    onOpenPinned,
+    onSearchPress,
+    notificationsMuted,
+    notificationsPending,
+    onToggleNotifications,
+}: ChatHeaderActionsProps) => {
     const menuRef = useRef<MenuRef>(null);
     const menuItems = getChatHeaderActions({
         onOpenProfile: () => {
@@ -21,6 +31,12 @@ export const ChatHeaderActions = ({ onOpenProfile, onOpenPinned, onSearchPress }
             menuRef.current?.close();
             onOpenPinned();
         },
+        onToggleNotifications: () => {
+            menuRef.current?.close();
+            onToggleNotifications();
+        },
+        notificationsMuted,
+        notificationsPending,
     });
     return (
         <View className="flex-row gap-1 items-center">

--- a/apps/client/src/widgets/chat/ui/chat-header/__tests__/ChatHeader.test.tsx
+++ b/apps/client/src/widgets/chat/ui/chat-header/__tests__/ChatHeader.test.tsx
@@ -66,6 +66,12 @@ jest.mock("@/shared/store/auth-store", () => ({
     useCurrentUserId: () => mockCurrentUserId,
 }));
 
+jest.mock("@/entities/user", () => ({
+    useCurrentUser: () => ({ data: { notifications: { mutedConversationIds: [] } } }),
+    useMuteConversationNotifications: () => ({ mutate: jest.fn(), isPending: false }),
+    useUnmuteConversationNotifications: () => ({ mutate: jest.fn(), isPending: false }),
+}));
+
 jest.mock("@/entities/presence", () => ({
     LastSeenLabel: ({ lastSeenAt }: { lastSeenAt: string }) => {
         const { Text } = require("react-native");

--- a/apps/client/src/widgets/chat/ui/subject-header/SubjectHeader.tsx
+++ b/apps/client/src/widgets/chat/ui/subject-header/SubjectHeader.tsx
@@ -2,6 +2,11 @@ import { safeGoBack } from "@/shared/lib/safeGoBack";
 import { useWindowSize } from "@/shared/lib/useWindowSize";
 import { Avatar } from "@/shared/ui";
 import { useChatStore } from "@/entities/conversation/model/chat-store";
+import {
+    useCurrentUser,
+    useMuteConversationNotifications,
+    useUnmuteConversationNotifications,
+} from "@/entities/user";
 import { CaretLeftIcon } from "@/shared/ui/phosphor";
 import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
@@ -23,6 +28,13 @@ export const SubjectHeader = ({ subjectId, onOpenPinned }: {
     const conversation = useChatStore((s) =>
         s.conversations.find((c) => c.id === subjectId),
     );
+    const { data: profile } = useCurrentUser();
+    const muteNotifications = useMuteConversationNotifications();
+    const unmuteNotifications = useUnmuteConversationNotifications();
+    const notificationsMuted =
+        profile?.notifications.mutedConversationIds?.includes(subjectId) ?? false;
+    const notificationsPending =
+        muteNotifications.isPending || unmuteNotifications.isPending;
     if (!conversation) return null;
     const subjectName = conversation.title ?? "Чат предмета";
     const subjectAvatarUrl = "";
@@ -54,6 +66,15 @@ export const SubjectHeader = ({ subjectId, onOpenPinned }: {
         <SubjectHeaderActions
           onOpenMembers={() => setIsMembersOpen(true)}
           onOpenPinned={() => onOpenPinned?.()}
+          notificationsMuted={notificationsMuted}
+          notificationsPending={notificationsPending}
+          onToggleNotifications={() => {
+            if (notificationsMuted) {
+              unmuteNotifications.mutate(subjectId);
+            } else {
+              muteNotifications.mutate(subjectId);
+            }
+          }}
         />
       </View>
 

--- a/apps/client/src/widgets/chat/ui/subject-header/SubjectHeaderActions.tsx
+++ b/apps/client/src/widgets/chat/ui/subject-header/SubjectHeaderActions.tsx
@@ -6,8 +6,17 @@ import { getSubjectHeaderActions } from "../../config/headerActions";
 interface SubjectHeaderActionsProps {
     onOpenMembers: () => void;
     onOpenPinned: () => void;
+    notificationsMuted: boolean;
+    notificationsPending?: boolean;
+    onToggleNotifications: () => void;
 }
-export const SubjectHeaderActions = ({ onOpenMembers, onOpenPinned }: SubjectHeaderActionsProps) => {
+export const SubjectHeaderActions = ({
+    onOpenMembers,
+    onOpenPinned,
+    notificationsMuted,
+    notificationsPending,
+    onToggleNotifications,
+}: SubjectHeaderActionsProps) => {
     const menuRef = useRef<MenuRef>(null);
     const menuItems = getSubjectHeaderActions({
         onOpenMembers: () => {
@@ -18,6 +27,12 @@ export const SubjectHeaderActions = ({ onOpenMembers, onOpenPinned }: SubjectHea
             menuRef.current?.close();
             onOpenPinned();
         },
+        onToggleNotifications: () => {
+            menuRef.current?.close();
+            onToggleNotifications();
+        },
+        notificationsMuted,
+        notificationsPending,
     });
     return (<View className="flex-row gap-1 items-center">
       <Pressable className="p-2 rounded-xl active:bg-white/10">

--- a/packages/api-client/src/__tests__/createApiClient.test.ts
+++ b/packages/api-client/src/__tests__/createApiClient.test.ts
@@ -225,6 +225,27 @@ describe("createApiClient", () => {
     });
   });
 
+  describe("users notification muting", () => {
+    it("mutes and unmutes one conversation", async () => {
+      const fetchSpy = mockFetchWith({ status: 204, ok: true });
+
+      const client = createApiClient({ baseUrl: "" });
+      await client.users.muteConversationNotifications("direct:1");
+      await client.users.unmuteConversationNotifications("direct:1");
+
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        1,
+        "/api/users/me/notifications/muted-conversations/direct%3A1",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        "/api/users/me/notifications/muted-conversations/direct%3A1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+  });
+
   describe("media", () => {
     it("does not send JSON content type for bodyless download-url requests", async () => {
       const fetchSpy = mockFetchWith({

--- a/packages/api-client/src/users.ts
+++ b/packages/api-client/src/users.ts
@@ -19,6 +19,7 @@ export type UserNotifications = {
   notificationSound: boolean;
   disciplineChatMessages: boolean;
   mentions: boolean;
+  mutedConversationIds: string[];
 };
 
 export type UserSoundVideo = {
@@ -126,6 +127,20 @@ export function createUsersApi(
         method: "PUT",
         body: JSON.stringify(dto),
       });
+    },
+
+    muteConversationNotifications(conversationId: string): Promise<void> {
+      return request<void>(
+        `/api/users/me/notifications/muted-conversations/${encodeURIComponent(conversationId)}`,
+        { method: "POST" }
+      );
+    },
+
+    unmuteConversationNotifications(conversationId: string): Promise<void> {
+      return request<void>(
+        `/api/users/me/notifications/muted-conversations/${encodeURIComponent(conversationId)}`,
+        { method: "DELETE" }
+      );
     },
 
     updateSoundVideo(dto: UpdateSoundVideoDto): Promise<void> {

--- a/src/BuildingBlocks/Contracts/Integration/User/NotificationPreferencesPayload.cs
+++ b/src/BuildingBlocks/Contracts/Integration/User/NotificationPreferencesPayload.cs
@@ -4,7 +4,8 @@ public sealed record NotificationPreferencesPayload(
     IReadOnlyDictionary<int, ChannelTogglePayload> Categories,
     QuietHoursPayload QuietHours,
     bool DndEnabled,
-    string Locale);
+    string Locale,
+    IReadOnlyList<string>? MutedConversationIds = null);
 
 public sealed record ChannelTogglePayload(bool Push, bool Email, bool InApp);
 

--- a/src/Services/Notification/NotificationService.Api/Application/Preferences/UserPreferences.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Preferences/UserPreferences.cs
@@ -8,17 +8,23 @@ public sealed record UserPreferences(
     QuietHours QuietHours,
     bool DndEnabled,
     string Locale,
-    bool Sound)
+    bool Sound,
+    IReadOnlyList<string> MutedConversationIds)
 {
     public ChannelToggle GetToggle(NotificationCategory category)
         => Categories.TryGetValue(category, out var toggle) ? toggle : ChannelToggle.AllOn;
+
+    public bool IsConversationMuted(string? conversationId)
+        => !string.IsNullOrWhiteSpace(conversationId) &&
+           MutedConversationIds.Any(id => string.Equals(id, conversationId, StringComparison.Ordinal));
 
     public static UserPreferences Default { get; } = new(
         BuildDefault(),
         QuietHours.Disabled("Asia/Yekaterinburg"),
         DndEnabled: false,
         Locale: "ru-RU",
-        Sound: true);
+        Sound: true,
+        MutedConversationIds: Array.Empty<string>());
 
     private static Dictionary<NotificationCategory, ChannelToggle> BuildDefault()
     {

--- a/src/Services/Notification/NotificationService.Api/Application/Routing/NotificationRouter.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Routing/NotificationRouter.cs
@@ -75,6 +75,21 @@ public sealed class NotificationRouter(
             var intent = await ResolveActorAsync(preparedIntent, cancellationToken).ConfigureAwait(false);
 
             var preferences = await preferencesClient.GetAsync(intent.RecipientUserId, cancellationToken).ConfigureAwait(false);
+            var conversationId = TryGetConversationId(intent);
+            if (preferences.IsConversationMuted(conversationId))
+            {
+                skipped++;
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug(
+                        "Skipping notification {SourceActionId} for recipient {RecipientId}; conversation {ConversationId} is muted",
+                        intent.SourceActionId,
+                        intent.RecipientUserId,
+                        conversationId);
+                }
+
+                continue;
+            }
 
             var candidates = SeverityRouter.Select(intent.Severity);
             var channels = PreferenceFilter.Filter(candidates, intent.Category, intent.Severity, preferences, timeProvider.GetUtcNow());
@@ -205,6 +220,11 @@ public sealed class NotificationRouter(
             Actor = actor with { DisplayName = displayName },
         };
     }
+
+    private static string? TryGetConversationId(NotificationIntent intent)
+        => intent.Data.Values.TryGetValue("conversationId", out var conversationId)
+            ? conversationId
+            : null;
 }
 
 public sealed record RoutingOutcome(int Created, int Updated, int Skipped)

--- a/src/Services/Notification/NotificationService.Api/Endpoints/UpdatePreferencesEndpoint.cs
+++ b/src/Services/Notification/NotificationService.Api/Endpoints/UpdatePreferencesEndpoint.cs
@@ -12,7 +12,8 @@ public sealed record UpdatePreferencesRequest(
     QuietHoursResponse QuietHours,
     bool DndEnabled,
     string Locale,
-    bool Sound);
+    bool Sound,
+    IReadOnlyList<string>? MutedConversationIds = null);
 
 public sealed class UpdatePreferencesEndpoint(IUserPreferencesClient client)
     : Endpoint<UpdatePreferencesRequest>
@@ -43,7 +44,14 @@ public sealed class UpdatePreferencesEndpoint(IUserPreferencesClient client)
             quietHours,
             req.DndEnabled,
             string.IsNullOrWhiteSpace(req.Locale) ? "ru-RU" : req.Locale,
-            req.Sound);
+            req.Sound,
+            req.MutedConversationIds is null
+                ? Array.Empty<string>()
+                : req.MutedConversationIds
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Select(id => id.Trim())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray());
 
         await client.UpdateAsync(userId, preferences, ct).ConfigureAwait(false);
         client.Invalidate(userId);

--- a/src/Services/Notification/NotificationService.Api/Infrastructure/Grpc/UserServiceClient.cs
+++ b/src/Services/Notification/NotificationService.Api/Infrastructure/Grpc/UserServiceClient.cs
@@ -122,7 +122,12 @@ public sealed class UserServiceClient(
             quietHours,
             payload.DndEnabled,
             string.IsNullOrWhiteSpace(payload.Locale) ? "ru-RU" : payload.Locale,
-            payload.Sound);
+            payload.Sound,
+            payload.MutedConversationIds
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray());
     }
 
     private static NotificationPreferencesPayload MapToGrpc(UserPreferences preferences)
@@ -158,6 +163,8 @@ public sealed class UserServiceClient(
                 },
             });
         }
+
+        payload.MutedConversationIds.AddRange(preferences.MutedConversationIds);
 
         return payload;
     }

--- a/src/Services/Notification/NotificationService.Api/Protos/External/user_internal.proto
+++ b/src/Services/Notification/NotificationService.Api/Protos/External/user_internal.proto
@@ -44,6 +44,7 @@ message NotificationPreferencesPayload {
   bool dnd_enabled = 3;
   string locale = 4;
   bool sound = 5;
+  repeated string muted_conversation_ids = 6;
 }
 
 message GetNotificationPreferencesRequest {

--- a/src/Services/User/UserService.Api.Contracts/Protos/internal.proto
+++ b/src/Services/User/UserService.Api.Contracts/Protos/internal.proto
@@ -45,6 +45,7 @@ message NotificationPreferencesPayload {
   bool dnd_enabled = 3;
   string locale = 4;
   bool sound = 5;
+  repeated string muted_conversation_ids = 6;
 }
 
 message GetNotificationPreferencesRequest {

--- a/src/Services/User/UserService.Api/Application/Contracts/Requests/UpdateNotificationPreferencesRequest.cs
+++ b/src/Services/User/UserService.Api/Application/Contracts/Requests/UpdateNotificationPreferencesRequest.cs
@@ -5,7 +5,8 @@ public sealed record UpdateNotificationPreferencesRequest(
     QuietHoursRequest QuietHours,
     bool DndEnabled,
     string Locale,
-    bool Sound);
+    bool Sound,
+    IReadOnlyList<string>? MutedConversationIds = null);
 
 public sealed record ChannelToggleRequest(bool Push, bool Email, bool InApp);
 

--- a/src/Services/User/UserService.Api/Application/Contracts/Responses/UserProfileResponse.cs
+++ b/src/Services/User/UserService.Api/Application/Contracts/Responses/UserProfileResponse.cs
@@ -19,14 +19,16 @@ public sealed record NotificationsResponse(
     bool NewMessages,
     bool NotificationSound,
     bool DisciplineChatMessages,
-    bool Mentions);
+    bool Mentions,
+    IReadOnlyList<string> MutedConversationIds);
 
 public sealed record NotificationPreferencesResponse(
     IReadOnlyDictionary<int, ChannelToggleResponse> Categories,
     QuietHoursResponse QuietHours,
     bool DndEnabled,
     string Locale,
-    bool Sound);
+    bool Sound,
+    IReadOnlyList<string> MutedConversationIds);
 
 public sealed record ChannelToggleResponse(bool Push, bool Email, bool InApp);
 

--- a/src/Services/User/UserService.Api/Domain/User.cs
+++ b/src/Services/User/UserService.Api/Domain/User.cs
@@ -71,7 +71,25 @@ public sealed class UserProfile
         bool disciplineChatMessages,
         bool mentions)
     {
-        Notifications = NotificationSettings.FromLegacy(newMessages, notificationSound, disciplineChatMessages, mentions);
+        Notifications = Notifications.WithLegacyToggles(
+            newMessages,
+            notificationSound,
+            disciplineChatMessages,
+            mentions);
+        Touch();
+        _domainEvents.Add(BuildSettingsChangedEvent());
+    }
+
+    public void MuteConversationNotifications(string conversationId)
+    {
+        Notifications = Notifications.WithMutedConversation(conversationId);
+        Touch();
+        _domainEvents.Add(BuildSettingsChangedEvent());
+    }
+
+    public void UnmuteConversationNotifications(string conversationId)
+    {
+        Notifications = Notifications.WithoutMutedConversation(conversationId);
         Touch();
         _domainEvents.Add(BuildSettingsChangedEvent());
     }
@@ -111,7 +129,8 @@ public sealed class UserProfile
             categories,
             quietHours,
             Notifications.DndEnabled,
-            Notifications.Locale);
+            Notifications.Locale,
+            Notifications.MutedConversationIds);
 
         return new UserNotificationSettingsChangedEvent(Id, preferences);
     }

--- a/src/Services/User/UserService.Api/Domain/ValueObjects/NotificationSettings.cs
+++ b/src/Services/User/UserService.Api/Domain/ValueObjects/NotificationSettings.cs
@@ -5,7 +5,8 @@ public sealed record NotificationSettings(
     QuietHours QuietHours,
     bool DndEnabled,
     string Locale,
-    bool Sound)
+    bool Sound,
+    IReadOnlyList<string> MutedConversationIds)
 {
     public const string DefaultLocale = "ru-RU";
 
@@ -14,7 +15,8 @@ public sealed record NotificationSettings(
         QuietHours.Default,
         DndEnabled: false,
         Locale: DefaultLocale,
-        Sound: true);
+        Sound: true,
+        MutedConversationIds: Array.Empty<string>());
 
     public ChannelToggle GetToggle(int category)
         => Categories.TryGetValue(category, out var toggle) ? toggle : ChannelToggle.AllOn;
@@ -42,21 +44,58 @@ public sealed record NotificationSettings(
 
     public NotificationSettings WithSound(bool enabled) => this with { Sound = enabled };
 
-    public static NotificationSettings FromLegacy(
+    public NotificationSettings WithMutedConversation(string conversationId)
+    {
+        var normalized = NormalizeConversationId(conversationId);
+        if (IsConversationMuted(normalized))
+        {
+            return this;
+        }
+
+        return this with { MutedConversationIds = MutedConversationIds.Append(normalized).ToArray() };
+    }
+
+    public NotificationSettings WithoutMutedConversation(string conversationId)
+    {
+        var normalized = NormalizeConversationId(conversationId);
+        if (!IsConversationMuted(normalized))
+        {
+            return this;
+        }
+
+        return this with
+        {
+            MutedConversationIds = MutedConversationIds
+                .Where(id => !string.Equals(id, normalized, StringComparison.Ordinal))
+                .ToArray(),
+        };
+    }
+
+    public bool IsConversationMuted(string conversationId)
+        => MutedConversationIds.Any(id => string.Equals(id, conversationId, StringComparison.Ordinal));
+
+    public NotificationSettings WithLegacyToggles(
         bool newMessages,
         bool sound,
         bool disciplineChatMessages,
         bool mentions)
     {
-        var copy = new Dictionary<int, ChannelToggle>(BuildDefaultCategories())
+        var copy = new Dictionary<int, ChannelToggle>(Categories)
         {
             [NotificationCategoryCode.ChatMessageDirect] = newMessages ? ChannelToggle.AllOn : ChannelToggle.AllOff,
             [NotificationCategoryCode.ChatMessageDiscipline] = disciplineChatMessages ? ChannelToggle.AllOn : ChannelToggle.AllOff,
             [NotificationCategoryCode.ChatMessageMention] = mentions ? ChannelToggle.AllOn : ChannelToggle.AllOff,
         };
 
-        return new NotificationSettings(copy, QuietHours.Default, DndEnabled: false, DefaultLocale, sound);
+        return this with { Categories = copy, Sound = sound };
     }
+
+    public static NotificationSettings FromLegacy(
+        bool newMessages,
+        bool sound,
+        bool disciplineChatMessages,
+        bool mentions)
+        => Default.WithLegacyToggles(newMessages, sound, disciplineChatMessages, mentions);
 
     private static Dictionary<int, ChannelToggle> BuildDefaultCategories()
     {
@@ -67,5 +106,11 @@ public sealed record NotificationSettings(
         }
 
         return dict;
+    }
+
+    private static string NormalizeConversationId(string conversationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        return conversationId.Trim();
     }
 }

--- a/src/Services/User/UserService.Api/Endpoints/GetMyProfileEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/GetMyProfileEndpoint.cs
@@ -63,13 +63,15 @@ public sealed class GetMyProfileEndpoint(IUserRepository userRepository)
                 NewMessages: legacyDirect.Push || legacyDirect.InApp,
                 NotificationSound: prefs.Sound,
                 DisciplineChatMessages: legacyDiscipline.Push || legacyDiscipline.InApp,
-                Mentions: legacyMentions.Push || legacyMentions.InApp),
+                Mentions: legacyMentions.Push || legacyMentions.InApp,
+                MutedConversationIds: prefs.MutedConversationIds),
             Preferences: new NotificationPreferencesResponse(
                 categories,
                 quietHours,
                 prefs.DndEnabled,
                 prefs.Locale,
-                prefs.Sound),
+                prefs.Sound,
+                prefs.MutedConversationIds),
             SoundVideo: new SoundVideoResponse(
                 user.SoundVideo.PlaybackDeviceId,
                 user.SoundVideo.RecordingDeviceId,

--- a/src/Services/User/UserService.Api/Endpoints/MutedConversationNotificationsEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/MutedConversationNotificationsEndpoint.cs
@@ -1,0 +1,72 @@
+using FastEndpoints;
+using UserService.Api.Domain;
+using UserService.Api.Domain.Interfaces;
+using UserService.Api.Infrastructure.Auth;
+
+namespace UserService.Api.Endpoints;
+
+public sealed class MuteConversationNotificationsEndpoint(IUserRepository userRepository)
+    : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Post("/me/notifications/muted-conversations/{conversationId}");
+        Summary(s => s.Summary = "Disable notifications for one conversation");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var conversationId = Route<string>("conversationId")!;
+        if (string.IsNullOrWhiteSpace(conversationId))
+        {
+            AddError("conversationId", "Conversation id is required.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var userId = HttpContext.User.GetUserId();
+        var user = await userRepository.GetByIdAsync(userId, ct).ConfigureAwait(false);
+        if (user is null)
+        {
+            user = UserProfile.CreateDefault(userId);
+            userRepository.Add(user);
+        }
+
+        user.MuteConversationNotifications(conversationId);
+        await userRepository.SaveChangesAsync(ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}
+
+public sealed class UnmuteConversationNotificationsEndpoint(IUserRepository userRepository)
+    : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Delete("/me/notifications/muted-conversations/{conversationId}");
+        Summary(s => s.Summary = "Enable notifications for one conversation");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var conversationId = Route<string>("conversationId")!;
+        if (string.IsNullOrWhiteSpace(conversationId))
+        {
+            AddError("conversationId", "Conversation id is required.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var userId = HttpContext.User.GetUserId();
+        var user = await userRepository.GetByIdAsync(userId, ct).ConfigureAwait(false);
+        if (user is null)
+        {
+            user = UserProfile.CreateDefault(userId);
+            userRepository.Add(user);
+        }
+
+        user.UnmuteConversationNotifications(conversationId);
+        await userRepository.SaveChangesAsync(ct).ConfigureAwait(false);
+        await Send.NoContentAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Services/User/UserService.Api/Endpoints/UpdateNotificationPreferencesEndpoint.cs
+++ b/src/Services/User/UserService.Api/Endpoints/UpdateNotificationPreferencesEndpoint.cs
@@ -60,6 +60,16 @@ public sealed class UpdateNotificationPreferencesEndpoint(IUserRepository userRe
             quietHours,
             request.DndEnabled,
             string.IsNullOrWhiteSpace(request.Locale) ? NotificationSettings.DefaultLocale : request.Locale,
-            request.Sound);
+            request.Sound,
+            NormalizeMutedConversationIds(request.MutedConversationIds));
     }
+
+    private static string[] NormalizeMutedConversationIds(IReadOnlyList<string>? ids)
+        => ids is null
+            ? Array.Empty<string>()
+            : ids
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
 }

--- a/src/Services/User/UserService.Api/Infrastructure/Persistence/Configurations/UserProfileConfiguration.cs
+++ b/src/Services/User/UserService.Api/Infrastructure/Persistence/Configurations/UserProfileConfiguration.cs
@@ -75,7 +75,8 @@ public sealed class UserProfileConfiguration : IEntityTypeConfiguration<UserProf
                 settings.QuietHours.Enabled),
             settings.DndEnabled,
             settings.Locale,
-            settings.Sound);
+            settings.Sound,
+            settings.MutedConversationIds);
 
         return JsonSerializer.Serialize(dto, JsonOptions);
     }
@@ -105,15 +106,26 @@ public sealed class UserProfileConfiguration : IEntityTypeConfiguration<UserProf
             quietHours,
             dto.DndEnabled,
             dto.Locale,
-            dto.Sound);
+            dto.Sound,
+            NormalizeMutedConversationIds(dto.MutedConversationIds));
     }
+
+    private static string[] NormalizeMutedConversationIds(IReadOnlyList<string>? ids)
+        => ids is null
+            ? Array.Empty<string>()
+            : ids
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
 
     private sealed record NotificationSettingsDto(
         IReadOnlyDictionary<string, ChannelToggleDto> Categories,
         QuietHoursDto QuietHours,
         bool DndEnabled,
         string Locale,
-        bool Sound);
+        bool Sound,
+        IReadOnlyList<string>? MutedConversationIds = null);
 
     private sealed record ChannelToggleDto(bool Push, bool Email, bool InApp);
 

--- a/src/Services/User/UserService.Api/Services/InternalApiService.cs
+++ b/src/Services/User/UserService.Api/Services/InternalApiService.cs
@@ -243,6 +243,8 @@ public sealed class InternalApiService(
             });
         }
 
+        payload.MutedConversationIds.AddRange(settings.MutedConversationIds);
+
         return payload;
     }
 
@@ -264,6 +266,11 @@ public sealed class InternalApiService(
             quietHours,
             payload.DndEnabled,
             string.IsNullOrWhiteSpace(payload.Locale) ? DomainSettings.DefaultLocale : payload.Locale,
-            payload.Sound);
+            payload.Sound,
+            payload.MutedConversationIds
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray());
     }
 }

--- a/tests/contract/ContractTests/NotificationContractTests.cs
+++ b/tests/contract/ContractTests/NotificationContractTests.cs
@@ -99,7 +99,8 @@ public sealed class NotificationContractTests
             },
             new QuietHoursPayload("Asia/Yekaterinburg", "22:00", "08:00", true),
             DndEnabled: false,
-            Locale: "ru-RU");
+            Locale: "ru-RU",
+            MutedConversationIds: ["direct:abc", "discipline:def"]);
 
         var original = new UserNotificationSettingsChangedEvent(Guid.NewGuid(), prefs);
 

--- a/tests/integration/UserService.IntegrationTests/ProfileEndpointTests.cs
+++ b/tests/integration/UserService.IntegrationTests/ProfileEndpointTests.cs
@@ -35,6 +35,7 @@ public sealed class ProfileEndpointTests(UserServiceFactory factory)
         Assert.True(profile.Notifications.NotificationSound);
         Assert.True(profile.Notifications.DisciplineChatMessages);
         Assert.True(profile.Notifications.Mentions);
+        Assert.Empty(profile.Notifications.MutedConversationIds);
     }
 
     [Fact]
@@ -115,6 +116,11 @@ public sealed class ProfileEndpointTests(UserServiceFactory factory)
     public async Task UpdateNotificationsShouldPersistSettings()
     {
         var client = CreateAuthenticatedClient();
+        const string mutedConversationId = "direct:legacy-preserve";
+        var muteResponse = await client.PostAsync(
+            new Uri($"/api/v1/me/notifications/muted-conversations/{Uri.EscapeDataString(mutedConversationId)}", UriKind.Relative),
+            content: null);
+        Assert.Equal(HttpStatusCode.NoContent, muteResponse.StatusCode);
 
         var updateResponse = await client.PutAsJsonAsync(
             new Uri("/api/v1/me/notifications", UriKind.Relative),
@@ -134,6 +140,34 @@ public sealed class ProfileEndpointTests(UserServiceFactory factory)
         Assert.True(profile?.Notifications.NotificationSound);
         Assert.False(profile?.Notifications.DisciplineChatMessages);
         Assert.True(profile?.Notifications.Mentions);
+        Assert.Contains(mutedConversationId, profile?.Notifications.MutedConversationIds ?? []);
+    }
+
+    [Fact]
+    public async Task MuteConversationNotificationsShouldPersistSettings()
+    {
+        var userId = Guid.NewGuid();
+        var client = CreateAuthenticatedClient();
+        client.DefaultRequestHeaders.Add("X-Test-UserId", userId.ToString());
+        const string conversationId = "discipline:math";
+
+        var muteResponse = await client.PostAsync(
+            new Uri($"/api/v1/me/notifications/muted-conversations/{Uri.EscapeDataString(conversationId)}", UriKind.Relative),
+            content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, muteResponse.StatusCode);
+        var mutedProfile = await (await client.GetAsync(new Uri("/api/v1/me", UriKind.Relative)))
+            .Content.ReadFromJsonAsync<UserProfileResponse>();
+        Assert.Contains(conversationId, mutedProfile?.Notifications.MutedConversationIds ?? []);
+        Assert.Contains(conversationId, mutedProfile?.Preferences.MutedConversationIds ?? []);
+
+        var unmuteResponse = await client.DeleteAsync(
+            new Uri($"/api/v1/me/notifications/muted-conversations/{Uri.EscapeDataString(conversationId)}", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NoContent, unmuteResponse.StatusCode);
+        var unmutedProfile = await (await client.GetAsync(new Uri("/api/v1/me", UriKind.Relative)))
+            .Content.ReadFromJsonAsync<UserProfileResponse>();
+        Assert.DoesNotContain(conversationId, unmutedProfile?.Notifications.MutedConversationIds ?? []);
     }
 
     [Fact]

--- a/tests/unit/NotificationService.UnitTests/Application/NotificationRouterTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Application/NotificationRouterTests.cs
@@ -210,6 +210,46 @@ public sealed class NotificationRouterTests
         captured!.Deliveries.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task RouteAsync_MutedConversation_SkipsAllDeliveriesAndBadge()
+    {
+        var recipient = Guid.NewGuid();
+        _prefs.GetAsync(recipient, Arg.Any<CancellationToken>())
+            .Returns(UserPreferences.Default with { MutedConversationIds = ["direct-1"] });
+
+        var intent = new NotificationIntent(
+            RecipientUserId: recipient,
+            Category: NotificationCategory.ChatMessageMention,
+            Severity: NotificationSeverity.High,
+            Content: Urfu.Link.Services.Notification.Domain.ValueObjects.NotificationContent.Create("title", "body"),
+            Data: Urfu.Link.Services.Notification.Domain.ValueObjects.NotificationData.From(
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["conversationId"] = "direct-1",
+                }),
+            GroupKey: null,
+            SourceEventId: Guid.NewGuid(),
+            SourceEventType: "test.event.v1",
+            SourceActionId: "chat:message:direct-1:00000000000000000000000000000001",
+            Priority: NotificationPriority.Mention);
+
+        var outcome = await _router.RouteAsync(
+            new TestEvent(),
+            new StaticHandler<TestEvent>([intent]),
+            default);
+
+        outcome.Created.Should().Be(0);
+        outcome.Updated.Should().Be(0);
+        outcome.Skipped.Should().Be(1);
+        await _repository.DidNotReceive().UpsertAsync(
+            Arg.Any<NotificationAggregate>(),
+            Arg.Any<CancellationToken>());
+        await _badgeStore.DidNotReceive().IncrementAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<NotificationCategory>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private sealed record TestEvent : Urfu.Link.BuildingBlocks.Contracts.Integration.IIntegrationEvent
     {
         public Guid EventId { get; } = Guid.NewGuid();

--- a/tests/unit/UserService.UnitTests/Domain/UserTests.cs
+++ b/tests/unit/UserService.UnitTests/Domain/UserTests.cs
@@ -25,6 +25,7 @@ public sealed class UserTests
         Assert.False(user.Notifications.QuietHours.Enabled);
         Assert.True(user.Notifications.GetToggle(NotificationCategoryCode.ChatMessageDirect).Push);
         Assert.Equal(NotificationCategoryCode.All.Count, user.Notifications.Categories.Count);
+        Assert.Empty(user.Notifications.MutedConversationIds);
         Assert.Null(user.SoundVideo.PlaybackDeviceId);
         Assert.Null(user.SoundVideo.RecordingDeviceId);
         Assert.Null(user.SoundVideo.WebcamDeviceId);
@@ -137,6 +138,12 @@ public sealed class UserTests
     public void UpdateNotificationsShouldMapLegacyFlagsAndRaiseEvent()
     {
         var user = UserProfile.CreateDefault(TestUserId);
+        user.UpdateNotificationPreferences(
+            NotificationSettings.Default
+                .WithDnd(true)
+                .WithLocale("en-US")
+                .WithMutedConversation("direct:abc"));
+        user.ClearDomainEvents();
 
         user.UpdateNotifications(
             newMessages: false,
@@ -148,14 +155,18 @@ public sealed class UserTests
         Assert.False(user.Notifications.GetToggle(NotificationCategoryCode.ChatMessageDirect).Push);
         Assert.True(user.Notifications.GetToggle(NotificationCategoryCode.ChatMessageDiscipline).Push);
         Assert.False(user.Notifications.GetToggle(NotificationCategoryCode.ChatMessageMention).Push);
+        Assert.True(user.Notifications.DndEnabled);
+        Assert.Equal("en-US", user.Notifications.Locale);
+        Assert.Contains("direct:abc", user.Notifications.MutedConversationIds);
 
         var evt = Assert.Single(user.DomainEvents);
         var notifEvent = Assert.IsType<UserNotificationSettingsChangedEvent>(evt);
         Assert.Equal(TestUserId, notifEvent.UserId);
-        Assert.Equal("ru-RU", notifEvent.Preferences.Locale);
-        Assert.False(notifEvent.Preferences.DndEnabled);
+        Assert.Equal("en-US", notifEvent.Preferences.Locale);
+        Assert.True(notifEvent.Preferences.DndEnabled);
         Assert.False(notifEvent.Preferences.Categories[NotificationCategoryCode.ChatMessageDirect].Push);
         Assert.True(notifEvent.Preferences.Categories[NotificationCategoryCode.ChatMessageDiscipline].Push);
+        Assert.Contains("direct:abc", notifEvent.Preferences.MutedConversationIds ?? []);
     }
 
     [Fact]
@@ -177,6 +188,27 @@ public sealed class UserTests
         var notifEvent = Assert.IsType<UserNotificationSettingsChangedEvent>(evt);
         Assert.Equal("en-US", notifEvent.Preferences.Locale);
         Assert.True(notifEvent.Preferences.DndEnabled);
+    }
+
+    [Fact]
+    public void MuteAndUnmuteConversationShouldUpdatePreferencesAndRaiseEvent()
+    {
+        var user = UserProfile.CreateDefault(TestUserId);
+
+        user.MuteConversationNotifications(" direct:abc ");
+
+        Assert.Contains("direct:abc", user.Notifications.MutedConversationIds);
+        var muteEvent = Assert.IsType<UserNotificationSettingsChangedEvent>(
+            Assert.Single(user.DomainEvents));
+        Assert.Contains("direct:abc", muteEvent.Preferences.MutedConversationIds ?? []);
+
+        user.ClearDomainEvents();
+        user.UnmuteConversationNotifications("direct:abc");
+
+        Assert.DoesNotContain("direct:abc", user.Notifications.MutedConversationIds);
+        var unmuteEvent = Assert.IsType<UserNotificationSettingsChangedEvent>(
+            Assert.Single(user.DomainEvents));
+        Assert.DoesNotContain("direct:abc", unmuteEvent.Preferences.MutedConversationIds ?? []);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add web browser notifications for background/inactive chat activity
- add per-conversation mute/unmute persistence and backend filtering
- remove direct-chat new-message toggle from notification settings and keep remaining controls working

## Tests
- pnpm --filter @urfu-link/api-client test -- --runInBand
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test
- dotnet test tests/unit/UserService.UnitTests/UserService.UnitTests.csproj
- dotnet test tests/integration/UserService.IntegrationTests/UserService.IntegrationTests.csproj
- dotnet test tests/unit/NotificationService.UnitTests/NotificationService.UnitTests.csproj
- dotnet test tests/integration/NotificationService.IntegrationTests/NotificationService.IntegrationTests.csproj
- dotnet test tests/contract/ContractTests/ContractTests.csproj
- git diff --check

## Manual smoke
- Started client with web:local and opened http://localhost:3000; login page rendered.