### PR TITLE
fix: allow keycloak bootstrap to write call service secrets

### DIFF
--- a/deploy/k8s/platform/vault/vault-auto-init-job.yaml
+++ b/deploy/k8s/platform/vault/vault-auto-init-job.yaml
@@ -210,6 +210,9 @@ spec:
               path "kv/data/urfu-link/prod/chat-service" {
                 capabilities = ["create", "update", "read"]
               }
+              path "kv/data/urfu-link/prod/call-service" {
+                capabilities = ["create", "update", "read"]
+              }
               path "kv/metadata/urfu-link/prod/*" {
                 capabilities = ["read", "list"]
               }


### PR DESCRIPTION
## Summary
- allow the keycloak-bootstrap Vault policy to write the call-service KV path
- unblocks ExternalSecret refresh for call-service internal gRPC secret

## Verification
- git diff --check
- server-side kubectl dry-run parsed manifest; existing Job immutability is expected because Argo sync uses Force=true,Replace=true