### PR TITLE
fix(client): clarify call system message time

### DIFF
--- a/apps/client/src/entities/chat-message/ui/ChatMessage.tsx
+++ b/apps/client/src/entities/chat-message/ui/ChatMessage.tsx
@@ -117,6 +117,29 @@ const buildSystemCallLabel = (systemCall?: ChatMessageProps["systemCall"]) => {
     }
 };
 
+const buildSystemCallTimeLabel = (
+    status: NonNullable<ChatMessageProps["systemCall"]>["status"] | undefined,
+    time: string,
+) => {
+    if (!time) return null;
+
+    switch (status) {
+        case "Started":
+            return time;
+        case "Missed":
+            return `Пропущен: ${time}`;
+        case "Declined":
+            return `Отклонён: ${time}`;
+        case "Cancelled":
+            return `Отменён: ${time}`;
+        case "Failed":
+        case "Completed":
+            return `Завершён: ${time}`;
+        default:
+            return time;
+    }
+};
+
 export const ChatMessage = ({
     id,
     text,
@@ -147,6 +170,7 @@ export const ChatMessage = ({
 
     if (kind === "SystemCall") {
         const systemText = buildSystemCallLabel(systemCall);
+        const timeLabel = buildSystemCallTimeLabel(systemCall?.status, time);
         const duration = formatDuration(systemCall?.duration);
         return (
             <View className="px-2 items-center">
@@ -162,9 +186,9 @@ export const ChatMessage = ({
                         </Text>
                     </View>
                     <View className="mt-1 flex-row flex-wrap gap-2 justify-center">
-                        {time ? (
+                        {timeLabel ? (
                             <Text className="text-[11px] text-text-placeholder">
-                                Начало: {time}
+                                {timeLabel}
                             </Text>
                         ) : null}
                         {duration ? (

--- a/apps/client/src/entities/chat-message/ui/__tests__/ChatMessage.test.tsx
+++ b/apps/client/src/entities/chat-message/ui/__tests__/ChatMessage.test.tsx
@@ -294,7 +294,32 @@ describe("ChatMessage read indicator", () => {
         expect(screen.getByText(label)).toBeTruthy();
     });
 
-    it("shows system call timing details", () => {
+    it("shows started system call time without a prefix", () => {
+        render(
+            <ChatMessage
+                id="message-1"
+                text=""
+                kind="SystemCall"
+                isOwn={false}
+                time="12:00"
+                avatarUrl=""
+                systemCall={{
+                    callId: "call-1",
+                    callType: "Audio",
+                    status: "Started",
+                    callerId: "user-1",
+                    duration: null,
+                    endReason: null,
+                }}
+            />,
+        );
+
+        expect(screen.getByText("12:00")).toBeTruthy();
+        expect(screen.queryByText("Начало: 12:00")).toBeNull();
+        expect(screen.queryByText("Завершён: 12:00")).toBeNull();
+    });
+
+    it("shows completed system call end time and duration", () => {
         render(
             <ChatMessage
                 id="message-1"
@@ -314,7 +339,8 @@ describe("ChatMessage read indicator", () => {
             />,
         );
 
-        expect(screen.getByText("Начало: 12:00")).toBeTruthy();
+        expect(screen.getByText("Завершён: 12:00")).toBeTruthy();
+        expect(screen.queryByText("Начало: 12:00")).toBeNull();
         expect(screen.getByText("Длительность: 3:12")).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Что сделано
- В system-call bubble для начатого звонка показывается только время без префикса.
- Для завершённого звонка показывается время завершения: \Завершён: HH:mm\, без \Начало\.
- Длительность завершённого звонка сохранена отдельной строкой.

## Проверки
- pnpm --filter @urfu-link/client test -- --runTestsByPath src/entities/chat-message/ui/__tests__/ChatMessage.test.tsx --watchAll=false
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test