### PR TITLE
fix(client): prevent stale call notification navigation

### DIFF
--- a/apps/client/src/entities/inbox-notification/model/types.ts
+++ b/apps/client/src/entities/inbox-notification/model/types.ts
@@ -5,6 +5,7 @@ export interface InboxNotificationProps {
     time: string;
     scope: "chats" | "subjects";
     deepLink?: string | null;
+    data?: Record<string, string>;
     actorName?: string | null;
     /** false — непрочитано (акцент в списке) */
     isRead?: boolean;

--- a/apps/client/src/features/call/ui/CallRoom.tsx
+++ b/apps/client/src/features/call/ui/CallRoom.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import {
     LiveKitRoom,
@@ -14,27 +14,32 @@ import {
     CallDrawer,
     CallErrorOverlay,
     CallLoadingOverlay,
-    MediaOverlayControls,
     type CallPanel,
     NoVideoPanel,
 } from "./CallRoomControls";
+import {
+    pickActiveScreenShare,
+    shouldDisableLocalScreenShareForRemoteOwner,
+    type ScreenShareCandidate,
+} from "./CallRoomMedia";
 
 type TrackRef = Parameters<typeof VideoTrack>[0]["trackRef"];
 type DefinedTrackRef = Exclude<TrackRef, null | undefined>;
 type CameraFacingMode = "user" | "environment";
+
+const getNativeScreenShareKey = (track: DefinedTrackRef) =>
+    `${track.participant.identity}:${track.publication?.trackSid ?? track.source}`;
 
 const NativeVideoPanel = ({
     isVideoAvailable,
     mainTrack,
     thumbnailTracks,
     mainPlaceholderLabel,
-    controls,
 }: {
     isVideoAvailable: boolean;
     mainTrack: DefinedTrackRef | null;
     thumbnailTracks: DefinedTrackRef[];
     mainPlaceholderLabel: string;
-    controls?: React.ReactNode;
 }) => {
     return (
         <View className="relative flex-1 bg-black/30">
@@ -63,7 +68,6 @@ const NativeVideoPanel = ({
                 </View>
             ) : null}
 
-            {controls ? <View className="absolute left-3 top-3">{controls}</View> : null}
         </View>
     );
 };
@@ -83,6 +87,7 @@ const NativeRoomContent = ({
 }: CallRoomProps) => {
     const [panel, setPanel] = useState<CallPanel>("none");
     const [facingMode, setFacingMode] = useState<CameraFacingMode>("user");
+    const [activeScreenShareOwnerId, setActiveScreenShareOwnerId] = useState<string | null>(null);
     const isVideoCall = call.callType === "Video";
     const isConnectedToCall = call.status === "Active";
 
@@ -91,6 +96,14 @@ const NativeRoomContent = ({
     const cameraTracks = useTracks([Track.Source.Camera], {
         onlySubscribed: true,
     });
+    const screenShareTracks = useTracks([Track.Source.ScreenShare], {
+        onlySubscribed: true,
+    });
+    const knownRemoteScreenShareKeysRef = useRef<Set<string>>(new Set());
+    const localUserId =
+        participantInfos.find((participant) => participant.isSelf)?.userId ??
+        localParticipant?.identity ??
+        null;
 
     const remoteCameraTracks = useMemo<DefinedTrackRef[]>(
         () =>
@@ -104,11 +117,90 @@ const NativeRoomContent = ({
         const local = cameraTracks.find((track) => track?.participant.isLocal);
         return (local as DefinedTrackRef | undefined) ?? null;
     }, [cameraTracks]);
+    const allScreenShareTracks = useMemo<DefinedTrackRef[]>(
+        () =>
+            screenShareTracks.filter(
+                (track): track is DefinedTrackRef =>
+                    track !== null && track !== undefined,
+            ),
+        [screenShareTracks],
+    );
+    const remoteScreenShareTracks = useMemo<DefinedTrackRef[]>(
+        () => allScreenShareTracks.filter((track) => !track.participant.isLocal),
+        [allScreenShareTracks],
+    );
+    const screenShareCandidates = useMemo<ScreenShareCandidate[]>(
+        () =>
+            allScreenShareTracks.map((track) => ({
+                ownerId: track.participant.identity,
+                key: getNativeScreenShareKey(track),
+                isLocal: track.participant.isLocal,
+            })),
+        [allScreenShareTracks],
+    );
+    const activeScreenShareCandidate = useMemo(
+        () =>
+            pickActiveScreenShare(
+                screenShareCandidates,
+                activeScreenShareOwnerId,
+                localUserId,
+            ),
+        [activeScreenShareOwnerId, localUserId, screenShareCandidates],
+    );
+    const activeScreenShareTrack = useMemo(
+        () =>
+            activeScreenShareCandidate
+                ? allScreenShareTracks.find(
+                    (track) => getNativeScreenShareKey(track) === activeScreenShareCandidate.key,
+                ) ?? null
+                : null,
+        [activeScreenShareCandidate, allScreenShareTracks],
+    );
 
-    const mainCameraTrack = remoteCameraTracks[0] ?? localCameraTrack;
+    useEffect(() => {
+        const nextOwnerId = activeScreenShareCandidate?.ownerId ?? null;
+        if (nextOwnerId !== activeScreenShareOwnerId) {
+            setActiveScreenShareOwnerId(nextOwnerId);
+        }
+    }, [activeScreenShareCandidate?.ownerId, activeScreenShareOwnerId]);
+
+    useEffect(() => {
+        const knownRemoteKeys = knownRemoteScreenShareKeysRef.current;
+        const latestNewRemote = [...remoteScreenShareTracks]
+            .reverse()
+            .find((track) => !knownRemoteKeys.has(getNativeScreenShareKey(track)));
+
+        knownRemoteScreenShareKeysRef.current = new Set(
+            remoteScreenShareTracks.map(getNativeScreenShareKey),
+        );
+
+        if (
+            latestNewRemote &&
+            localParticipant &&
+            shouldDisableLocalScreenShareForRemoteOwner(
+                localUserId,
+                latestNewRemote.participant.identity,
+                isScreenShareEnabled,
+            )
+        ) {
+            setActiveScreenShareOwnerId(latestNewRemote.participant.identity);
+            void localParticipant.setScreenShareEnabled(false).catch((error) => {
+                console.error("Failed to stop local screen share after remote owner changed", error);
+            });
+        }
+    }, [isScreenShareEnabled, localParticipant, localUserId, remoteScreenShareTracks]);
+
+    const mainCameraTrack = activeScreenShareTrack ?? remoteCameraTracks[0] ?? localCameraTrack;
     const thumbnailCameraTracks = useMemo(() => {
         if (!mainCameraTrack) {
             return [];
+        }
+
+        if (mainCameraTrack === activeScreenShareTrack) {
+            return [
+                ...remoteCameraTracks,
+                ...(localCameraTrack ? [localCameraTrack] : []),
+            ];
         }
 
         if (mainCameraTrack === localCameraTrack) {
@@ -116,7 +208,7 @@ const NativeRoomContent = ({
         }
 
         return localCameraTrack ? [...remoteCameraTracks.slice(1), localCameraTrack] : remoteCameraTracks.slice(1);
-    }, [remoteCameraTracks, localCameraTrack, mainCameraTrack]);
+    }, [activeScreenShareTrack, remoteCameraTracks, localCameraTrack, mainCameraTrack]);
 
     const toggleMicrophone = useCallback(async () => {
         if (!localParticipant) return;
@@ -166,11 +258,23 @@ const NativeRoomContent = ({
         if (!localParticipant || !isConnectedToCall) return;
 
         try {
-            await localParticipant.setScreenShareEnabled(!isScreenShareEnabled);
+            const next = !isScreenShareEnabled;
+            await localParticipant.setScreenShareEnabled(next);
+            if (next) {
+                setActiveScreenShareOwnerId(localUserId);
+            } else if (activeScreenShareOwnerId === localUserId) {
+                setActiveScreenShareOwnerId(null);
+            }
         } catch (error) {
             console.error("Failed to toggle screen share", error);
         }
-    }, [isScreenShareEnabled, isConnectedToCall, localParticipant]);
+    }, [
+        activeScreenShareOwnerId,
+        isConnectedToCall,
+        isScreenShareEnabled,
+        localParticipant,
+        localUserId,
+    ]);
 
     return (
         <View className="flex-1">
@@ -189,29 +293,22 @@ const NativeRoomContent = ({
                         mainTrack={mainCameraTrack}
                         thumbnailTracks={thumbnailCameraTracks}
                         mainPlaceholderLabel={callTitle}
-                        controls={
-                            isConnectedToCall ? (
-                                <MediaOverlayControls
-                                    cameraEnabled={isCameraEnabled}
-                                    screenShareEnabled={isScreenShareEnabled}
-                                    switchCameraAvailable={isCameraEnabled}
-                                    screenShareAvailable={isConnectedToCall}
-                                    busy={isLeaving}
-                                    onToggleCamera={toggleCamera}
-                                    onSwitchCamera={switchCamera}
-                                    onToggleScreenShare={toggleScreenShare}
-                                />
-                            ) : null
-                        }
                     />
                 )}
             </View>
 
             <CallControls
                 micEnabled={isMicrophoneEnabled}
+                cameraEnabled={isCameraEnabled}
+                screenShareEnabled={isScreenShareEnabled}
+                switchCameraAvailable={isCameraEnabled}
+                screenShareAvailable={isConnectedToCall}
                 busy={isLeaving}
                 isMobile={isMobile}
                 onToggleMicrophone={toggleMicrophone}
+                onToggleCamera={toggleCamera}
+                onSwitchCamera={switchCamera}
+                onToggleScreenShare={toggleScreenShare}
                 onOpenChat={() => setPanel(panel === "chat" ? "none" : "chat")}
                 onOpenParticipants={() =>
                     setPanel(panel === "participants" ? "none" : "participants")

--- a/apps/client/src/features/call/ui/CallRoom.web.tsx
+++ b/apps/client/src/features/call/ui/CallRoom.web.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import {
     ConnectionState,
     isBrowserSupported,
@@ -17,10 +17,14 @@ import {
     CallDrawer,
     CallErrorOverlay,
     CallLoadingOverlay,
-    MediaOverlayControls,
     SpeakingFrame,
     type CallPanel,
 } from "./CallRoomControls";
+import {
+    pickActiveScreenShare,
+    shouldDisableLocalScreenShareForRemoteOwner,
+    type ScreenShareCandidate,
+} from "./CallRoomMedia";
 
 type CameraFacingMode = "user" | "environment";
 
@@ -146,10 +150,12 @@ const VideoElement = ({
     track,
     muted,
     mirrored,
+    objectFit = "cover",
 }: {
     track: LocalVideoTrack | RemoteVideoTrack;
     muted?: boolean;
     mirrored?: boolean;
+    objectFit?: "cover" | "contain";
 }) => {
     const ref = useRef<HTMLVideoElement | null>(null);
 
@@ -176,7 +182,7 @@ const VideoElement = ({
             width: "100%",
             height: "100%",
             backgroundColor: "#000",
-            objectFit: "cover",
+            objectFit,
             transform: mirrored ? "scaleX(-1)" : undefined,
         },
     });
@@ -186,24 +192,14 @@ const ParticipantTile = ({
     participant,
     isVideoCall,
     localFacingMode,
-    isBusy,
-    switchCameraAvailable,
-    screenShareAvailable,
-    onToggleCamera,
-    onSwitchCamera,
-    onToggleScreenShare,
+    compact = false,
 }: {
     participant: ParticipantMediaInfo;
     isVideoCall: boolean;
     localFacingMode: CameraFacingMode;
-    isBusy: boolean;
-    switchCameraAvailable: boolean;
-    screenShareAvailable: boolean;
-    onToggleCamera: () => Promise<void>;
-    onSwitchCamera: () => Promise<void>;
-    onToggleScreenShare: () => Promise<void>;
+    compact?: boolean;
 }) => {
-    const visibleTrack = participant.screenTrack ?? participant.cameraTrack;
+    const visibleTrack = participant.cameraTrack;
     const shouldMirror =
         participant.isSelf &&
         visibleTrack === participant.cameraTrack &&
@@ -222,31 +218,16 @@ const ParticipantTile = ({
                     ) : (
                         <View className="items-center gap-3">
                             <Avatar
-                                size={96}
+                                size={compact ? 48 : 96}
                                 src={participant.avatarUrl}
                                 name={participant.displayName}
                             />
-                            <Text className="text-white text-base font-semibold">
+                            <Text className={`${compact ? "text-xs" : "text-base"} text-white font-semibold`}>
                                 {participant.displayName}
                             </Text>
                         </View>
                     )}
                 </View>
-
-                {participant.isSelf && isVideoCall ? (
-                    <View className="absolute right-3 top-3">
-                        <MediaOverlayControls
-                            cameraEnabled={participant.isCameraEnabled}
-                            screenShareEnabled={participant.isScreenShareEnabled}
-                            switchCameraAvailable={switchCameraAvailable}
-                            screenShareAvailable={screenShareAvailable}
-                            busy={isBusy}
-                            onToggleCamera={onToggleCamera}
-                            onSwitchCamera={onSwitchCamera}
-                            onToggleScreenShare={onToggleScreenShare}
-                        />
-                    </View>
-                ) : null}
 
                 <View className="absolute left-3 right-3 bottom-3 gap-2">
                     <View className="self-start rounded-full bg-black/65 px-3 py-1">
@@ -293,41 +274,135 @@ const CallStage = ({
     isVideoCall,
     isMobile,
     localFacingMode,
-    isBusy,
-    switchCameraAvailable,
-    screenShareAvailable,
-    onToggleCamera,
-    onSwitchCamera,
-    onToggleScreenShare,
+    activeScreenShare,
+    onOpenScreenShareFullscreen,
 }: {
     participants: ParticipantMediaInfo[];
     isVideoCall: boolean;
     isMobile: boolean;
     localFacingMode: CameraFacingMode;
-    isBusy: boolean;
-    switchCameraAvailable: boolean;
-    screenShareAvailable: boolean;
-    onToggleCamera: () => Promise<void>;
-    onSwitchCamera: () => Promise<void>;
-    onToggleScreenShare: () => Promise<void>;
-}) => (
-    <View className={`flex-1 p-3 gap-3 ${isMobile ? "" : "flex-row"}`}>
-        {participants.map((participant) => (
-            <ParticipantTile
-                key={participant.userId}
-                participant={participant}
-                isVideoCall={isVideoCall}
-                localFacingMode={localFacingMode}
-                isBusy={isBusy}
-                switchCameraAvailable={switchCameraAvailable}
-                screenShareAvailable={screenShareAvailable}
-                onToggleCamera={onToggleCamera}
-                onSwitchCamera={onSwitchCamera}
-                onToggleScreenShare={onToggleScreenShare}
-            />
-        ))}
-    </View>
-);
+    activeScreenShare: WebVideoTrackRef | null;
+    onOpenScreenShareFullscreen: () => void;
+}) => {
+    const screenOwner = activeScreenShare
+        ? participants.find((participant) => participant.userId === activeScreenShare.ownerId) ?? null
+        : null;
+
+    if (activeScreenShare && screenOwner) {
+        return (
+            <View className={`flex-1 gap-3 p-3 ${isMobile ? "" : "flex-row"}`}>
+                <View className="flex-1 rounded-[28px] overflow-hidden border border-white/10 bg-black">
+                    <View className="flex-1">
+                        <VideoElement
+                            track={activeScreenShare.track}
+                            muted={activeScreenShare.isLocal}
+                            objectFit="contain"
+                        />
+                        <View className="absolute left-4 top-4 rounded-full bg-black/70 px-3 py-1.5">
+                            <Text className="text-white text-xs font-semibold">
+                                {screenOwner.displayName} показывает экран
+                            </Text>
+                        </View>
+                        <Pressable
+                            testID="call-screen-fullscreen"
+                            accessibilityLabel="Открыть демонстрацию на весь экран"
+                            onPress={onOpenScreenShareFullscreen}
+                            className="absolute right-4 top-4 rounded-full bg-white/12 px-3 py-2"
+                        >
+                            <Text className="text-white text-xs font-semibold">Во весь экран</Text>
+                        </Pressable>
+                    </View>
+                </View>
+                <ParticipantRail
+                    participants={participants}
+                    isVideoCall={isVideoCall}
+                    isMobile={isMobile}
+                    localFacingMode={localFacingMode}
+                />
+            </View>
+        );
+    }
+
+    if (!isMobile && participants.length > 2) {
+        const primary =
+            participants.find((participant) => participant.isSpeaking) ??
+            participants.find((participant) => participant.cameraTrack) ??
+            participants[0];
+        const railParticipants = participants.filter(
+            (participant) => participant.userId !== primary.userId,
+        );
+
+        return (
+            <View className="flex-1 flex-row gap-3 p-3">
+                <ParticipantTile
+                    participant={primary}
+                    isVideoCall={isVideoCall}
+                    localFacingMode={localFacingMode}
+                />
+                <ParticipantRail
+                    participants={railParticipants}
+                    isVideoCall={isVideoCall}
+                    isMobile={isMobile}
+                    localFacingMode={localFacingMode}
+                />
+            </View>
+        );
+    }
+
+    return (
+        <View className={`flex-1 p-3 gap-3 ${isMobile ? "" : "flex-row"}`}>
+            {participants.map((participant) => (
+                <ParticipantTile
+                    key={participant.userId}
+                    participant={participant}
+                    isVideoCall={isVideoCall}
+                    localFacingMode={localFacingMode}
+                />
+            ))}
+        </View>
+    );
+};
+
+const ParticipantRail = ({
+    participants,
+    isVideoCall,
+    isMobile,
+    localFacingMode,
+}: {
+    participants: ParticipantMediaInfo[];
+    isVideoCall: boolean;
+    isMobile: boolean;
+    localFacingMode: CameraFacingMode;
+}) => {
+    const visibleParticipants = participants.slice(0, isMobile ? 4 : 6);
+    const overflow = Math.max(0, participants.length - visibleParticipants.length);
+
+    return (
+        <View
+            className={`gap-2 ${isMobile ? "flex-row h-28" : "w-24"}`}
+            testID="call-participant-rail"
+        >
+            {visibleParticipants.map((participant) => (
+                <View
+                    key={participant.userId}
+                    className={`${isMobile ? "w-24" : "h-20"} rounded-2xl overflow-hidden`}
+                >
+                    <ParticipantTile
+                        participant={participant}
+                        isVideoCall={isVideoCall}
+                        localFacingMode={localFacingMode}
+                        compact
+                    />
+                </View>
+            ))}
+            {overflow > 0 ? (
+                <View className={`${isMobile ? "w-20" : "h-14"} rounded-2xl bg-white/10 items-center justify-center`}>
+                    <Text className="text-white text-sm font-semibold">+{overflow}</Text>
+                </View>
+            ) : null}
+        </View>
+    );
+};
 
 export const CallRoom = ({
     call,
@@ -353,8 +428,13 @@ export const CallRoom = ({
     const [isCameraEnabled, setIsCameraEnabled] = useState(false);
     const [isScreenShareEnabled, setIsScreenShareEnabled] = useState(false);
     const [videoTracks, setVideoTracks] = useState<WebVideoTrackRef[]>([]);
+    const [activeSpeakerIds, setActiveSpeakerIds] = useState<Set<string>>(() => new Set());
+    const [activeScreenShareOwnerId, setActiveScreenShareOwnerId] = useState<string | null>(null);
+    const [isScreenShareFullscreen, setIsScreenShareFullscreen] = useState(false);
     const [facingMode, setFacingMode] = useState<CameraFacingMode>("user");
     const [videoInputCount, setVideoInputCount] = useState(0);
+    const knownRemoteScreenShareKeysRef = useRef<Set<string>>(new Set());
+    const browserFullscreenActiveRef = useRef(false);
 
     const isVideoCall = call.callType === "Video";
     const isConnectedToCall = call.status === "Active";
@@ -364,7 +444,8 @@ export const CallRoom = ({
             Boolean(navigator.mediaDevices?.getDisplayMedia),
         [],
     );
-    const canSwitchCamera = isMobile || videoInputCount > 1;
+    const canSwitchCamera = isMobile && videoInputCount > 1;
+    const localUserId = participantInfos.find((participant) => participant.isSelf)?.userId ?? null;
 
     const refreshVideoInputs = useCallback(async () => {
         try {
@@ -401,7 +482,7 @@ export const CallRoom = ({
         };
     }, [refreshVideoInputs]);
 
-    const syncRoomState = useCallback(() => {
+    const syncRoomState = useCallback((syncActiveSpeakers = true) => {
         const room = roomRef.current;
         if (!room) {
             setConnectionState(ConnectionState.Disconnected);
@@ -409,6 +490,7 @@ export const CallRoom = ({
             setIsCameraEnabled(false);
             setIsScreenShareEnabled(false);
             setVideoTracks([]);
+            setActiveSpeakerIds(new Set());
             return;
         }
 
@@ -417,6 +499,11 @@ export const CallRoom = ({
         setIsCameraEnabled(room.localParticipant.isCameraEnabled);
         setIsScreenShareEnabled(room.localParticipant.isScreenShareEnabled);
         setVideoTracks(collectVideoTracks(room, participantInfos));
+        if (syncActiveSpeakers) {
+            setActiveSpeakerIds(
+                new Set(room.activeSpeakers.map((speaker) => speaker.identity)),
+            );
+        }
         syncRemoteAudioTracks(room, remoteAudioElementsRef);
     }, [participantInfos]);
 
@@ -443,6 +530,14 @@ export const CallRoom = ({
                 syncRoomState();
             }
         };
+        const onActiveSpeakersChanged = (
+            speakers: Array<{ identity: string }>,
+        ) => {
+            if (isDisposed) return;
+
+            setActiveSpeakerIds(new Set(speakers.map((speaker) => speaker.identity)));
+            syncRoomState(false);
+        };
 
         room.on(RoomEvent.Connected, onRoomChanged);
         room.on(RoomEvent.ConnectionStateChanged, onRoomChanged);
@@ -454,7 +549,7 @@ export const CallRoom = ({
         room.on(RoomEvent.TrackUnmuted, onRoomChanged);
         room.on(RoomEvent.LocalTrackPublished, onRoomChanged);
         room.on(RoomEvent.LocalTrackUnpublished, onRoomChanged);
-        room.on(RoomEvent.ActiveSpeakersChanged, onRoomChanged);
+        room.on(RoomEvent.ActiveSpeakersChanged, onActiveSpeakersChanged);
         room.on(RoomEvent.Disconnected, onRoomChanged);
 
         void (async () => {
@@ -505,7 +600,7 @@ export const CallRoom = ({
             room.off(RoomEvent.TrackUnmuted, onRoomChanged);
             room.off(RoomEvent.LocalTrackPublished, onRoomChanged);
             room.off(RoomEvent.LocalTrackUnpublished, onRoomChanged);
-            room.off(RoomEvent.ActiveSpeakersChanged, onRoomChanged);
+            room.off(RoomEvent.ActiveSpeakersChanged, onActiveSpeakersChanged);
             room.off(RoomEvent.Disconnected, onRoomChanged);
             detachRemoteAudioTracks(remoteAudioElementsRef);
             void room.disconnect();
@@ -556,18 +651,87 @@ export const CallRoom = ({
                 isScreenShareEnabled: participant.isSelf
                     ? isScreenShareEnabled
                     : Boolean(liveParticipant?.isScreenShareEnabled || screenTrack),
-                isSpeaking: Boolean(liveParticipant?.isSpeaking),
+                isSpeaking: activeSpeakerIds.has(participant.userId) || Boolean(liveParticipant?.isSpeaking),
                 cameraTrack,
                 screenTrack,
             };
         });
     }, [
+        activeSpeakerIds,
         isCameraEnabled,
         isMicrophoneEnabled,
         isScreenShareEnabled,
         participantInfos,
         videoTracks,
     ]);
+
+    const screenShareCandidates = useMemo<ScreenShareCandidate[]>(
+        () =>
+            videoTracks
+                .filter((track) => track.source === Track.Source.ScreenShare)
+                .map((track) => ({
+                    ownerId: track.ownerId,
+                    key: track.key,
+                    isLocal: track.isLocal,
+                })),
+        [videoTracks],
+    );
+
+    const activeScreenShareCandidate = useMemo(
+        () =>
+            pickActiveScreenShare(
+                screenShareCandidates,
+                activeScreenShareOwnerId,
+                localUserId,
+            ),
+        [activeScreenShareOwnerId, localUserId, screenShareCandidates],
+    );
+
+    const activeScreenShareTrack = useMemo(
+        () =>
+            activeScreenShareCandidate
+                ? videoTracks.find((track) => track.key === activeScreenShareCandidate.key) ?? null
+                : null,
+        [activeScreenShareCandidate, videoTracks],
+    );
+
+    useEffect(() => {
+        const nextOwnerId = activeScreenShareCandidate?.ownerId ?? null;
+        if (nextOwnerId !== activeScreenShareOwnerId) {
+            setActiveScreenShareOwnerId(nextOwnerId);
+        }
+        if (!nextOwnerId) {
+            setIsScreenShareFullscreen(false);
+        }
+    }, [activeScreenShareCandidate?.ownerId, activeScreenShareOwnerId]);
+
+    useEffect(() => {
+        const remoteCandidates = screenShareCandidates.filter((candidate) => !candidate.isLocal);
+        const knownRemoteKeys = knownRemoteScreenShareKeysRef.current;
+        const latestNewRemote = [...remoteCandidates]
+            .reverse()
+            .find((candidate) => !knownRemoteKeys.has(candidate.key));
+
+        knownRemoteScreenShareKeysRef.current = new Set(
+            remoteCandidates.map((candidate) => candidate.key),
+        );
+
+        if (
+            latestNewRemote &&
+            shouldDisableLocalScreenShareForRemoteOwner(
+                localUserId,
+                latestNewRemote.ownerId,
+                isScreenShareEnabled,
+            )
+        ) {
+            setActiveScreenShareOwnerId(latestNewRemote.ownerId);
+            void roomRef.current?.localParticipant
+                .setScreenShareEnabled(false)
+                .catch((error) => {
+                    console.error("Failed to stop local screen share after remote owner changed", error);
+                });
+        }
+    }, [isScreenShareEnabled, localUserId, screenShareCandidates]);
 
     const toggleMicrophone = useCallback(async () => {
         const room = roomRef.current;
@@ -638,14 +802,21 @@ export const CallRoom = ({
         if (!room || !isConnectedToCall || !canShareScreen) return;
 
         try {
+            const next = !room.localParticipant.isScreenShareEnabled;
             await room.localParticipant.setScreenShareEnabled(
-                !room.localParticipant.isScreenShareEnabled,
+                next,
             );
+            if (next) {
+                setActiveScreenShareOwnerId(localUserId);
+            } else if (activeScreenShareOwnerId === localUserId) {
+                setActiveScreenShareOwnerId(null);
+                setIsScreenShareFullscreen(false);
+            }
             syncRoomState();
         } catch (error) {
             console.error("Failed to toggle screen share", error);
         }
-    }, [canShareScreen, isConnectedToCall, syncRoomState]);
+    }, [activeScreenShareOwnerId, canShareScreen, isConnectedToCall, localUserId, syncRoomState]);
 
     const connectionError = tokenError || loadError || roomError;
     const isConnecting =
@@ -653,6 +824,63 @@ export const CallRoom = ({
         (!!callToken?.token &&
             connectionState !== ConnectionState.Connected &&
             call.status === "Active");
+
+    const openScreenShareFullscreen = useCallback(() => {
+        if (!activeScreenShareTrack) return;
+
+        setPanel("none");
+        setIsScreenShareFullscreen(true);
+        const requestFullscreen = document.documentElement.requestFullscreen;
+        if (requestFullscreen) {
+            void requestFullscreen.call(document.documentElement)
+                .then(() => {
+                    browserFullscreenActiveRef.current = true;
+                })
+                .catch(() => {
+                    browserFullscreenActiveRef.current = false;
+                });
+        }
+    }, [activeScreenShareTrack]);
+
+    const closeScreenShareFullscreen = useCallback(() => {
+        setIsScreenShareFullscreen(false);
+        const shouldExitBrowserFullscreen =
+            browserFullscreenActiveRef.current && document.fullscreenElement;
+        browserFullscreenActiveRef.current = false;
+        if (shouldExitBrowserFullscreen) {
+            void document.exitFullscreen?.().catch(() => undefined);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!isScreenShareFullscreen) return undefined;
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                closeScreenShareFullscreen();
+            }
+        };
+        const onFullscreenChange = () => {
+            if (browserFullscreenActiveRef.current && !document.fullscreenElement) {
+                browserFullscreenActiveRef.current = false;
+                setIsScreenShareFullscreen(false);
+            }
+        };
+
+        window.addEventListener("keydown", onKeyDown);
+        document.addEventListener("fullscreenchange", onFullscreenChange);
+
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+            document.removeEventListener("fullscreenchange", onFullscreenChange);
+        };
+    }, [closeScreenShareFullscreen, isScreenShareFullscreen]);
+
+    useEffect(() => {
+        if (!activeScreenShareTrack && isScreenShareFullscreen) {
+            closeScreenShareFullscreen();
+        }
+    }, [activeScreenShareTrack, closeScreenShareFullscreen, isScreenShareFullscreen]);
 
     return (
         <View className="flex-1">
@@ -668,12 +896,8 @@ export const CallRoom = ({
                     isVideoCall={isConnectedToCall}
                     isMobile={isMobile}
                     localFacingMode={facingMode}
-                    isBusy={isLeaving}
-                    switchCameraAvailable={canSwitchCamera}
-                    screenShareAvailable={canShareScreen}
-                    onToggleCamera={toggleCamera}
-                    onSwitchCamera={switchCamera}
-                    onToggleScreenShare={toggleScreenShare}
+                    activeScreenShare={activeScreenShareTrack}
+                    onOpenScreenShareFullscreen={openScreenShareFullscreen}
                 />
 
                 {isConnecting ? <CallLoadingOverlay /> : null}
@@ -687,9 +911,16 @@ export const CallRoom = ({
 
             <CallControls
                 micEnabled={isMicrophoneEnabled}
+                cameraEnabled={isCameraEnabled}
+                screenShareEnabled={isScreenShareEnabled}
+                switchCameraAvailable={canSwitchCamera}
+                screenShareAvailable={canShareScreen}
                 busy={isLeaving}
                 isMobile={isMobile}
                 onToggleMicrophone={toggleMicrophone}
+                onToggleCamera={toggleCamera}
+                onSwitchCamera={switchCamera}
+                onToggleScreenShare={toggleScreenShare}
                 onOpenChat={() => setPanel(panel === "chat" ? "none" : "chat")}
                 onOpenParticipants={() =>
                     setPanel(panel === "participants" ? "none" : "participants")
@@ -704,6 +935,23 @@ export const CallRoom = ({
                 participantInfos={participantInfos}
                 onClose={() => setPanel("none")}
             />
+
+            {isScreenShareFullscreen && activeScreenShareTrack ? (
+                <View className="absolute inset-0 z-50 bg-black">
+                    <VideoElement
+                        track={activeScreenShareTrack.track}
+                        muted={activeScreenShareTrack.isLocal}
+                        objectFit="contain"
+                    />
+                    <Pressable
+                        accessibilityLabel="Закрыть полноэкранную демонстрацию"
+                        onPress={closeScreenShareFullscreen}
+                        className="absolute right-4 top-4 rounded-full bg-white/15 px-4 py-2"
+                    >
+                        <Text className="text-white text-sm font-semibold">Закрыть</Text>
+                    </Pressable>
+                </View>
+            ) : null}
         </View>
     );
 };

--- a/apps/client/src/features/call/ui/CallRoomControls.tsx
+++ b/apps/client/src/features/call/ui/CallRoomControls.tsx
@@ -121,7 +121,7 @@ const ControlButton = ({
         onPress={onPress}
         disabled={disabled || !onPress}
         className={`h-12 rounded-xl items-center justify-center gap-2 ${
-            showLabel ? "px-3 flex-1 flex-row" : "w-12"
+            showLabel ? "px-4 min-w-[82px] flex-row" : "w-12"
         } ${
             disabled
                 ? "bg-white/5"
@@ -146,81 +146,19 @@ const ControlButton = ({
     </Pressable>
 );
 
-const OverlayButton = ({
-    testID,
-    icon: Icon,
-    label,
-    isActive,
-    disabled,
-    onPress,
-}: {
-    testID: string;
-    icon: React.ComponentType<IconProps>;
-    label: string;
-    isActive?: boolean;
-    disabled?: boolean;
-    onPress?: () => void;
-}) => (
-    <Pressable
-        testID={testID}
-        accessibilityLabel={label}
-        onPress={onPress}
-        disabled={disabled || !onPress}
-        className={`h-11 w-11 rounded-full items-center justify-center border ${
-            disabled
-                ? "bg-black/35 border-white/10"
-                : isActive
-                  ? "bg-brand-600 border-brand-400/70"
-                  : "bg-black/65 border-white/15"
-        }`}
+const SpeakingIndicator = () => (
+    <View
+        accessible
+        accessibilityLabel="Сейчас говорит"
+        className="absolute left-3 top-3 z-10 h-8 w-8 rounded-full bg-emerald-500/95 items-center justify-center flex-row gap-0.5"
     >
-        <Icon size={19} className={disabled ? "text-white/35" : "text-white"} />
-    </Pressable>
-);
-
-export const MediaOverlayControls = ({
-    cameraEnabled,
-    screenShareEnabled,
-    switchCameraAvailable,
-    screenShareAvailable,
-    busy,
-    onToggleCamera,
-    onSwitchCamera,
-    onToggleScreenShare,
-}: {
-    cameraEnabled: boolean;
-    screenShareEnabled: boolean;
-    switchCameraAvailable: boolean;
-    screenShareAvailable: boolean;
-    busy: boolean;
-    onToggleCamera: () => Promise<void> | void;
-    onSwitchCamera: () => Promise<void> | void;
-    onToggleScreenShare: () => Promise<void> | void;
-}) => (
-    <View className="flex-row gap-2 rounded-full bg-black/25 p-1">
-        <OverlayButton
-            testID="call-media-camera"
-            icon={VideoCameraIcon}
-            label="Камера"
-            onPress={onToggleCamera}
-            isActive={cameraEnabled}
-            disabled={busy}
-        />
-        <OverlayButton
-            testID="call-media-switch-camera"
-            icon={ArrowsClockwiseIcon}
-            label="Сменить камеру"
-            onPress={onSwitchCamera}
-            disabled={busy || !cameraEnabled || !switchCameraAvailable}
-        />
-        <OverlayButton
-            testID="call-media-screen"
-            icon={ScreencastIcon}
-            label="Экран"
-            onPress={onToggleScreenShare}
-            isActive={screenShareEnabled}
-            disabled={busy || !screenShareAvailable}
-        />
+        {[10, 16, 12].map((height, index) => (
+            <View
+                key={index}
+                className="w-1 rounded-full bg-white animate-pulse"
+                style={{ height }}
+            />
+        ))}
     </View>
 );
 
@@ -246,28 +184,38 @@ export const SpeakingFrame = ({
                 : undefined
         }
     >
-        {isSpeaking ? (
-            <View className="absolute left-3 top-3 z-10 rounded-full bg-emerald-500/95 px-2 py-1">
-                <Text className="text-white text-[11px] font-semibold">Говорит</Text>
-            </View>
-        ) : null}
+        {isSpeaking ? <SpeakingIndicator /> : null}
         {children}
     </View>
 );
 
 export const CallControls = ({
     micEnabled,
+    cameraEnabled,
+    screenShareEnabled,
+    switchCameraAvailable,
+    screenShareAvailable,
     busy,
     isMobile,
     onToggleMicrophone,
+    onToggleCamera,
+    onSwitchCamera,
+    onToggleScreenShare,
     onOpenChat,
     onOpenParticipants,
     onLeave,
 }: {
     micEnabled: boolean;
+    cameraEnabled: boolean;
+    screenShareEnabled: boolean;
+    switchCameraAvailable: boolean;
+    screenShareAvailable: boolean;
     busy: boolean;
     isMobile: boolean;
     onToggleMicrophone: () => Promise<void>;
+    onToggleCamera: () => Promise<void> | void;
+    onSwitchCamera: () => Promise<void> | void;
+    onToggleScreenShare: () => Promise<void> | void;
     onOpenChat: () => void;
     onOpenParticipants: () => void;
     onLeave: () => void;
@@ -275,38 +223,68 @@ export const CallControls = ({
     const showLabel = !isMobile;
 
     return (
-        <View className="border-t border-white/10 px-3 pb-3 pt-2 flex-row gap-2 items-center justify-center">
-            <ControlButton
-                testID="call-control-mic"
-                icon={micEnabled ? MicrophoneIcon : MicrophoneSlashIcon}
-                label="Микрофон"
-                onPress={onToggleMicrophone}
-                isActive={micEnabled}
-                disabled={busy}
-                showLabel={showLabel}
-            />
-            <ControlButton
-                testID="call-control-chat"
-                icon={ChatCircleTextIcon}
-                label="Чат"
-                onPress={onOpenChat}
-                showLabel={showLabel}
-            />
-            <ControlButton
-                testID="call-control-more"
-                icon={DotsThreeVerticalIcon}
-                onPress={onOpenParticipants}
-                showLabel={false}
-            />
-            <ControlButton
-                testID="call-control-leave"
-                icon={PhoneDisconnectIcon}
-                label="Завершить"
-                onPress={onLeave}
-                danger
-                disabled={busy}
-                showLabel={showLabel}
-            />
+        <View className="px-3 pb-4 pt-2 items-center justify-center">
+            <View className="max-w-full rounded-[28px] border border-white/10 bg-app-card/95 p-2 flex-row gap-2 items-center justify-center">
+                <ControlButton
+                    testID="call-control-mic"
+                    icon={micEnabled ? MicrophoneIcon : MicrophoneSlashIcon}
+                    label="Микрофон"
+                    onPress={onToggleMicrophone}
+                    isActive={micEnabled}
+                    disabled={busy}
+                    showLabel={showLabel}
+                />
+                <ControlButton
+                    testID="call-control-camera"
+                    icon={VideoCameraIcon}
+                    label="Камера"
+                    onPress={onToggleCamera}
+                    isActive={cameraEnabled}
+                    disabled={busy}
+                    showLabel={showLabel}
+                />
+                {isMobile && switchCameraAvailable ? (
+                    <ControlButton
+                        testID="call-control-switch-camera"
+                        icon={ArrowsClockwiseIcon}
+                        label="Сменить камеру"
+                        onPress={onSwitchCamera}
+                        disabled={busy || !cameraEnabled}
+                        showLabel={showLabel}
+                    />
+                ) : null}
+                <ControlButton
+                    testID="call-control-screen"
+                    icon={ScreencastIcon}
+                    label="Экран"
+                    onPress={onToggleScreenShare}
+                    isActive={screenShareEnabled}
+                    disabled={busy || !screenShareAvailable}
+                    showLabel={showLabel}
+                />
+                <ControlButton
+                    testID="call-control-chat"
+                    icon={ChatCircleTextIcon}
+                    label="Чат"
+                    onPress={onOpenChat}
+                    showLabel={showLabel}
+                />
+                <ControlButton
+                    testID="call-control-more"
+                    icon={DotsThreeVerticalIcon}
+                    onPress={onOpenParticipants}
+                    showLabel={false}
+                />
+                <ControlButton
+                    testID="call-control-leave"
+                    icon={PhoneDisconnectIcon}
+                    label="Завершить"
+                    onPress={onLeave}
+                    danger
+                    disabled={busy}
+                    showLabel={showLabel}
+                />
+            </View>
         </View>
     );
 };
@@ -328,8 +306,10 @@ export const CallDrawer = ({
 
     return (
         <View
-            className={`absolute inset-y-0 right-0 ${
-                isMobile ? "w-full" : "w-96"
+            className={`absolute z-40 ${
+                isMobile
+                    ? "inset-x-0 top-0 bottom-24"
+                    : "inset-y-0 right-0 w-96"
             } bg-app-card border-l border-white/10`}
         >
             {panel === "participants" ? (

--- a/apps/client/src/features/call/ui/CallRoomMedia.ts
+++ b/apps/client/src/features/call/ui/CallRoomMedia.ts
@@ -1,0 +1,39 @@
+export type ScreenShareCandidate = {
+    ownerId: string;
+    key: string;
+    isLocal: boolean;
+};
+
+export const pickActiveScreenShare = (
+    candidates: ScreenShareCandidate[],
+    previousOwnerId: string | null,
+    localUserId: string | null,
+): ScreenShareCandidate | null => {
+    if (candidates.length === 0) return null;
+
+    const previousCandidate = previousOwnerId
+        ? candidates.find((candidate) => candidate.ownerId === previousOwnerId)
+        : undefined;
+    if (previousCandidate && candidates[candidates.length - 1]?.ownerId === previousOwnerId) {
+        return previousCandidate;
+    }
+
+    const localCandidate = localUserId
+        ? candidates.find((candidate) => candidate.isLocal && candidate.ownerId === localUserId)
+        : undefined;
+    if (localCandidate) return localCandidate;
+
+    return candidates[candidates.length - 1] ?? null;
+};
+
+export const shouldDisableLocalScreenShareForRemoteOwner = (
+    localUserId: string | null,
+    activeOwnerId: string | null,
+    localScreenShareEnabled: boolean,
+) =>
+    Boolean(
+        localUserId &&
+        activeOwnerId &&
+        activeOwnerId !== localUserId &&
+        localScreenShareEnabled,
+    );

--- a/apps/client/src/features/call/ui/CallScreenBase.tsx
+++ b/apps/client/src/features/call/ui/CallScreenBase.tsx
@@ -12,6 +12,7 @@ import {
     useParticipantsStore,
 } from "@/entities/conversation/model/participants-store";
 import { useCurrentUserId } from "@/shared/store/auth-store";
+import { useCurrentUser } from "@/entities/user";
 import { playCallSound } from "@/shared/lib/call-sounds";
 import { CallRoom } from "./CallRoom";
 import type { ParticipantInfo } from "./CallRoom.types";
@@ -42,6 +43,7 @@ export const CallScreen = () => {
     const callId = normalizeId(id);
     const { isMobile } = useWindowSize();
     const currentUserId = useCurrentUserId();
+    const { data: currentUser } = useCurrentUser();
 
     const loadCall = useCallStore((state) => state.loadCall);
     const setActiveCall = useCallStore((state) => state.setActiveCall);
@@ -99,18 +101,29 @@ export const CallScreen = () => {
                 (entry) => entry.userId === userId,
             );
             const isSelf = userId === currentUserId;
+            const displayName = conversationParticipant?.displayName?.trim()
+                || (isSelf ? currentUser?.identity.name?.trim() : null)
+                || "Участник";
+            const avatarUrl = conversationParticipant?.avatarUrl
+                || (isSelf ? currentUser?.account.avatarUrl : null)
+                || null;
 
             return {
                 userId,
-                displayName: isSelf
-                    ? "Вы"
-                    : conversationParticipant?.displayName || "Участник",
-                avatarUrl: conversationParticipant?.avatarUrl ?? null,
+                displayName,
+                avatarUrl,
                 isSelf,
                 isConnected: Boolean(connectedByUserId.get(userId)),
             };
         });
-    }, [call?.participantIds, call?.participants, conversationParticipants, currentUserId]);
+    }, [
+        call?.participantIds,
+        call?.participants,
+        conversationParticipants,
+        currentUser?.account.avatarUrl,
+        currentUser?.identity.name,
+        currentUserId,
+    ]);
 
     const statusText = useMemo(() => {
         if (!call) {

--- a/apps/client/src/features/call/ui/__tests__/CallRoomControls.test.tsx
+++ b/apps/client/src/features/call/ui/__tests__/CallRoomControls.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import {
     CallControls,
-    MediaOverlayControls,
     SpeakingFrame,
 } from "../CallRoomControls";
 
@@ -42,13 +41,23 @@ jest.mock("../CallChatPanel", () => ({
 }));
 
 describe("CallRoomControls", () => {
-    it("keeps video controls out of the bottom bar", () => {
+    it("renders media controls in the bottom bar", () => {
+        const onToggleCamera = jest.fn();
+        const onToggleScreenShare = jest.fn();
+
         render(
             <CallControls
                 micEnabled
+                cameraEnabled={false}
+                screenShareEnabled={false}
+                switchCameraAvailable={false}
+                screenShareAvailable
                 busy={false}
                 isMobile={false}
                 onToggleMicrophone={jest.fn()}
+                onToggleCamera={onToggleCamera}
+                onSwitchCamera={jest.fn()}
+                onToggleScreenShare={onToggleScreenShare}
                 onOpenChat={jest.fn()}
                 onOpenParticipants={jest.fn()}
                 onLeave={jest.fn()}
@@ -56,42 +65,44 @@ describe("CallRoomControls", () => {
         );
 
         expect(screen.getByTestId("call-control-mic")).toBeTruthy();
+        expect(screen.getByTestId("call-control-camera")).toBeTruthy();
+        expect(screen.getByTestId("call-control-screen")).toBeTruthy();
         expect(screen.getByTestId("call-control-chat")).toBeTruthy();
         expect(screen.getByTestId("call-control-more")).toBeTruthy();
         expect(screen.getByTestId("call-control-leave")).toBeTruthy();
-        expect(screen.queryByTestId("call-control-camera")).toBeNull();
         expect(screen.queryByTestId("call-control-switch-camera")).toBeNull();
-        expect(screen.queryByTestId("call-control-screen")).toBeNull();
-        expect(screen.queryByText("Камера")).toBeNull();
+        expect(screen.getByText("Камера")).toBeTruthy();
+        expect(screen.getByText("Экран")).toBeTruthy();
         expect(screen.queryByText("Сменить камеру")).toBeNull();
-        expect(screen.queryByText("Экран")).toBeNull();
+
+        fireEvent.press(screen.getByTestId("call-control-camera"));
+        fireEvent.press(screen.getByTestId("call-control-screen"));
+
+        expect(onToggleCamera).toHaveBeenCalledTimes(1);
+        expect(onToggleScreenShare).toHaveBeenCalledTimes(1);
     });
 
-    it("renders camera actions as icon-only overlay controls", () => {
-        const onToggleCamera = jest.fn();
-        const onSwitchCamera = jest.fn();
-        const onToggleScreenShare = jest.fn();
-
+    it("renders switch camera only for mobile controls", () => {
         render(
-            <MediaOverlayControls
+            <CallControls
+                micEnabled
                 cameraEnabled
                 screenShareEnabled={false}
                 switchCameraAvailable
                 screenShareAvailable
                 busy={false}
-                onToggleCamera={onToggleCamera}
-                onSwitchCamera={onSwitchCamera}
-                onToggleScreenShare={onToggleScreenShare}
+                isMobile
+                onToggleMicrophone={jest.fn()}
+                onToggleCamera={jest.fn()}
+                onSwitchCamera={jest.fn()}
+                onToggleScreenShare={jest.fn()}
+                onOpenChat={jest.fn()}
+                onOpenParticipants={jest.fn()}
+                onLeave={jest.fn()}
             />,
         );
 
-        fireEvent.press(screen.getByTestId("call-media-camera"));
-        fireEvent.press(screen.getByTestId("call-media-switch-camera"));
-        fireEvent.press(screen.getByTestId("call-media-screen"));
-
-        expect(onToggleCamera).toHaveBeenCalledTimes(1);
-        expect(onSwitchCamera).toHaveBeenCalledTimes(1);
-        expect(onToggleScreenShare).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId("call-control-switch-camera")).toBeTruthy();
         expect(screen.queryByText("Камера")).toBeNull();
         expect(screen.queryByText("Сменить камеру")).toBeNull();
         expect(screen.queryByText("Экран")).toBeNull();
@@ -112,6 +123,7 @@ describe("CallRoomControls", () => {
             </SpeakingFrame>,
         );
 
-        expect(screen.getByText("Говорит")).toBeTruthy();
+        expect(screen.queryByText("Говорит")).toBeNull();
+        expect(screen.getByLabelText("Сейчас говорит")).toBeTruthy();
     });
 });

--- a/apps/client/src/features/call/ui/__tests__/CallRoomMedia.test.ts
+++ b/apps/client/src/features/call/ui/__tests__/CallRoomMedia.test.ts
@@ -1,0 +1,66 @@
+import {
+    pickActiveScreenShare,
+    shouldDisableLocalScreenShareForRemoteOwner,
+    type ScreenShareCandidate,
+} from "../CallRoomMedia";
+
+const candidate = (
+    ownerId: string,
+    key: string,
+    isLocal = false,
+): ScreenShareCandidate => ({
+    ownerId,
+    key,
+    isLocal,
+});
+
+describe("CallRoomMedia", () => {
+    it("keeps the local presenter as active immediately after local screen share starts", () => {
+        expect(
+            pickActiveScreenShare(
+                [
+                    candidate("remote-1", "remote-old"),
+                    candidate("user-1", "local-new", true),
+                ],
+                "user-1",
+                "user-1",
+            ),
+        ).toEqual(candidate("user-1", "local-new", true));
+    });
+
+    it("keeps a remote winner while the local screen share is being unpublished", () => {
+        expect(
+            pickActiveScreenShare(
+                [
+                    candidate("remote-1", "remote-old"),
+                    candidate("user-1", "local-pending-stop", true),
+                    candidate("remote-2", "remote-new"),
+                ],
+                "remote-2",
+                "user-1",
+            ),
+        ).toEqual(candidate("remote-2", "remote-new"));
+    });
+
+    it("uses last remote presenter when multiple remote screen shares race", () => {
+        expect(
+            pickActiveScreenShare(
+                [
+                    candidate("remote-1", "remote-old"),
+                    candidate("remote-2", "remote-new"),
+                ],
+                "remote-1",
+                "user-1",
+            ),
+        ).toEqual(candidate("remote-2", "remote-new"));
+    });
+
+    it("tells the local client to stop sharing when a remote owner wins", () => {
+        expect(shouldDisableLocalScreenShareForRemoteOwner("user-1", "remote-2", true))
+            .toBe(true);
+        expect(shouldDisableLocalScreenShareForRemoteOwner("user-1", "user-1", true))
+            .toBe(false);
+        expect(shouldDisableLocalScreenShareForRemoteOwner("user-1", "remote-2", false))
+            .toBe(false);
+    });
+});

--- a/apps/client/src/features/call/ui/__tests__/CallScreen.test.tsx
+++ b/apps/client/src/features/call/ui/__tests__/CallScreen.test.tsx
@@ -70,6 +70,23 @@ jest.mock("@/shared/store/auth-store", () => ({
     useCurrentUserId: () => "user-1",
 }));
 
+jest.mock("@/entities/user", () => ({
+    useCurrentUser: () => ({
+        data: {
+            userId: "user-1",
+            identity: {
+                name: "Current User",
+                email: "current@example.test",
+                username: "current",
+            },
+            account: {
+                avatarUrl: "https://cdn.test/current.png",
+                aboutMe: null,
+            },
+        },
+    }),
+}));
+
 jest.mock("@/entities/call", () => ({
     useCallStore: (selector: (state: typeof mockCallState) => unknown) =>
         selector(mockCallState),
@@ -86,8 +103,8 @@ jest.mock("@/entities/conversation/model/chat-store", () => ({
 
 jest.mock("@/entities/conversation/model/participants-store", () => ({
     useConversationParticipants: () => [
-        { userId: "user-1", displayName: "Current User" },
-        { userId: "user-2", displayName: "Second User" },
+        { userId: "user-1", displayName: "Current User", avatarUrl: "" },
+        { userId: "user-2", displayName: "Second User", avatarUrl: "https://cdn.test/second.png" },
     ],
     useParticipantsStore: {
         getState: () => ({ load: mockLoadParticipants }),
@@ -95,9 +112,21 @@ jest.mock("@/entities/conversation/model/participants-store", () => ({
 }));
 
 jest.mock("../CallRoom", () => ({
-    CallRoom: ({ call }: { call: CallSessionDto }) => {
+    CallRoom: ({
+        call,
+        participantInfos,
+    }: {
+        call: CallSessionDto;
+        participantInfos: Array<{ userId: string; displayName: string; avatarUrl?: string | null; isSelf: boolean }>;
+    }) => {
         const { Text } = require("react-native");
-        return <Text>LiveKit room for {call.id}</Text>;
+        const self = participantInfos.find((participant) => participant.isSelf);
+        return (
+            <>
+                <Text>LiveKit room for {call.id}</Text>
+                <Text>{`self:${self?.displayName}:${self?.avatarUrl}`}</Text>
+            </>
+        );
     },
 }));
 
@@ -124,5 +153,12 @@ describe("CallScreen", () => {
         expect(
             screen.queryByText("Звонки в веб-версии временно недоступны"),
         ).toBeNull();
+    });
+
+    it("renders the current user like a normal participant with profile avatar fallback", () => {
+        render(<CallScreen />);
+
+        expect(screen.getByText("self:Current User:https://cdn.test/current.png")).toBeTruthy();
+        expect(screen.queryByText("self:Вы:https://cdn.test/current.png")).toBeNull();
     });
 });

--- a/apps/client/src/shared/api/inbox.ts
+++ b/apps/client/src/shared/api/inbox.ts
@@ -30,6 +30,7 @@ export const inboxApi = {
                 time: formatTime(item.lastOccurrenceAtUtc),
                 scope: inferNotificationScope({ ...item, deepLink }),
                 deepLink,
+                data: item.data,
                 actorName: item.actor?.displayName ?? null,
                 isRead: item.readAtUtc !== null,
             };

--- a/apps/client/src/shared/lib/__tests__/browser-notifications.test.ts
+++ b/apps/client/src/shared/lib/__tests__/browser-notifications.test.ts
@@ -268,4 +268,86 @@ describe("browser notifications", () => {
         expect(showServerBrowserNotification({ ...notification, id: "notification-2" })).toBe(false);
         expect(instances).toHaveLength(1);
     });
+
+    it("routes server call notifications to the source chat when conversation data is available", () => {
+        const navigate = jest.fn();
+        setBrowserNotificationNavigationForTests(navigate);
+
+        const notification: NotificationDto = {
+            id: "notification-call",
+            recipientUserId: "user-1",
+            type: "call.missed",
+            category: 11,
+            severity: 1,
+            title: "Пропущенный звонок",
+            body: "Звонок остался без ответа",
+            imageUrl: null,
+            deepLink: "urfulink://call/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/missed",
+            data: {
+                conversationId: "direct-1",
+                callId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+            actor: null,
+            entity: null,
+            actions: [],
+            groupKey: null,
+            occurrenceCount: 1,
+            createdAtUtc: "2026-05-24T10:03:00.000Z",
+            lastOccurrenceAtUtc: "2026-05-24T10:03:00.000Z",
+            readAtUtc: null,
+            seenAtUtc: null,
+            savedAtUtc: null,
+            doneAtUtc: null,
+            archivedAtUtc: null,
+            snoozedUntilUtc: null,
+            expiresAtUtc: null,
+        };
+
+        expect(showServerBrowserNotification(notification)).toBe(true);
+
+        instances[0].onclick?.();
+
+        expect(navigate).toHaveBeenCalledWith("/chats/direct-1");
+        expect(navigate).not.toHaveBeenCalledWith(expect.stringContaining("/call/"));
+    });
+
+    it("shows stale server call notifications without opening the call screen", () => {
+        const navigate = jest.fn();
+        setBrowserNotificationNavigationForTests(navigate);
+
+        const notification: NotificationDto = {
+            id: "notification-call",
+            recipientUserId: "user-1",
+            type: "call.missed",
+            category: 11,
+            severity: 1,
+            title: "Пропущенный звонок",
+            body: "Звонок остался без ответа",
+            imageUrl: null,
+            deepLink: "urfulink://call/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/missed",
+            data: {
+                callId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+            actor: null,
+            entity: null,
+            actions: [],
+            groupKey: null,
+            occurrenceCount: 1,
+            createdAtUtc: "2026-05-24T10:03:00.000Z",
+            lastOccurrenceAtUtc: "2026-05-24T10:03:00.000Z",
+            readAtUtc: null,
+            seenAtUtc: null,
+            savedAtUtc: null,
+            doneAtUtc: null,
+            archivedAtUtc: null,
+            snoozedUntilUtc: null,
+            expiresAtUtc: null,
+        };
+
+        expect(showServerBrowserNotification(notification)).toBe(true);
+
+        instances[0].onclick?.();
+
+        expect(navigate).not.toHaveBeenCalled();
+    });
 });

--- a/apps/client/src/shared/lib/__tests__/notificationDeepLink.test.ts
+++ b/apps/client/src/shared/lib/__tests__/notificationDeepLink.test.ts
@@ -8,7 +8,6 @@ const hyphenatedGuid = "3f7d3e57-b4f5-481e-93a1-c8e9b4d70a11";
 const compactRootId = "11111111222233334444555555555555";
 const compactReplyId = "aaaaaaaa111122223333bbbbbbbbbbbb";
 const compactCallId = "abcd1234abcdabcdabcdabcdabcdabcd";
-const hyphenatedCallId = "abcd1234-abcd-abcd-abcd-abcdabcdabcd";
 
 describe("resolveNotificationDeepLink", () => {
     it("routes direct chat message notifications to the message in the chat", () => {
@@ -72,15 +71,39 @@ describe("resolveNotificationDeepLink", () => {
             });
     });
 
-    it("routes call links directly to the call screen", () => {
+    it("does not route stale call links without a source conversation", () => {
         expect(resolveNotificationDeepLink(`urfulink://call/${compactCallId}`, "chats"))
-            .toEqual({
-                href: `/call/${hyphenatedCallId}`,
-            });
+            .toBeNull();
 
         expect(resolveNotificationDeepLink(`urfulink://call/${compactCallId}/ended`, "chats"))
+            .toBeNull();
+    });
+
+    it("routes call links with source conversation data to the chat instead of the call screen", () => {
+        expect(
+            resolveNotificationDeepLink(
+                `urfulink://call/${compactCallId}/missed`,
+                "chats",
+                { conversationId: "direct-1" },
+            ),
+        )
             .toEqual({
-                href: `/call/${hyphenatedCallId}`,
+                href: "/chats/direct-1",
+            });
+
+        expect(
+            resolveNotificationDeepLink(
+                `urfulink://call/${compactCallId}/missed`,
+                "chats",
+                {
+                    conversationId: "direct-1",
+                    messageId: compactGuid,
+                },
+            ),
+        )
+            .toEqual({
+                href: `/chats/direct-1?message=${hyphenatedGuid}`,
+                messageId: hyphenatedGuid,
             });
     });
 

--- a/apps/client/src/shared/lib/browser-notifications.ts
+++ b/apps/client/src/shared/lib/browser-notifications.ts
@@ -127,7 +127,7 @@ export const showMessageBrowserNotification = (
 
 export const showServerBrowserNotification = (notification: NotificationDto) => {
     const scope = inferNotificationScope(notification);
-    const target = resolveNotificationDeepLink(notification.deepLink, scope);
+    const target = resolveNotificationDeepLink(notification.deepLink, scope, notification.data);
     const conversationId = notification.data.conversationId;
     const messageId = notification.data.messageId;
     const conversationMessageKey = buildConversationMessageKey(conversationId, messageId);

--- a/apps/client/src/shared/lib/notificationDeepLink.ts
+++ b/apps/client/src/shared/lib/notificationDeepLink.ts
@@ -143,9 +143,20 @@ const resolveMediaLink = (segments: string[]): NotificationNavigationTarget => (
     }),
 });
 
-const resolveCallLink = (segments: string[]): NotificationNavigationTarget => ({
-    href: segments[0] ? `/call/${toHyphenatedGuidIfCompact(segments[0])}` as Href : "/call" as Href,
-});
+const resolveCallLink = (
+    scope: InboxScope,
+    data?: Record<string, string> | null,
+): NotificationNavigationTarget | null => {
+    const conversationId = data?.conversationId;
+    if (!conversationId) return null;
+
+    const messageId = data.messageId ? toHyphenatedGuidIfCompact(data.messageId) : undefined;
+
+    return {
+        href: resolveConversationHref(conversationId, scope, { message: messageId }),
+        messageId,
+    };
+};
 
 const resolveSystemLink = (segments: string[]): NotificationNavigationTarget => ({
     href: buildHref("/profile/notifications", {
@@ -157,6 +168,7 @@ const resolveSystemLink = (segments: string[]): NotificationNavigationTarget => 
 export const resolveNotificationDeepLink = (
     deepLink: string | null | undefined,
     scope: InboxScope,
+    data?: Record<string, string> | null,
 ): NotificationNavigationTarget | null => {
     const parsed = parseDeepLink(deepLink);
     if (!parsed) return null;
@@ -169,7 +181,7 @@ export const resolveNotificationDeepLink = (
         case "media":
             return resolveMediaLink(parsed.segments);
         case "call":
-            return resolveCallLink(parsed.segments);
+            return resolveCallLink(scope, data);
         case "account":
             return { href: "/profile" as Href };
         case "system":
@@ -182,11 +194,15 @@ export const resolveNotificationDeepLink = (
 };
 
 export const inferNotificationScope = (
-    notification: Pick<NotificationDto, "category" | "deepLink" | "type">,
+    notification: Pick<NotificationDto, "category" | "deepLink" | "type"> & {
+        data?: Record<string, string> | null;
+    },
 ): InboxScope => {
     const parsed = parseDeepLink(notification.deepLink);
+    const dataConversationId = notification.data?.conversationId;
 
     if (parsed?.host === "discipline") return "subjects";
+    if (dataConversationId && isDisciplineConversationId(dataConversationId)) return "subjects";
     if (
         parsed?.host === "chat" &&
         parsed.segments[0] === "conv" &&

--- a/apps/client/src/widgets/inbox/ui/InboxLayout.tsx
+++ b/apps/client/src/widgets/inbox/ui/InboxLayout.tsx
@@ -109,6 +109,7 @@ export const InboxLayout = () => {
             const target = resolveNotificationDeepLink(
                 notification.deepLink,
                 notification.scope,
+                notification.data,
             );
             if (!target) return;
 

--- a/apps/client/src/widgets/inbox/ui/__tests__/InboxLayout.test.tsx
+++ b/apps/client/src/widgets/inbox/ui/__tests__/InboxLayout.test.tsx
@@ -10,6 +10,22 @@ const mockSetPendingScrollToMessageId = jest.fn();
 const mockRouterPush = jest.fn();
 let mockCurrentView: "messages" | "notifications" = "messages";
 let mockCurrentTab: "chats" | "subjects" = "chats";
+let mockNotifications: any[] = [
+    {
+        id: "notification-1",
+        title: "Новое сообщение",
+        description: "Иван написал вам",
+        time: "12:10",
+        scope: "chats",
+        deepLink:
+            "urfulink://chat/conv/direct-1/msg/3f7d3e57b4f5481e93a1c8e9b4d70a11",
+        data: {
+            conversationId: "direct-1",
+            messageId: "3f7d3e57b4f5481e93a1c8e9b4d70a11",
+        },
+        isRead: false,
+    },
+];
 
 jest.mock("expo-router", () => ({
     router: {
@@ -77,18 +93,7 @@ jest.mock("@/entities/conversation/model/chat-store", () => ({
 jest.mock("@/shared/store/useInboxStore", () => ({
     useInboxStore: (selector: (state: unknown) => unknown) =>
         selector({
-            notifications: [
-                {
-                    id: "notification-1",
-                    title: "Новое сообщение",
-                    description: "Иван написал вам",
-                    time: "12:10",
-                    scope: "chats",
-                    deepLink:
-                        "urfulink://chat/conv/direct-1/msg/3f7d3e57b4f5481e93a1c8e9b4d70a11",
-                    isRead: false,
-                },
-            ],
+            notifications: mockNotifications,
             isNotificationsLoading: false,
             isMarkingAllNotificationsRead: false,
             fetchNotifications: mockFetchNotifications,
@@ -128,6 +133,22 @@ describe("InboxLayout navigation", () => {
         jest.clearAllMocks();
         mockCurrentView = "messages";
         mockCurrentTab = "chats";
+        mockNotifications = [
+            {
+                id: "notification-1",
+                title: "Новое сообщение",
+                description: "Иван написал вам",
+                time: "12:10",
+                scope: "chats",
+                deepLink:
+                    "urfulink://chat/conv/direct-1/msg/3f7d3e57b4f5481e93a1c8e9b4d70a11",
+                data: {
+                    conversationId: "direct-1",
+                    messageId: "3f7d3e57b4f5481e93a1c8e9b4d70a11",
+                },
+                isRead: false,
+            },
+        ];
     });
 
     it("reopens a chat even if the row is still marked active", () => {
@@ -152,5 +173,31 @@ describe("InboxLayout navigation", () => {
         expect(mockRouterPush).toHaveBeenCalledWith(
             "/chats/direct-1?message=3f7d3e57-b4f5-481e-93a1-c8e9b4d70a11",
         );
+    });
+
+    it("marks stale call notifications read without opening a call screen", () => {
+        mockCurrentView = "notifications";
+        mockNotifications = [
+            {
+                id: "notification-call",
+                title: "Пропущенный звонок",
+                description: "Звонок остался без ответа",
+                time: "12:10",
+                scope: "chats",
+                deepLink: "urfulink://call/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/missed",
+                data: {
+                    callId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                },
+                isRead: false,
+            },
+        ];
+
+        render(<InboxLayout />);
+
+        fireEvent.press(screen.getByTestId("inbox-notification-row"));
+
+        expect(mockMarkNotificationRead).toHaveBeenCalledWith("notification-call");
+        expect(mockSetPendingScrollToMessageId).not.toHaveBeenCalled();
+        expect(mockRouterPush).not.toHaveBeenCalled();
     });
 });

--- a/src/Services/Notification/NotificationService.Api/Application/Handlers/Call/CallIncomingHandler.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Handlers/Call/CallIncomingHandler.cs
@@ -6,7 +6,9 @@ using Urfu.Link.Services.Notification.Domain.ValueObjects;
 
 namespace Urfu.Link.Services.Notification.Application.Handlers.Call;
 
-public sealed class CallIncomingHandler : INotificationHandler<CallIncomingEvent>
+public sealed class CallIncomingHandler :
+    INotificationHandler<CallIncomingEvent>,
+    INotificationHandler<CallIncomingV2Event>
 {
     public Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
         CallIncomingEvent integrationEvent,
@@ -33,6 +35,54 @@ public sealed class CallIncomingHandler : INotificationHandler<CallIncomingEvent
 
         var drafts = new List<NotificationIntent>(integrationEvent.Recipients.Count);
         foreach (var recipientId in integrationEvent.Recipients)
+        {
+            if (recipientId == integrationEvent.CallerId)
+            {
+                continue;
+            }
+
+            drafts.Add(new NotificationIntent(
+                RecipientUserId: recipientId,
+                Category: NotificationCategory.CallIncoming,
+                Severity: NotificationSeverity.Urgent,
+                Content: content,
+                Data: data,
+                GroupKey: groupKey,
+                SourceEventId: integrationEvent.EventId,
+                SourceEventType: integrationEvent.EventType,
+                SourceActionId: NotificationSourceActions.CallIncoming(integrationEvent.CallId),
+                Priority: NotificationPriority.UrgentCall,
+                Actor: new NotificationActor(integrationEvent.CallerId, null, null)));
+        }
+
+        return Task.FromResult<IReadOnlyList<NotificationIntent>>(drafts);
+    }
+
+    public Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
+        CallIncomingV2Event integrationEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(integrationEvent);
+        _ = cancellationToken;
+
+        var label = integrationEvent.CallType == CallType.Video ? "Видеозвонок" : "Звонок";
+        var content = NotificationContent.Create(
+            "Входящий звонок",
+            $"{label} от пользователя",
+            imageUrl: null,
+            deepLink: $"urfulink://chat/conv/{integrationEvent.ConversationId}");
+
+        var data = NotificationData.From(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["conversationId"] = integrationEvent.ConversationId,
+            ["callId"] = integrationEvent.CallId.ToString("N", CultureInfo.InvariantCulture),
+            ["callerId"] = integrationEvent.CallerId.ToString("N", CultureInfo.InvariantCulture),
+            ["callType"] = integrationEvent.CallType.ToString(),
+        });
+
+        var groupKey = GroupKey.ForCall(integrationEvent.CallId);
+        var drafts = new List<NotificationIntent>(integrationEvent.ParticipantIds.Count);
+        foreach (var recipientId in integrationEvent.ParticipantIds)
         {
             if (recipientId == integrationEvent.CallerId)
             {

--- a/src/Services/Notification/NotificationService.Api/Application/Handlers/Call/CallMissedHandler.cs
+++ b/src/Services/Notification/NotificationService.Api/Application/Handlers/Call/CallMissedHandler.cs
@@ -6,7 +6,9 @@ using Urfu.Link.Services.Notification.Domain.ValueObjects;
 
 namespace Urfu.Link.Services.Notification.Application.Handlers.Call;
 
-public sealed class CallMissedHandler : INotificationHandler<CallMissedEvent>
+public sealed class CallMissedHandler :
+    INotificationHandler<CallMissedEvent>,
+    INotificationHandler<CallMissedV2Event>
 {
     public Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
         CallMissedEvent integrationEvent,
@@ -24,6 +26,44 @@ public sealed class CallMissedHandler : INotificationHandler<CallMissedEvent>
 
         var data = NotificationData.From(new Dictionary<string, string>(StringComparer.Ordinal)
         {
+            ["callId"] = integrationEvent.CallId.ToString("N", CultureInfo.InvariantCulture),
+            ["callerId"] = integrationEvent.CallerId.ToString("N", CultureInfo.InvariantCulture),
+            ["ringSeconds"] = ((int)integrationEvent.RingDuration.TotalSeconds).ToString(CultureInfo.InvariantCulture),
+        });
+
+        var draft = new NotificationIntent(
+            RecipientUserId: integrationEvent.RecipientId,
+            Category: NotificationCategory.CallMissed,
+            Severity: NotificationSeverity.Normal,
+            Content: content,
+            Data: data,
+            GroupKey: GroupKey.ForCall(integrationEvent.CallId),
+            SourceEventId: integrationEvent.EventId,
+            SourceEventType: integrationEvent.EventType,
+            SourceActionId: NotificationSourceActions.CallMissed(integrationEvent.CallId, integrationEvent.RecipientId),
+            Priority: NotificationPriority.ChatMessage,
+            Actor: new NotificationActor(integrationEvent.CallerId, null, null));
+
+        return Task.FromResult<IReadOnlyList<NotificationIntent>>([draft]);
+    }
+
+    public Task<IReadOnlyList<NotificationIntent>> PrepareAsync(
+        CallMissedV2Event integrationEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(integrationEvent);
+        _ = cancellationToken;
+
+        var label = integrationEvent.CallType == CallType.Video ? "Видеозвонок" : "Звонок";
+        var content = NotificationContent.Create(
+            "Пропущенный звонок",
+            $"{label} остался без ответа",
+            imageUrl: null,
+            deepLink: $"urfulink://chat/conv/{integrationEvent.ConversationId}");
+
+        var data = NotificationData.From(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["conversationId"] = integrationEvent.ConversationId,
             ["callId"] = integrationEvent.CallId.ToString("N", CultureInfo.InvariantCulture),
             ["callerId"] = integrationEvent.CallerId.ToString("N", CultureInfo.InvariantCulture),
             ["ringSeconds"] = ((int)integrationEvent.RingDuration.TotalSeconds).ToString(CultureInfo.InvariantCulture),

--- a/src/Services/Notification/NotificationService.Api/Messaging/CallEventsConsumer.cs
+++ b/src/Services/Notification/NotificationService.Api/Messaging/CallEventsConsumer.cs
@@ -45,12 +45,7 @@ public sealed class CallEventsConsumer(
                     await RoutingDispatcher.Route(
                         scope,
                         scope.GetRequiredService<CallIncomingHandler>(),
-                        new CallIncomingEvent(
-                            evt.CallId,
-                            evt.CallerId,
-                            evt.ParticipantIds,
-                            evt.CallType,
-                            evt.OccurredAtUtc),
+                        evt,
                         cancellationToken).ConfigureAwait(false);
                     break;
                 }
@@ -70,13 +65,7 @@ public sealed class CallEventsConsumer(
                     await RoutingDispatcher.Route(
                         scope,
                         scope.GetRequiredService<CallMissedHandler>(),
-                        new CallMissedEvent(
-                            evt.CallId,
-                            evt.CallerId,
-                            evt.RecipientId,
-                            evt.CallType,
-                            evt.RingDuration,
-                            evt.OccurredAtUtc),
+                        evt,
                         cancellationToken).ConfigureAwait(false);
                     break;
                 }

--- a/src/Services/Notification/NotificationService.Api/Messaging/NotificationKafkaEventDispatcher.cs
+++ b/src/Services/Notification/NotificationService.Api/Messaging/NotificationKafkaEventDispatcher.cs
@@ -95,7 +95,8 @@ public sealed class NotificationKafkaEventDispatcher
                 dryRun,
                 cancellationToken).ConfigureAwait(false),
             "call.incoming.v2" => await RouteAsync(
-                MapIncomingV2(payload),
+                payload.Deserialize<CallIncomingV2Event>(JsonOptions)
+                    ?? throw new JsonException("CallIncomingV2Event payload null"),
                 scope.GetRequiredService<CallIncomingHandler>(),
                 scope,
                 dryRun,
@@ -107,7 +108,8 @@ public sealed class NotificationKafkaEventDispatcher
                 dryRun,
                 cancellationToken).ConfigureAwait(false),
             "call.missed.v2" => await RouteAsync(
-                MapMissedV2(payload),
+                payload.Deserialize<CallMissedV2Event>(JsonOptions)
+                    ?? throw new JsonException("CallMissedV2Event payload null"),
                 scope.GetRequiredService<CallMissedHandler>(),
                 scope,
                 dryRun,
@@ -338,31 +340,6 @@ public sealed class NotificationKafkaEventDispatcher
             scope,
             dryRun,
             cancellationToken).ConfigureAwait(false);
-    }
-
-    private static CallIncomingEvent MapIncomingV2(JsonNode payload)
-    {
-        var evt = payload.Deserialize<CallIncomingV2Event>(JsonOptions)
-            ?? throw new JsonException("CallIncomingV2Event payload null");
-        return new CallIncomingEvent(
-            evt.CallId,
-            evt.CallerId,
-            evt.ParticipantIds,
-            evt.CallType,
-            evt.OccurredAtUtc);
-    }
-
-    private static CallMissedEvent MapMissedV2(JsonNode payload)
-    {
-        var evt = payload.Deserialize<CallMissedV2Event>(JsonOptions)
-            ?? throw new JsonException("CallMissedV2Event payload null");
-        return new CallMissedEvent(
-            evt.CallId,
-            evt.CallerId,
-            evt.RecipientId,
-            evt.CallType,
-            evt.RingDuration,
-            evt.OccurredAtUtc);
     }
 
     private static async Task<NotificationKafkaDispatchResult> ArchiveAsync(

--- a/tests/unit/NotificationService.UnitTests/Application/CallNotificationHandlerTests.cs
+++ b/tests/unit/NotificationService.UnitTests/Application/CallNotificationHandlerTests.cs
@@ -52,6 +52,31 @@ public sealed class CallNotificationHandlerTests
     }
 
     [Fact]
+    public async Task Incoming_call_v2_notification_routes_to_source_chat()
+    {
+        const string conversationId = "direct-1";
+        var evt = new CallIncomingV2Event(
+            CallId,
+            conversationId,
+            CallerId,
+            [CallerId, CalleeId, OtherRecipientId],
+            CallType.Video,
+            OccurredAt);
+
+        var intents = await new CallIncomingHandler().PrepareAsync(evt, CancellationToken.None);
+
+        intents.Select(intent => intent.RecipientUserId).Should().BeEquivalentTo([CalleeId, OtherRecipientId]);
+        intents.Should().AllSatisfy(intent =>
+        {
+            intent.Content.DeepLink.Should().Be($"urfulink://chat/conv/{conversationId}");
+            intent.Data.Values["conversationId"].Should().Be(conversationId);
+            intent.Data.Values["callId"].Should().Be(CallId.ToString("N"));
+            intent.Data.Values["callerId"].Should().Be(CallerId.ToString("N"));
+            intent.Data.Values["callType"].Should().Be(nameof(CallType.Video));
+        });
+    }
+
+    [Fact]
     public async Task Missed_call_notification_targets_recipient_and_includes_ring_seconds()
     {
         var evt = new CallMissedEvent(
@@ -79,6 +104,30 @@ public sealed class CallNotificationHandlerTests
         intent.Data.Values["ringSeconds"].Should().Be("47");
         intent.Actor.Should().NotBeNull();
         intent.Actor!.Id.Should().Be(CallerId);
+    }
+
+    [Fact]
+    public async Task Missed_call_v2_notification_routes_to_source_chat()
+    {
+        const string conversationId = "direct-1";
+        var evt = new CallMissedV2Event(
+            CallId,
+            conversationId,
+            CallerId,
+            CalleeId,
+            [CallerId, CalleeId],
+            CallType.Audio,
+            TimeSpan.FromSeconds(47),
+            OccurredAt);
+
+        var intents = await new CallMissedHandler().PrepareAsync(evt, CancellationToken.None);
+
+        var intent = intents.Should().ContainSingle().Subject;
+        intent.Content.DeepLink.Should().Be($"urfulink://chat/conv/{conversationId}");
+        intent.Data.Values["conversationId"].Should().Be(conversationId);
+        intent.Data.Values["callId"].Should().Be(CallId.ToString("N"));
+        intent.Data.Values["callerId"].Should().Be(CallerId.ToString("N"));
+        intent.Data.Values["ringSeconds"].Should().Be("47");
     }
 
     [Fact]


### PR DESCRIPTION
﻿## Что изменилось
- Call-уведомления больше не открывают `/call/:id`: новые v2 уведомления ведут в исходный чат, старые без `conversationId` только помечаются прочитанными.
- Обновлён экран звонка: нижний dock с camera/screen controls, self отображается как обычный участник, speaking indicator без текста, single-owner screen share, fullscreen overlay.
- Backend NotificationService теперь обрабатывает `call.incoming.v2` и `call.missed.v2` напрямую и сохраняет `conversationId` в notification data.

## Проверки
- `pnpm --filter @urfu-link/client test -- --runInBand`
- `pnpm --filter @urfu-link/client typecheck`
- `pnpm client:web:build`
- `dotnet test tests/unit/NotificationService.UnitTests/NotificationService.UnitTests.csproj --no-restore`
- `dotnet test Urfu.Link.slnx --no-restore`
- Browser smoke: `devuser/devpass`, notifications tab, click stale missed-call notification does not navigate to `/call/...`.
