### PR TITLE
Prevent stale frontend web bundles

### DIFF
--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -23,7 +23,33 @@ server {
     return 200 "ok";
   }
 
+  location = /index.html {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /index.html =404;
+  }
+
+  location = /app-config.js {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /app-config.js =404;
+  }
+
+  location = /metadata.json {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /metadata.json =404;
+  }
+
+  location /_expo/static/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
   location / {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
     try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
## Summary
- Prevents stale SPA HTML/config from being cached by browsers or proxies.
- Keeps hashed Expo static assets cacheable with immutable headers.
- Returns 404 for missing hashed static files instead of falling back to `index.html`.

## Why
Prod is running the new frontend image and the old web-calls fallback string is not present in the pod, but users can still see the old screen from a cached web bundle. The frontend nginx config did not define cache policy for SPA entry files.

## Verification
- `docker run --rm -v ${PWD}/apps/client/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginxinc/nginx-unprivileged:1.29-alpine nginx -t`
- `git diff --check`