### PR TITLE
Harden production media rollout scripts

### DIFF
--- a/deploy/scripts/prod-media-preflight.ps1
+++ b/deploy/scripts/prod-media-preflight.ps1
@@ -69,7 +69,10 @@ function Invoke-RemoteScript {
 
 foreach ($domain in $MediaDomains) {
     $addresses = @(Resolve-DnsName $domain -ErrorAction SilentlyContinue |
-        Where-Object { $_.Type -eq "A" } |
+        Where-Object {
+            $_.Type -eq "A" -and
+            ((-not ($_.PSObject.Properties.Name -contains "Section")) -or $_.Section -eq "Answer")
+        } |
         Select-Object -ExpandProperty IPAddress -Unique)
 
     if ($addresses.Count -eq 1 -and $addresses[0] -eq $ExpectedIp) {

--- a/deploy/scripts/prod-media-smoke.ps1
+++ b/deploy/scripts/prod-media-smoke.ps1
@@ -12,6 +12,9 @@ $ErrorActionPreference = "Stop"
 function Invoke-Remote {
     param([string]$Command)
     ssh -o BatchMode=yes $SshTarget $Command
+    if ($LASTEXITCODE -ne 0) {
+        throw "Remote command failed with exit code ${LASTEXITCODE}: $Command"
+    }
 }
 
 Write-Host "[smoke] Checking LiveKit HTTPS endpoint." -ForegroundColor Cyan

--- a/deploy/scripts/prod-media-switch.ps1
+++ b/deploy/scripts/prod-media-switch.ps1
@@ -9,6 +9,16 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 function Invoke-Remote {
     param([string]$Command)
     ssh -o BatchMode=yes $SshTarget $Command
+    if ($LASTEXITCODE -ne 0) {
+        throw "Remote command failed with exit code ${LASTEXITCODE}: $Command"
+    }
+}
+
+function Invoke-RemoteScript {
+    param([string]$Script)
+    $normalizedScript = $Script.Replace("`r`n", "`n").Replace("`r", "`n")
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($normalizedScript))
+    Invoke-Remote "printf '%s' '$encoded' | base64 -d | bash"
 }
 
 if ($DirectApply) {
@@ -71,8 +81,11 @@ Invoke-Remote "kubectl delete deploy,svc,cm coturn -n urfu-platform --ignore-not
 Write-Host "[media] Restarting LiveKit and call-service." -ForegroundColor Cyan
 Invoke-Remote "kubectl rollout restart deploy/livekit -n urfu-platform"
 $restartAt = (Get-Date).ToUniversalTime().ToString("o")
-$callServiceRestartPatch = '{"spec":{"restartAt":"' + $restartAt + '"}}'
-Invoke-Remote "kubectl patch rollout call-service -n urfu-prod --type merge -p '$callServiceRestartPatch'"
+$callServiceRestartScript = @"
+set -eu
+kubectl patch rollout call-service -n urfu-prod --type merge --patch '{"spec":{"restartAt":"$restartAt"}}'
+"@
+Invoke-RemoteScript $callServiceRestartScript
 
 Write-Host "[media] Waiting for readiness." -ForegroundColor Cyan
 Invoke-Remote "kubectl rollout status deploy/livekit -n urfu-platform --timeout=180s"


### PR DESCRIPTION
## Summary
- Filters DNS preflight checks to Answer-section A records only.
- Makes SSH helper commands fail the PowerShell rollout scripts when remote commands fail.
- Restarts call-service via a base64-encoded remote bash script so JSON merge patch quoting is stable from Windows.

## Verification
- PowerShell parser for all prod media scripts
- `deploy/scripts/prod-media-preflight.ps1 -RequireTargetState`
- `git diff --check`