### PR TITLE
Guard web audio playback for calls

### DIFF
--- a/apps/client/src/shared/lib/__tests__/message-sounds.test.ts
+++ b/apps/client/src/shared/lib/__tests__/message-sounds.test.ts
@@ -136,4 +136,18 @@ describe("message sounds", () => {
 
         await expect(playMessageSound("send")).resolves.toBe(false);
     });
+
+    it("swallows async playback rejections from browser autoplay policy", async () => {
+        (createAudioPlayer as jest.Mock).mockImplementation(() => {
+            const player = createPlayer();
+            player.play.mockRejectedValue(new DOMException("NotAllowedError", "NotAllowedError"));
+            players.push(player);
+            return player;
+        });
+
+        await expect(playMessageSound("receive", { conversationId: "direct-1", now: 1000 }))
+            .resolves.toBe(false);
+
+        expect(players[0].play).toHaveBeenCalledTimes(1);
+    });
 });

--- a/apps/client/src/shared/lib/message-sounds.ts
+++ b/apps/client/src/shared/lib/message-sounds.ts
@@ -12,6 +12,7 @@ type ExpoAudioModule = typeof import("expo-audio");
 type AudioPlayer = import("expo-audio").AudioPlayer;
 type AudioSource = import("expo-audio").AudioSource;
 type AudioRuntime = Pick<ExpoAudioModule, "createAudioPlayer" | "setAudioModeAsync">;
+type PlayableAudioPlayer = AudioPlayer & { play: () => void | Promise<void> };
 
 const RECEIVE_THROTTLE_MS = 400;
 const DEFAULT_PREFERENCES: UserNotifications = {
@@ -89,6 +90,10 @@ const getPlayer = async (kind: SoundKind) => {
     return players[kind]!;
 };
 
+const playPlayer = async (player: AudioPlayer) => {
+    await Promise.resolve((player as PlayableAudioPlayer).play());
+};
+
 export const configureMessageSounds = (nextPreferences: UserNotifications | null | undefined) => {
     preferences = {
         ...(nextPreferences ?? DEFAULT_PREFERENCES),
@@ -106,7 +111,7 @@ export const playMessageSound = async (
         const player = await getPlayer(kind);
         if (player.playing) player.pause();
         await player.seekTo(0).catch(() => undefined);
-        player.play();
+        await playPlayer(player);
         return true;
     } catch {
         return false;

--- a/apps/client/src/shared/lib/useCallHub.ts
+++ b/apps/client/src/shared/lib/useCallHub.ts
@@ -4,6 +4,7 @@ import { HubConnectionState } from "@microsoft/signalr";
 import type { CallSessionDto } from "@urfu-link/api-client";
 import { createHubConnection } from "@/shared/lib/signalr";
 import { useCallStore } from "@/entities/call/model/call-store";
+import { playMessageSound } from "@/shared/lib/message-sounds";
 
 const connectHub = async (connection: ReturnType<typeof createHubConnection>) => {
     if (connection.state === HubConnectionState.Connected) {
@@ -31,6 +32,9 @@ export const useCallHub = () => {
 
         connection.on("IncomingCall", (call: CallSessionDto) => {
             handleIncomingCall(call);
+            void playMessageSound("receive", {
+                conversationId: call.conversationId,
+            });
         });
 
         connection.on("CallAccepted", (call: CallSessionDto) => {


### PR DESCRIPTION
## Summary
- Awaits `expo-audio` player playback so browser autoplay rejections are caught instead of becoming uncaught promises.
- Plays the guarded receive sound when a `IncomingCall` SignalR event arrives.
- Adds regression coverage for `NotAllowedError`/browser autoplay rejection.

## Verification
- `pnpm --filter @urfu-link/client test -- --runTestsByPath src/shared/lib/__tests__/message-sounds.test.ts`
- `pnpm --filter @urfu-link/client typecheck`
- `pnpm --filter @urfu-link/client test` (39 suites / 190 tests)
- `pnpm --filter @urfu-link/client web:build`
- `git diff --check`