### PR TITLE
fix: allow keycloak bootstrap to write call service secrets

### DIFF
--- a/deploy/k8s/platform/vault/vault-auto-init-job.yaml
+++ b/deploy/k8s/platform/vault/vault-auto-init-job.yaml
@@ -210,6 +210,9 @@ spec:
               path "kv/data/urfu-link/prod/chat-service" {
                 capabilities = ["create", "update", "read"]
               }
+              path "kv/data/urfu-link/prod/call-service" {
+                capabilities = ["create", "update", "read"]
+              }
               path "kv/metadata/urfu-link/prod/*" {
                 capabilities = ["read", "list"]
               }


### PR DESCRIPTION
## Summary
- promote Vault policy fix from develop to master
- lets keycloak-bootstrap write call-service internal auth secret so ExternalSecret can refresh

## Verification
- PR #423 merged into develop
- production issue confirmed over SSH before fix: ExternalSecret/call-service-secrets was missing internal_auth_client_secret