### PR TITLE
fix: use discipline wording in inbox

### DIFF
--- a/apps/client/src/widgets/chat/ui/subject-header/SubjectMembersModal.tsx
+++ b/apps/client/src/widgets/chat/ui/subject-header/SubjectMembersModal.tsx
@@ -38,7 +38,7 @@ export const SubjectMembersModal = ({ isOpen, onClose, members, onOpenProfile }:
 
             <ScrollView className="w-full" contentContainerClassName="px-8 py-6 gap-2" showsVerticalScrollIndicator={false}>
                 {members.length === 0 ? (
-                    <EmptyState size="compact" icon={UsersIcon} title="В предмете пока нет участников" />
+                    <EmptyState size="compact" icon={UsersIcon} title="В дисциплине пока нет участников" />
                 ) : (
                     members.map((member) => (
                         <Pressable

--- a/apps/client/src/widgets/inbox/lib/empty-state-config.ts
+++ b/apps/client/src/widgets/inbox/lib/empty-state-config.ts
@@ -9,7 +9,7 @@ export const getInboxEmptyState = (tab: TabType, view: ViewType) => {
             title:
                 tab === "chats"
                     ? "Уведомлений по чатам нет"
-                    : "Уведомлений по предметам нет",
+                    : "Уведомлений по дисциплинам нет",
             description: "Здесь появятся новые упоминания и важные события",
         };
     }
@@ -22,7 +22,6 @@ export const getInboxEmptyState = (tab: TabType, view: ViewType) => {
           }
         : {
               icon: BookOpenIcon,
-              title: "Предметов пока нет",
-              description: "Курсы появятся, когда вас добавят в группы",
+              title: "Дисциплин нет",
           };
 };

--- a/apps/client/src/widgets/inbox/model/use-inbox-conversations.ts
+++ b/apps/client/src/widgets/inbox/model/use-inbox-conversations.ts
@@ -139,7 +139,7 @@ const mapConversation = (
             disciplineRowName ??
             c.title ??
             peerName ??
-            (c.type === "Direct" ? "Личный чат" : "Чат предмета"),
+            (c.type === "Direct" ? "Личный чат" : "Чат дисциплины"),
         message: typingPreview ?? formatLastMessagePreview(latestMessage, preview),
         time: formatInboxTime(lastAt),
         unreadCount,

--- a/apps/client/src/widgets/inbox/ui/Inbox.tsx
+++ b/apps/client/src/widgets/inbox/ui/Inbox.tsx
@@ -38,7 +38,7 @@ export const Inbox = <T,>({
             ? "Уведомления"
             : currentTab === "chats"
               ? "Личные чаты"
-              : "Предметы";
+              : "Дисциплины";
     const showNotificationToolbar =
         currentView === "notifications" && !isSearchActive && data.length > 0;
 


### PR DESCRIPTION
﻿## Summary
- rename subject inbox copy from subjects/courses wording to disciplines
- simplify empty state to only "????????? ???"
- update discipline chat/member fallback labels

## Tests
- pnpm client:typecheck
- git diff --check
