### PR TITLE
Promote LiveKit hostNetwork rollout fix

### DIFF
--- a/deploy/k8s/platform/media/README.md
+++ b/deploy/k8s/platform/media/README.md
@@ -8,5 +8,7 @@ uses a cert-manager certificate for `turn.urfu-link.ghjc.ru`.
 
 LiveKit runs with `hostNetwork: true` on the single k3s node so external
 WebRTC ports (`7881/tcp`, `3478/udp`, `5349/tcp`, `50000-50100/udp`) are bound
-by `livekit-server` itself. The `7880/tcp` HTTP API remains behind the
-`livekit.urfu-link.ghjc.ru` ingress and must not be opened directly in UFW.
+by `livekit-server` itself. Its Deployment uses `Recreate` because two
+host-networked LiveKit pods cannot bind the same media ports on one node. The
+`7880/tcp` HTTP API remains behind the `livekit.urfu-link.ghjc.ru` ingress and
+must not be opened directly in UFW.

--- a/deploy/k8s/platform/media/livekit.yaml
+++ b/deploy/k8s/platform/media/livekit.yaml
@@ -7,6 +7,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: livekit


### PR DESCRIPTION
## Summary
Promotes the LiveKit hostNetwork rollout fix from `develop` to `master`.

## Why
The production rollout applied the embedded TURN resources but LiveKit became degraded because the Deployment tried RollingUpdate on a single host-networked node. The new pod could not schedule while the old pod owned the media host ports. `Recreate` is required for this topology.

## Verification
- `kubectl kustomize deploy/k8s/platform`
- `git diff --check`