### PR TITLE
Promote frontend cache-control fix

### DIFF
--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -23,7 +23,33 @@ server {
     return 200 "ok";
   }
 
+  location = /index.html {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /index.html =404;
+  }
+
+  location = /app-config.js {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /app-config.js =404;
+  }
+
+  location = /metadata.json {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    try_files /metadata.json =404;
+  }
+
+  location /_expo/static/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
   location / {
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
     try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
## Summary
Promotes frontend cache-control fix to production.

## Why
The production pod already contains the new web-calls code and no old fallback string, but users can still see the stale web bundle because SPA entry files were cacheable by default. This makes `index.html`, `app-config.js`, and `metadata.json` non-cacheable and keeps hashed static assets immutable.

## Verification
- nginx config syntax check with `nginxinc/nginx-unprivileged:1.29-alpine nginx -t`
- `git diff --check`