### PR TITLE
fix: prevent native LiveKit imports in web bundle

### DIFF
--- a/apps/client/app/_layout.tsx
+++ b/apps/client/app/_layout.tsx
@@ -1,10 +1,10 @@
-import { registerGlobals } from "@livekit/react-native";
 import { AppProviders } from "@/providers";
+import { registerLiveKitGlobals } from "@/shared/lib/registerLiveKitGlobals";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import "../global.css";
 
-registerGlobals();
+registerLiveKitGlobals();
 
 export default function RootLayout() {
     return (<AppProviders>

--- a/apps/client/src/features/call/ui/CallScreen.web.tsx
+++ b/apps/client/src/features/call/ui/CallScreen.web.tsx
@@ -1,0 +1,38 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const normalizeId = (value: string | string[] | undefined): string | null => {
+    if (Array.isArray(value)) return value[0] ?? null;
+    return value ?? null;
+};
+
+export const CallScreen = () => {
+    const { id } = useLocalSearchParams<{ id: string | string[] }>();
+    const router = useRouter();
+    const callId = normalizeId(id);
+
+    return (
+        <SafeAreaView className="flex-1 bg-app-bg">
+            <View className="flex-1 items-center justify-center px-6">
+                <View className="w-full max-w-[480px] rounded-2xl border border-white/10 bg-app-card p-6">
+                    <Text className="text-white text-xl font-semibold text-center">
+                        Звонки в веб-версии временно недоступны
+                    </Text>
+                    <Text className="text-text-muted text-center mt-3">
+                        Откройте мобильное приложение, чтобы подключиться к звонку.
+                    </Text>
+                    {callId ? (
+                        <Text className="text-text-muted text-center mt-2">ID звонка: {callId}</Text>
+                    ) : null}
+                    <Pressable
+                        className="mt-6 rounded-xl bg-brand-600 px-4 py-3 items-center"
+                        onPress={() => router.replace("/chats" as never)}
+                    >
+                        <Text className="text-white font-semibold">Вернуться в чаты</Text>
+                    </Pressable>
+                </View>
+            </View>
+        </SafeAreaView>
+    );
+};

--- a/apps/client/src/features/call/ui/__tests__/CallScreen.web.test.tsx
+++ b/apps/client/src/features/call/ui/__tests__/CallScreen.web.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+const mockReplace = jest.fn();
+
+jest.mock("expo-router", () => ({
+    useLocalSearchParams: () => ({ id: "call-123" }),
+    useRouter: () => ({
+        replace: mockReplace,
+    }),
+}));
+
+const { CallScreen } = require("../CallScreen.web");
+
+describe("CallScreen web", () => {
+    beforeEach(() => {
+        mockReplace.mockClear();
+    });
+
+    it("renders a web-safe fallback without loading native LiveKit components", () => {
+        render(<CallScreen />);
+
+        expect(screen.getByText("Звонки в веб-версии временно недоступны")).toBeTruthy();
+        expect(screen.getByText("ID звонка: call-123")).toBeTruthy();
+    });
+
+    it("returns the user to chats from the fallback", () => {
+        render(<CallScreen />);
+
+        fireEvent.press(screen.getByText("Вернуться в чаты"));
+
+        expect(mockReplace).toHaveBeenCalledWith("/chats");
+    });
+});

--- a/apps/client/src/shared/lib/__tests__/registerLiveKitGlobals.web.test.ts
+++ b/apps/client/src/shared/lib/__tests__/registerLiveKitGlobals.web.test.ts
@@ -1,0 +1,11 @@
+describe("registerLiveKitGlobals web", () => {
+    it("does not import the native LiveKit bridge on web", () => {
+        jest.doMock("@livekit/react-native", () => {
+            throw new Error("native LiveKit bridge must not be imported on web");
+        });
+
+        const { registerLiveKitGlobals } = require("../registerLiveKitGlobals.web");
+
+        expect(() => registerLiveKitGlobals()).not.toThrow();
+    });
+});

--- a/apps/client/src/shared/lib/registerLiveKitGlobals.native.ts
+++ b/apps/client/src/shared/lib/registerLiveKitGlobals.native.ts
@@ -1,0 +1,5 @@
+import { registerGlobals } from "@livekit/react-native";
+
+export const registerLiveKitGlobals = () => {
+    registerGlobals();
+};

--- a/apps/client/src/shared/lib/registerLiveKitGlobals.ts
+++ b/apps/client/src/shared/lib/registerLiveKitGlobals.ts
@@ -1,0 +1,1 @@
+export const registerLiveKitGlobals = () => {};

--- a/apps/client/src/shared/lib/registerLiveKitGlobals.web.ts
+++ b/apps/client/src/shared/lib/registerLiveKitGlobals.web.ts
@@ -1,0 +1,1 @@
+export const registerLiveKitGlobals = () => {};


### PR DESCRIPTION
## Что исправлено
- web-сборка больше не импортирует native LiveKit bridge на старте приложения
- экран звонка на web получает безопасный fallback вместо native-only компонентов
- добавлены тесты на web-ветки LiveKit-регистрации и экрана звонка

## Проверка
- pnpm --filter @urfu-link/client test -- CallScreen.web registerLiveKitGlobals.web --runInBand
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client web:build
- pnpm --filter @urfu-link/client test -- --runInBand
- проверка dist в браузере: ошибок страницы нет, собранный JS не содержит requireNativeComponent / @livekit/react-native-webrtc