### PR TITLE
fix(client): восстановить стили animated компонентов

### DIFF
--- a/apps/client/src/shared/lib/__tests__/nativewind-interop.test.ts
+++ b/apps/client/src/shared/lib/__tests__/nativewind-interop.test.ts
@@ -1,0 +1,35 @@
+describe("nativewind animated interop", () => {
+    it("registers className interop on the exported animated components", () => {
+        jest.isolateModules(() => {
+            const cssInterop = jest.fn((component) => component);
+            const animatedView = function AnimatedView() {
+                return null;
+            };
+            const animatedText = function AnimatedText() {
+                return null;
+            };
+            const animatedPressable = function AnimatedPressable() {
+                return null;
+            };
+            const createAnimatedComponent = jest
+                .fn()
+                .mockReturnValueOnce(animatedView)
+                .mockReturnValueOnce(animatedText)
+                .mockReturnValueOnce(animatedPressable);
+
+            jest.doMock("nativewind", () => ({ cssInterop }));
+            jest.doMock("react-native-reanimated", () => ({
+                __esModule: true,
+                default: {
+                    createAnimatedComponent,
+                },
+            }));
+
+            const interop = require("../nativewind-interop");
+
+            expect(cssInterop).toHaveBeenCalledWith(interop.AnimatedView, { className: "style" });
+            expect(cssInterop).toHaveBeenCalledWith(interop.AnimatedText, { className: "style" });
+            expect(cssInterop).toHaveBeenCalledWith(interop.AnimatedPressable, { className: "style" });
+        });
+    });
+});

--- a/apps/client/src/shared/lib/nativewind-interop.ts
+++ b/apps/client/src/shared/lib/nativewind-interop.ts
@@ -2,11 +2,10 @@ import { cssInterop } from "nativewind";
 import { Pressable, View, Text } from "react-native";
 import Animated from "react-native-reanimated";
 
-cssInterop(Animated.View, { className: "style" });
-cssInterop(Animated.Text, { className: "style" });
-
 export const AnimatedView = Animated.createAnimatedComponent(View);
 export const AnimatedText = Animated.createAnimatedComponent(Text);
 export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
+cssInterop(AnimatedView, { className: "style" });
+cssInterop(AnimatedText, { className: "style" });
 cssInterop(AnimatedPressable, { className: "style" });


### PR DESCRIPTION
﻿## Что исправлено

- Исправлен NativeWind interop для экспортируемых `AnimatedView`, `AnimatedText`, `AnimatedPressable`.
- Это возвращает `className`-стили на анимированные элементы звонка: dock, кнопки, карточки, rail и overlay снова получают размеры/позиционирование.
- Добавлен тест, который проверяет регистрацию `cssInterop` именно на экспортируемых animated-компонентах.

## Проверки

- `pnpm --filter @urfu-link/client test -- nativewind-interop.test.ts CallRoomControls.test.tsx --runInBand`
- `pnpm --filter @urfu-link/client typecheck`
- `pnpm client:web:build`
- `pnpm --filter @urfu-link/client test -- --runInBand`
