### PR TITLE
fix(client): растянуть сцену звонка и добавить анимации

### DIFF
--- a/apps/client/src/features/call/ui/CallRoom.web.tsx
+++ b/apps/client/src/features/call/ui/CallRoom.web.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, View } from "react-native";
+import {
+    FadeIn,
+    FadeInDown,
+    FadeInRight,
+    FadeOut,
+    LinearTransition,
+    ZoomIn,
+    ZoomOut,
+} from "react-native-reanimated";
 import {
     ConnectionState,
     isBrowserSupported,
@@ -12,6 +21,7 @@ import {
 } from "livekit-client";
 import { Avatar } from "@/shared/ui";
 import { playCallSound } from "@/shared/lib/call-sounds";
+import { AnimatedPressable, AnimatedView } from "@/shared/lib/nativewind-interop";
 import { SpeakerHighIcon } from "@/shared/ui/phosphor";
 import type { CallRoomProps, ParticipantInfo } from "./CallRoom.types";
 import {
@@ -25,6 +35,8 @@ import {
 } from "./CallRoomControls";
 import {
     buildScreenShareAudioKey,
+    getCallStageLayoutStyles,
+    getParticipantRailCardStyle,
     isActiveScreenShareAudio,
     normalizeSelectedStageItem,
     pickActiveScreenShare,
@@ -251,16 +263,22 @@ const ScreenShareVolumeControl = ({
 
     return (
         <View className="relative">
-            <Pressable
+            <AnimatedPressable
                 testID="call-screen-audio-toggle"
                 accessibilityLabel={volume <= 0 ? "Включить звук демонстрации" : "Настроить звук демонстрации"}
                 onPress={() => setIsOpen((value) => !value)}
+                layout={LinearTransition.duration(180)}
                 className="h-9 w-9 rounded-full bg-white/12 items-center justify-center active:scale-95"
             >
                 <SpeakerHighIcon size={16} className={volume <= 0 ? "text-white/45" : "text-white"} />
-            </Pressable>
+            </AnimatedPressable>
             {isOpen ? (
-                <View className="absolute right-0 top-12 w-52 rounded-2xl border border-white/10 bg-black/85 p-3 gap-3">
+                <AnimatedView
+                    entering={FadeInDown.duration(180)}
+                    exiting={FadeOut.duration(120)}
+                    layout={LinearTransition.duration(180)}
+                    className="absolute right-0 top-12 w-52 rounded-2xl border border-white/10 bg-black/85 p-3 gap-3"
+                >
                     <View className="flex-row items-center justify-between">
                         <Text className="text-white text-xs font-semibold">Звук экрана</Text>
                         <Text className="text-white/70 text-xs">{percent}%</Text>
@@ -279,16 +297,17 @@ const ScreenShareVolumeControl = ({
                             accentColor: "#2563eb",
                         },
                     })}
-                    <Pressable
+                    <AnimatedPressable
                         accessibilityLabel={volume <= 0 ? "Включить звук демонстрации" : "Выключить звук демонстрации"}
                         onPress={() => onVolumeChange(volume <= 0 ? 1 : 0)}
+                        layout={LinearTransition.duration(180)}
                         className="h-8 rounded-lg bg-white/10 items-center justify-center"
                     >
                         <Text className="text-white text-xs font-semibold">
                             {volume <= 0 ? "Включить" : "Выключить"}
                         </Text>
-                    </Pressable>
-                </View>
+                    </AnimatedPressable>
+                </AnimatedView>
             ) : null}
         </View>
     );
@@ -314,10 +333,14 @@ const ParticipantTile = ({
         localFacingMode === "user";
 
     return (
-        <Pressable
+        <AnimatedPressable
             testID="call-participant-tile"
             accessibilityLabel={`Сделать главным: ${participant.displayName}`}
             onPress={onPress}
+            entering={FadeIn.duration(160)}
+            exiting={FadeOut.duration(120)}
+            layout={LinearTransition.duration(220)}
+            style={{ width: "100%", height: "100%" }}
             className="flex-1 min-h-0 active:scale-[0.99]"
         >
             <SpeakingFrame isSpeaking={participant.isSpeaking}>
@@ -362,7 +385,7 @@ const ParticipantTile = ({
                     </View>
                 </View>
             </SpeakingFrame>
-        </Pressable>
+        </AnimatedPressable>
     );
 };
 
@@ -389,10 +412,14 @@ const ScreenShareTile = ({
     const ownerName = owner?.displayName ?? "Пользователь";
 
     return (
-        <Pressable
+        <AnimatedPressable
             testID="call-screen-share-tile"
             accessibilityLabel={`Сделать главной демонстрацию: ${ownerName}`}
             onPress={onPress}
+            entering={FadeIn.duration(160)}
+            exiting={FadeOut.duration(120)}
+            layout={LinearTransition.duration(220)}
+            style={{ width: "100%", height: "100%" }}
             className="flex-1 min-h-0 rounded-[28px] overflow-hidden border border-white/10 bg-black active:scale-[0.99]"
         >
             {track ? (
@@ -414,17 +441,18 @@ const ScreenShareTile = ({
                         volume={screenShareVolume}
                         onVolumeChange={onScreenShareVolumeChange}
                     />
-                    <Pressable
+                    <AnimatedPressable
                         testID="call-screen-fullscreen"
                         accessibilityLabel="Открыть демонстрацию на весь экран"
                         onPress={onOpenScreenShareFullscreen}
+                        layout={LinearTransition.duration(180)}
                         className="rounded-full bg-white/12 px-3 py-2 active:scale-95"
                     >
                         <Text className="text-white text-xs font-semibold">Во весь экран</Text>
-                    </Pressable>
+                    </AnimatedPressable>
                 </View>
             ) : null}
-        </Pressable>
+        </AnimatedPressable>
     );
 };
 
@@ -484,6 +512,7 @@ const ParticipantRail = ({
     participants,
     isVideoCall,
     isMobile,
+    hasScreenShare,
     localFacingMode,
     onSelectItem,
 }: {
@@ -491,10 +520,14 @@ const ParticipantRail = ({
     participants: ParticipantMediaInfo[];
     isVideoCall: boolean;
     isMobile: boolean;
+    hasScreenShare: boolean;
     localFacingMode: CameraFacingMode;
     onSelectItem: (itemId: string) => void;
 }) => {
     if (items.length === 0) return null;
+
+    const layoutStyles = getCallStageLayoutStyles(isMobile);
+    const cardStyle = getParticipantRailCardStyle(isMobile, hasScreenShare);
 
     return (
         <ScrollView
@@ -502,15 +535,24 @@ const ParticipantRail = ({
             horizontal={isMobile}
             showsHorizontalScrollIndicator={false}
             showsVerticalScrollIndicator={false}
-            className={isMobile ? "max-h-28" : "w-40"}
-            contentContainerStyle={isMobile ? { gap: 8 } : { gap: 8 }}
+            style={layoutStyles.rail}
+            className={isMobile ? "max-h-32" : "w-44"}
+            contentContainerStyle={
+                isMobile
+                    ? { gap: 8, paddingRight: 4 }
+                    : { gap: 8, alignItems: "stretch" }
+            }
         >
             <View className={`gap-2 ${isMobile ? "flex-row" : ""}`}>
-                {items.map((item) => (
-                    <View
+                {items.map((item, index) => (
+                    <AnimatedView
                         key={item.id}
                         testID={item.kind === "screen" ? "call-screen-share-rail-card" : undefined}
-                        className={`${isMobile ? "w-28 h-24" : "w-40 h-28"} rounded-2xl overflow-hidden`}
+                        entering={(isMobile ? FadeInDown : FadeInRight).delay(index * 35).duration(180)}
+                        exiting={FadeOut.duration(120)}
+                        layout={LinearTransition.duration(220)}
+                        style={cardStyle}
+                        className="rounded-2xl overflow-hidden"
                     >
                         <StageItemTile
                             item={item}
@@ -524,7 +566,7 @@ const ParticipantRail = ({
                             screenShareVolume={1}
                             onScreenShareVolumeChange={() => undefined}
                         />
-                    </View>
+                    </AnimatedView>
                 ))}
             </View>
         </ScrollView>
@@ -557,13 +599,28 @@ const CallStage = ({
     onScreenShareVolumeChange: (volume: number) => void;
 }) => {
     const mainItem = selectedItem ?? items[0] ?? null;
-    if (!mainItem) return <View className="flex-1" />;
+    if (!mainItem) return <View className="flex-1 w-full self-stretch" />;
 
     const railItems = items.filter((item) => item.id !== mainItem.id);
+    const layoutStyles = getCallStageLayoutStyles(isMobile);
+    const hasScreenShare = items.some((item) => item.kind === "screen");
 
     return (
-        <View className={`flex-1 gap-3 p-3 ${isMobile ? "" : "flex-row"}`}>
-            <View className="flex-1 min-h-0">
+        <AnimatedView
+            testID="call-stage"
+            entering={FadeIn.duration(180)}
+            layout={LinearTransition.duration(240)}
+            style={layoutStyles.container}
+            className={`flex-1 min-w-0 min-h-0 self-stretch gap-3 p-3 ${
+                isMobile ? "" : "flex-row"
+            }`}
+        >
+            <AnimatedView
+                testID="call-stage-main"
+                layout={LinearTransition.duration(240)}
+                style={layoutStyles.main}
+                className="flex-1 min-w-0 min-h-0 self-stretch"
+            >
                 <StageItemTile
                     item={mainItem}
                     participants={participants}
@@ -576,16 +633,17 @@ const CallStage = ({
                     screenShareVolume={screenShareVolume}
                     onScreenShareVolumeChange={onScreenShareVolumeChange}
                 />
-            </View>
+            </AnimatedView>
             <ParticipantRail
                 items={railItems}
                 participants={participants}
                 isVideoCall={isVideoCall}
                 isMobile={isMobile}
+                hasScreenShare={hasScreenShare}
                 localFacingMode={localFacingMode}
                 onSelectItem={onSelectStageItem}
             />
-        </View>
+        </AnimatedView>
     );
 };
 
@@ -1151,8 +1209,8 @@ export const CallRoom = ({
     }, [activeScreenShareTrack, closeScreenShareFullscreen, isScreenShareFullscreen]);
 
     return (
-        <View className="flex-1">
-            <View className="flex-1 relative">
+        <View className="flex-1 min-w-0 self-stretch">
+            <View className="flex-1 min-w-0 relative self-stretch">
                 <CallErrorOverlay
                     message={connectionError}
                     isLeaving={isLeaving}
@@ -1176,9 +1234,13 @@ export const CallRoom = ({
                 {isConnecting ? <CallLoadingOverlay /> : null}
 
                 {connectionState === ConnectionState.Reconnecting ? (
-                    <View className="absolute left-3 top-3 rounded-lg bg-black/60 px-3 py-2">
+                    <AnimatedView
+                        entering={FadeInDown.duration(180)}
+                        exiting={FadeOut.duration(120)}
+                        className="absolute left-3 top-3 rounded-lg bg-black/60 px-3 py-2"
+                    >
                         <Text className="text-white text-xs">Восстановление соединения...</Text>
-                    </View>
+                    </AnimatedView>
                 ) : null}
             </View>
 
@@ -1210,27 +1272,37 @@ export const CallRoom = ({
             />
 
             {isScreenShareFullscreen && activeScreenShareTrack ? (
-                <View className="absolute inset-0 z-50 bg-black">
+                <AnimatedView
+                    entering={FadeIn.duration(160)}
+                    exiting={FadeOut.duration(120)}
+                    className="absolute inset-0 z-50 bg-black"
+                >
                     <VideoElement
                         track={activeScreenShareTrack.track}
                         muted={activeScreenShareTrack.isLocal}
                         objectFit="contain"
                     />
-                    <Pressable
+                    <AnimatedPressable
                         accessibilityLabel="Закрыть полноэкранную демонстрацию"
                         onPress={closeScreenShareFullscreen}
+                        entering={ZoomIn.duration(160)}
+                        exiting={ZoomOut.duration(120)}
                         className="absolute right-4 top-4 rounded-full bg-white/15 px-4 py-2"
                     >
                         <Text className="text-white text-sm font-semibold">Закрыть</Text>
-                    </Pressable>
-                    <View className="absolute right-4 top-16">
+                    </AnimatedPressable>
+                    <AnimatedView
+                        entering={FadeInRight.duration(180)}
+                        exiting={FadeOut.duration(120)}
+                        className="absolute right-4 top-16"
+                    >
                         <ScreenShareVolumeControl
                             available={hasActiveScreenShareAudio}
                             volume={screenShareVolume}
                             onVolumeChange={setScreenShareVolume}
                         />
-                    </View>
-                </View>
+                    </AnimatedView>
+                </AnimatedView>
             ) : null}
         </View>
     );

--- a/apps/client/src/features/call/ui/CallRoomControls.tsx
+++ b/apps/client/src/features/call/ui/CallRoomControls.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 import {
     ActivityIndicator,
-    Pressable,
     ScrollView,
     Text,
     View,
 } from "react-native";
+import { AnimatedPressable, AnimatedView } from "@/shared/lib/nativewind-interop";
 import { Avatar, ModalOverlay } from "@/shared/ui";
+import {
+    FadeIn,
+    FadeInDown,
+    FadeInRight,
+    FadeOut,
+    LinearTransition,
+    ZoomIn,
+    ZoomOut,
+} from "react-native-reanimated";
 import {
     ArrowsClockwiseIcon,
     ChatCircleTextIcon,
@@ -31,20 +40,29 @@ export const NoVideoPanel = ({
     label: string;
     avatarUrl?: string | null;
 }) => (
-    <View className="flex-1 bg-black/50 items-center justify-center px-10">
+    <AnimatedView
+        entering={FadeIn.duration(180)}
+        exiting={FadeOut.duration(120)}
+        layout={LinearTransition.duration(200)}
+        className="flex-1 bg-black/50 items-center justify-center px-10"
+    >
         <Avatar name={label} src={avatarUrl} size={160} />
         <Text className="text-white mt-4 text-base">{label}</Text>
         <Text className="text-white/70 text-sm mt-2">
             Подключено к звонку без видео
         </Text>
-    </View>
+    </AnimatedView>
 );
 
 export const CallLoadingOverlay = () => (
-    <View className="absolute inset-0 items-center justify-center bg-black/70">
+    <AnimatedView
+        entering={FadeIn.duration(160)}
+        exiting={FadeOut.duration(120)}
+        className="absolute inset-0 items-center justify-center bg-black/70"
+    >
         <ActivityIndicator size="large" color="#fff" />
         <Text className="text-white mt-3">Подключение к звуковому каналу...</Text>
-    </View>
+    </AnimatedView>
 );
 
 export const CallErrorOverlay = ({
@@ -82,18 +100,24 @@ const Panel = ({
     onClose: () => void;
     children: React.ReactNode;
 }) => (
-    <View className="w-full h-full bg-app-card border-l border-white/10">
+    <AnimatedView
+        entering={FadeInRight.duration(180)}
+        exiting={FadeOut.duration(120)}
+        layout={LinearTransition.duration(180)}
+        className="w-full h-full bg-app-card border-l border-white/10"
+    >
         <View className="h-12 px-4 border-b border-white/10 flex-row items-center justify-between">
             <Text className="text-white font-semibold">{title}</Text>
-            <Pressable
+            <AnimatedPressable
                 className="h-8 w-8 rounded-full items-center justify-center bg-white/10"
                 onPress={onClose}
+                layout={LinearTransition.duration(160)}
             >
                 <XIcon size={14} className="text-white" />
-            </Pressable>
+            </AnimatedPressable>
         </View>
         <View className="flex-1 p-4">{children}</View>
-    </View>
+    </AnimatedView>
 );
 
 const ControlButton = ({
@@ -117,11 +141,14 @@ const ControlButton = ({
     iconOnlySize?: number;
     onPress?: () => void;
 }) => (
-    <Pressable
+    <AnimatedPressable
         testID={testID}
         accessibilityLabel={label}
         onPress={onPress}
         disabled={disabled || !onPress}
+        entering={ZoomIn.duration(150)}
+        exiting={ZoomOut.duration(120)}
+        layout={LinearTransition.duration(180)}
         style={
             showLabel
                 ? undefined
@@ -153,7 +180,7 @@ const ControlButton = ({
                 {label}
             </Text>
         ) : null}
-    </Pressable>
+    </AnimatedPressable>
 );
 
 const StatusIconBadge = ({
@@ -165,9 +192,12 @@ const StatusIconBadge = ({
     children: React.ReactNode;
     active?: boolean;
 }) => (
-    <View
+    <AnimatedView
         accessible
         accessibilityLabel={label}
+        entering={ZoomIn.duration(140)}
+        exiting={ZoomOut.duration(100)}
+        layout={LinearTransition.duration(160)}
         className={`h-7 w-7 rounded-full items-center justify-center border ${
             active
                 ? "border-brand-300/60 bg-brand-600/90"
@@ -175,7 +205,7 @@ const StatusIconBadge = ({
         }`}
     >
         {children}
-    </View>
+    </AnimatedView>
 );
 
 const CameraOffIcon = () => (
@@ -238,9 +268,12 @@ export const ParticipantStatusIcons = ({
 );
 
 const SpeakingIndicator = () => (
-    <View
+    <AnimatedView
         accessible
         accessibilityLabel="Сейчас говорит"
+        entering={ZoomIn.duration(150)}
+        exiting={ZoomOut.duration(120)}
+        layout={LinearTransition.duration(160)}
         className="absolute left-3 top-3 z-10 h-8 w-8 rounded-full bg-emerald-500/95 items-center justify-center flex-row gap-0.5"
     >
         {[10, 16, 12].map((height, index) => (
@@ -250,7 +283,7 @@ const SpeakingIndicator = () => (
                 style={{ height }}
             />
         ))}
-    </View>
+    </AnimatedView>
 );
 
 export const SpeakingFrame = ({
@@ -260,7 +293,8 @@ export const SpeakingFrame = ({
     isSpeaking: boolean;
     children: React.ReactNode;
 }) => (
-    <View
+    <AnimatedView
+        layout={LinearTransition.duration(200)}
         className={`relative flex-1 min-h-0 rounded-2xl overflow-hidden border bg-black/35 ${
             isSpeaking ? "border-emerald-400" : "border-white/10"
         }`}
@@ -277,7 +311,7 @@ export const SpeakingFrame = ({
     >
         {isSpeaking ? <SpeakingIndicator /> : null}
         {children}
-    </View>
+    </AnimatedView>
 );
 
 export const CallControls = ({
@@ -315,9 +349,15 @@ export const CallControls = ({
     const iconOnlySize = isMobile ? 44 : 48;
 
     return (
-        <View className="px-3 pb-4 pt-2 items-center justify-center">
-            <View
+        <AnimatedView
+            entering={FadeInDown.duration(180)}
+            layout={LinearTransition.duration(220)}
+            className="px-3 pb-4 pt-2 items-center justify-center"
+        >
+            <AnimatedView
                 testID="call-controls-dock"
+                entering={ZoomIn.duration(180)}
+                layout={LinearTransition.duration(220)}
                 style={isMobile ? { flexWrap: "wrap", maxWidth: 336 } : undefined}
                 className={`max-w-full rounded-[28px] border border-white/10 bg-app-card/95 p-2 flex-row ${
                     isMobile ? "gap-1.5" : "gap-2"
@@ -389,8 +429,8 @@ export const CallControls = ({
                     showLabel={showLabel}
                     iconOnlySize={iconOnlySize}
                 />
-            </View>
-        </View>
+            </AnimatedView>
+        </AnimatedView>
     );
 };
 
@@ -410,7 +450,11 @@ export const CallDrawer = ({
     if (panel === "none") return null;
 
     return (
-        <View
+        <AnimatedView
+            testID="call-drawer"
+            entering={(isMobile ? FadeInDown : FadeInRight).duration(200)}
+            exiting={FadeOut.duration(140)}
+            layout={LinearTransition.duration(220)}
             className={`absolute z-40 ${
                 isMobile
                     ? "inset-x-0 top-0 bottom-24"
@@ -421,9 +465,12 @@ export const CallDrawer = ({
                 <Panel title="Участники" onClose={onClose}>
                     <ScrollView>
                         <View className="gap-3">
-                            {participantInfos.map((participant) => (
-                                <View
+                            {participantInfos.map((participant, index) => (
+                                <AnimatedView
                                     key={participant.userId}
+                                    entering={FadeInRight.delay(index * 35).duration(160)}
+                                    exiting={FadeOut.duration(100)}
+                                    layout={LinearTransition.duration(180)}
                                     className="flex-row items-center gap-3"
                                 >
                                     <Avatar
@@ -439,7 +486,7 @@ export const CallDrawer = ({
                                             {participant.isConnected ? "В звонке" : "Подключается"}
                                         </Text>
                                     </View>
-                                </View>
+                                </AnimatedView>
                             ))}
                         </View>
                     </ScrollView>
@@ -447,6 +494,6 @@ export const CallDrawer = ({
             ) : (
                 <CallChatPanel conversationId={conversationId} onClose={onClose} />
             )}
-        </View>
+        </AnimatedView>
     );
 };

--- a/apps/client/src/features/call/ui/CallRoomMedia.ts
+++ b/apps/client/src/features/call/ui/CallRoomMedia.ts
@@ -1,4 +1,5 @@
 import type { ScreenShareCaptureOptions } from "livekit-client";
+import type { ViewStyle } from "react-native";
 
 export type ScreenShareCandidate = {
     ownerId: string;
@@ -96,3 +97,52 @@ export const isActiveScreenShareAudio = (
     activeOwnerId: string | null,
     isLocal: boolean,
 ) => Boolean(activeOwnerId && ownerId === activeOwnerId && !isLocal);
+
+export const getCallStageLayoutStyles = (
+    isMobile: boolean,
+): { container: ViewStyle; main: ViewStyle; rail: ViewStyle } => ({
+    container: {
+        alignSelf: "stretch",
+        flexGrow: 1,
+        flexShrink: 1,
+        minHeight: 0,
+        minWidth: 0,
+        width: "100%",
+    },
+    main: {
+        alignSelf: "stretch",
+        flexBasis: isMobile ? "auto" : 0,
+        flexGrow: 1,
+        flexShrink: 1,
+        minHeight: 0,
+        minWidth: 0,
+        width: "100%",
+    },
+    rail: isMobile
+        ? {
+              flexShrink: 0,
+              maxHeight: 132,
+              width: "100%",
+          }
+        : {
+              alignSelf: "stretch",
+              flexShrink: 0,
+              minHeight: 0,
+              width: 176,
+          },
+});
+
+export const getParticipantRailCardStyle = (
+    isMobile: boolean,
+    hasScreenShare: boolean,
+): ViewStyle & { width: number; height: number } => {
+    if (isMobile) {
+        return hasScreenShare
+            ? { width: 128, height: 108 }
+            : { width: 112, height: 96 };
+    }
+
+    return hasScreenShare
+        ? { width: 176, height: 128 }
+        : { width: 160, height: 112 };
+};

--- a/apps/client/src/features/call/ui/__tests__/CallRoomControls.test.tsx
+++ b/apps/client/src/features/call/ui/__tests__/CallRoomControls.test.tsx
@@ -1,5 +1,30 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 
+jest.mock("react-native-reanimated", () => {
+    const { Text, View } = require("react-native");
+    const animationBuilder = {
+        delay: () => animationBuilder,
+        duration: () => animationBuilder,
+        springify: () => animationBuilder,
+    };
+
+    return {
+        __esModule: true,
+        default: {
+            Text,
+            View,
+            createAnimatedComponent: (Component: React.ComponentType) => Component,
+        },
+        FadeIn: animationBuilder,
+        FadeInDown: animationBuilder,
+        FadeInRight: animationBuilder,
+        FadeOut: animationBuilder,
+        LinearTransition: animationBuilder,
+        ZoomIn: animationBuilder,
+        ZoomOut: animationBuilder,
+    };
+});
+
 import {
     CallControls,
     ParticipantStatusIcons,

--- a/apps/client/src/features/call/ui/__tests__/CallRoomMedia.test.ts
+++ b/apps/client/src/features/call/ui/__tests__/CallRoomMedia.test.ts
@@ -1,6 +1,8 @@
 import {
     buildScreenShareAudioKey,
     isActiveScreenShareAudio,
+    getCallStageLayoutStyles,
+    getParticipantRailCardStyle,
     normalizeSelectedStageItem,
     pickActiveScreenShare,
     resolveDefaultStageItem,
@@ -181,5 +183,43 @@ describe("CallRoomMedia", () => {
         expect(isActiveScreenShareAudio("remote-1", "remote-1", false)).toBe(true);
         expect(isActiveScreenShareAudio("remote-2", "remote-1", false)).toBe(false);
         expect(isActiveScreenShareAudio("user-1", "user-1", true)).toBe(false);
+    });
+
+    it("stretches the desktop call stage across the available viewport", () => {
+        const layout = getCallStageLayoutStyles(false);
+
+        expect(layout.container).toEqual(
+            expect.objectContaining({
+                alignSelf: "stretch",
+                flexGrow: 1,
+                minWidth: 0,
+                width: "100%",
+            }),
+        );
+        expect(layout.main).toEqual(
+            expect.objectContaining({
+                alignSelf: "stretch",
+                flexBasis: 0,
+                flexGrow: 1,
+                minWidth: 0,
+            }),
+        );
+        expect(layout.rail).toEqual(
+            expect.objectContaining({
+                alignSelf: "stretch",
+                flexShrink: 0,
+                width: 176,
+            }),
+        );
+    });
+
+    it("uses larger rail cards when screen share is present", () => {
+        const desktopDefault = getParticipantRailCardStyle(false, false);
+        const desktopScreenShare = getParticipantRailCardStyle(false, true);
+        const mobileScreenShare = getParticipantRailCardStyle(true, true);
+
+        expect(desktopScreenShare.width).toBeGreaterThan(desktopDefault.width);
+        expect(desktopScreenShare.height).toBeGreaterThan(desktopDefault.height);
+        expect(mobileScreenShare).toEqual(expect.objectContaining({ width: 128, height: 108 }));
     });
 });

--- a/apps/client/src/shared/lib/nativewind-interop.ts
+++ b/apps/client/src/shared/lib/nativewind-interop.ts
@@ -8,3 +8,5 @@ cssInterop(Animated.Text, { className: "style" });
 export const AnimatedView = Animated.createAnimatedComponent(View);
 export const AnimatedText = Animated.createAnimatedComponent(Text);
 export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+cssInterop(AnimatedPressable, { className: "style" });


### PR DESCRIPTION
﻿## Что изменилось

- Растянул web-сцену звонка на всю доступную ширину: main-карточка забирает свободное место, rail фиксирован и не ограничивает сцену половиной экрана.
- Увеличил карточки участников в rail, когда активна демонстрация экрана.
- Добавил Reanimated-анимации для stage, rail-карточек, плиток, fullscreen overlay, volume popover, drawer, bottom dock, кнопок, status icons и служебных overlay.
- Добавил тесты на layout-контракты stage/rail и размеры карточек.

## Проверки

- `pnpm --filter @urfu-link/client test -- --runInBand`
- `pnpm --filter @urfu-link/client typecheck`
- `pnpm client:web:build`
