### PR TITLE
fix(client): sync voice message duration display

### DIFF
--- a/apps/client/src/features/voice-message/model/__tests__/useVoiceRecorder.test.ts
+++ b/apps/client/src/features/voice-message/model/__tests__/useVoiceRecorder.test.ts
@@ -92,7 +92,7 @@ describe("useVoiceRecorder", () => {
         expect(result.current.error).toContain("микрофону");
     });
 
-    it("creates a voice draft with rounded duration and disables recording mode on stop", async () => {
+    it("creates a voice draft with whole-second duration and disables recording mode on stop", async () => {
         const { result, rerender } = renderHook(() => useVoiceRecorder());
         mockRecorderState = {
             isRecording: true,
@@ -110,7 +110,7 @@ describe("useVoiceRecorder", () => {
             expect.objectContaining({
                 uri: "file://voice.m4a",
                 mimeType: "audio/m4a",
-                durationSeconds: 13,
+                durationSeconds: 12,
             }),
         );
         expect(setAudioModeAsync).toHaveBeenCalledWith(

--- a/apps/client/src/features/voice-message/model/useVoiceRecorder.ts
+++ b/apps/client/src/features/voice-message/model/useVoiceRecorder.ts
@@ -82,7 +82,7 @@ export const useVoiceRecorder = ({
 
             const durationSeconds = Math.max(
                 1,
-                Math.min(maxDurationSeconds, Math.ceil(durationMillisRef.current / 1000)),
+                Math.min(maxDurationSeconds, Math.floor(durationMillisRef.current / 1000)),
             );
             const mimeType = getVoiceMimeType(uri, Platform.OS === "web" ? "web" : "native");
             const nextDraft: VoiceRecordingDraft = {

--- a/apps/client/src/features/voice-message/ui/VoiceMessagePlayer.tsx
+++ b/apps/client/src/features/voice-message/ui/VoiceMessagePlayer.tsx
@@ -42,8 +42,13 @@ export const VoiceMessagePlayer = ({
     }, [player, playbackUri, sourceUri]);
 
     const totalSeconds = useMemo(() => {
-        if (durationSeconds && durationSeconds > 0) return durationSeconds;
-        return status.duration && status.duration > 0 ? status.duration : 0;
+        const metadataDuration = durationSeconds && durationSeconds > 0 ? durationSeconds : 0;
+        const playerDuration = status.duration && status.duration > 0 ? status.duration : 0;
+
+        if (metadataDuration > 0 && playerDuration > 0) {
+            return Math.min(metadataDuration, playerDuration);
+        }
+        return metadataDuration || playerDuration;
     }, [durationSeconds, status.duration]);
     const currentSeconds = Math.max(0, Math.min(status.currentTime ?? 0, totalSeconds || Number.MAX_SAFE_INTEGER));
     const progress = totalSeconds > 0 ? Math.min(currentSeconds / totalSeconds, 1) : 0;

--- a/apps/client/src/features/voice-message/ui/__tests__/VoiceMessagePlayer.test.tsx
+++ b/apps/client/src/features/voice-message/ui/__tests__/VoiceMessagePlayer.test.tsx
@@ -126,4 +126,22 @@ describe("VoiceMessagePlayer", () => {
         expect(screen.getByText("0:05")).toBeTruthy();
         expect(screen.getByText("0:17")).toBeTruthy();
     });
+
+    it("uses the loaded audio duration when saved metadata is longer", () => {
+        mockStatus = {
+            playing: false,
+            currentTime: 4.2,
+            duration: 4.2,
+        };
+
+        render(
+            <VoiceMessagePlayer
+                sourceUri="file://voice.m4a"
+                durationSeconds={5}
+            />,
+        );
+
+        expect(screen.getAllByText("0:04")).toHaveLength(2);
+        expect(screen.queryByText("0:05")).toBeNull();
+    });
 });


### PR DESCRIPTION
## Summary
- store voice draft duration using the same whole-second floor as the recorder timer
- prefer the loaded audio duration when saved voice metadata is longer than the real file
- add coverage for old 0:05 metadata on a 4.2s voice file

## Tests
- pnpm --filter @urfu-link/client typecheck
- pnpm --filter @urfu-link/client test -- src/features/voice-message --runInBand
- pnpm --filter @urfu-link/client test -- --runInBand