### PR TITLE
fix: make outbox worker retry transient failures

### DIFF
--- a/src/BuildingBlocks/Outbox/Class1.cs
+++ b/src/BuildingBlocks/Outbox/Class1.cs
@@ -216,19 +216,20 @@ public sealed class OutboxPublisherWorker(
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await outboxStore.RecoverAsync(stoppingToken).ConfigureAwait(false);
+        await RecoverUntilSuccessfulAsync(stoppingToken).ConfigureAwait(false);
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            var nextMessage = await outboxStore.DequeueAsync(stoppingToken).ConfigureAwait(false);
-            if (nextMessage is null)
-            {
-                await Task.Delay(options.Value.PollInterval, stoppingToken).ConfigureAwait(false);
-                continue;
-            }
-
+            OutboxMessage? nextMessage = null;
             try
             {
+                nextMessage = await outboxStore.DequeueAsync(stoppingToken).ConfigureAwait(false);
+                if (nextMessage is null)
+                {
+                    await Task.Delay(options.Value.PollInterval, stoppingToken).ConfigureAwait(false);
+                    continue;
+                }
+
                 await publisher
                     .PublishSerializedAsync(nextMessage.Topic, nextMessage.Key, nextMessage.Payload, stoppingToken)
                     .ConfigureAwait(false);
@@ -239,18 +240,51 @@ public sealed class OutboxPublisherWorker(
             {
                 throw;
             }
-            catch (Exception exception) when (
-                exception is KafkaException
-                or ProduceException<string, string>
-                or RedisException
-                or TimeoutException
-                or InvalidOperationException
-                or JsonException)
+            catch (Exception exception) when (IsRecoverableOutboxException(exception))
             {
-                logger.LogError(exception, "Outbox publish failed for message {MessageId}", nextMessage.Id);
+                if (nextMessage is null)
+                {
+                    logger.LogError(exception, "Outbox processing failed before a message was dequeued");
+                }
+                else
+                {
+                    logger.LogError(exception, "Outbox publish failed for message {MessageId}", nextMessage.Id);
+                }
+
                 await Task.Delay(options.Value.PollInterval, stoppingToken).ConfigureAwait(false);
             }
         }
+    }
+
+    private async Task RecoverUntilSuccessfulAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await outboxStore.RecoverAsync(stoppingToken).ConfigureAwait(false);
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception) when (IsRecoverableOutboxException(exception))
+            {
+                logger.LogError(exception, "Outbox recovery failed; retrying");
+                await Task.Delay(options.Value.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsRecoverableOutboxException(Exception exception)
+    {
+        return exception is KafkaException
+            or ProduceException<string, string>
+            or RedisException
+            or TimeoutException
+            or InvalidOperationException
+            or JsonException;
     }
 }
 

--- a/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
+++ b/tests/unit/BuildingBlocks.UnitTests/BuildingBlocks.UnitTests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Auth\Auth.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Contracts\Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\Observability\Observability.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Outbox\Outbox.csproj" />
     <ProjectReference Include="..\..\..\src\BuildingBlocks\ServiceDefaults\ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/tests/unit/BuildingBlocks.UnitTests/Outbox/OutboxPublisherWorkerTests.cs
+++ b/tests/unit/BuildingBlocks.UnitTests/Outbox/OutboxPublisherWorkerTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using Urfu.Link.BuildingBlocks.Contracts.Integration;
+using Urfu.Link.BuildingBlocks.Outbox;
+
+namespace Urfu.Link.BuildingBlocks.UnitTests.Outbox;
+
+public sealed class OutboxPublisherWorkerTests
+{
+    [Fact]
+    public async Task Recovers_after_transient_recovery_failure_instead_of_faulting_host()
+    {
+        var store = new ThrowOnceOutboxStore(
+            failOnRecover: true,
+            secondRecoverObserved: new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+        using var worker = CreateWorker(store);
+
+        await worker.StartAsync(CancellationToken.None);
+        await store.SecondRecoverObserved.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await worker.StopAsync(CancellationToken.None);
+
+        store.RecoverCalls.Should().BeGreaterThanOrEqualTo(2);
+        worker.ExecuteTask.Should().NotBeNull();
+        worker.ExecuteTask!.IsFaulted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Continues_after_transient_dequeue_failure_instead_of_faulting_host()
+    {
+        var store = new ThrowOnceOutboxStore(
+            failOnDequeue: true,
+            secondDequeueObserved: new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+        using var worker = CreateWorker(store);
+
+        await worker.StartAsync(CancellationToken.None);
+        await store.SecondDequeueObserved.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await worker.StopAsync(CancellationToken.None);
+
+        store.DequeueCalls.Should().BeGreaterThanOrEqualTo(2);
+        worker.ExecuteTask.Should().NotBeNull();
+        worker.ExecuteTask!.IsFaulted.Should().BeFalse();
+    }
+
+    private static OutboxPublisherWorker CreateWorker(IOutboxStore store)
+    {
+        return new OutboxPublisherWorker(
+            store,
+            new NoopKafkaPublisher(),
+            Options.Create(new OutboxOptions { PollInterval = TimeSpan.FromMilliseconds(10) }),
+            NullLogger<OutboxPublisherWorker>.Instance);
+    }
+
+    private sealed class ThrowOnceOutboxStore(
+        bool failOnRecover = false,
+        bool failOnDequeue = false,
+        TaskCompletionSource? secondRecoverObserved = null,
+        TaskCompletionSource? secondDequeueObserved = null) : IOutboxStore
+    {
+        public TaskCompletionSource SecondRecoverObserved { get; } =
+            secondRecoverObserved ?? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource SecondDequeueObserved { get; } =
+            secondDequeueObserved ?? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int RecoverCalls { get; private set; }
+
+        public int DequeueCalls { get; private set; }
+
+        public ValueTask EnqueueAsync<TEvent>(
+            string topic,
+            IntegrationEnvelope<TEvent> envelope,
+            CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public Task RecoverAsync(CancellationToken cancellationToken = default)
+        {
+            RecoverCalls++;
+            if (failOnRecover && RecoverCalls == 1)
+            {
+                throw CreateRedisFailure();
+            }
+
+            if (RecoverCalls >= 2)
+            {
+                SecondRecoverObserved.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<OutboxMessage?> DequeueAsync(CancellationToken cancellationToken = default)
+        {
+            DequeueCalls++;
+            if (failOnDequeue && DequeueCalls == 1)
+            {
+                throw CreateRedisFailure();
+            }
+
+            if (DequeueCalls >= 2)
+            {
+                SecondDequeueObserved.TrySetResult();
+            }
+
+            return Task.FromResult<OutboxMessage?>(null);
+        }
+
+        public Task CompleteAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        private static RedisConnectionException CreateRedisFailure()
+        {
+            return new RedisConnectionException(ConnectionFailureType.SocketFailure, "transient redis failure");
+        }
+    }
+
+    private sealed class NoopKafkaPublisher : IKafkaPublisher
+    {
+        public Task PublishAsync<TEvent>(
+            string topic,
+            IntegrationEnvelope<TEvent> envelope,
+            CancellationToken cancellationToken = default)
+            where TEvent : IIntegrationEvent
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task PublishSerializedAsync(string topic, string key, string payload, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- retry outbox recovery instead of faulting the host on transient Redis/Kafka failures
- keep dequeue/publish/complete loop alive after recoverable failures
- add unit coverage for recovery and dequeue transient Redis failures

## Tests
- dotnet test tests\\unit\\BuildingBlocks.UnitTests\\BuildingBlocks.UnitTests.csproj
- dotnet test tests\\unit\\NotificationService.UnitTests\\NotificationService.UnitTests.csproj